### PR TITLE
Merge information-layer into macro-data-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Key operations:
 | `list_items` | Merged document feed across news / gov reports / notes, filtered by `subject`, `q` (FTS5), `document_type`, `country_code`, `min_confidence` |
 | `get_document` | Single document by `document_id` or `hash_sha256` (17-field summary + markdown body + subject tags) |
 | `list_subjects` | Subject vocabulary (auto-synced from `src/storage/subjects.yaml`) |
+| `backfill_document_indexes` | One-shot FTS + subject-tag backfill for DBs whose documents predate the new sidecars (idempotent) |
 
 ## Information layer
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,47 @@ Key operations:
 | `get_recent_releases` | Recent economic data releases |
 | `get_upcoming_calendar` | Upcoming calendar events |
 | `get_market_snapshot` | Latest market prices |
+| `list_items` | Merged document feed across news / gov reports / notes, filtered by `subject`, `q` (FTS5), `document_type`, `country_code`, `min_confidence` |
+| `get_document` | Single document by `document_id` or `hash_sha256` (17-field summary + markdown body + subject tags) |
+| `list_subjects` | Subject vocabulary (auto-synced from `src/storage/subjects.yaml`) |
+
+## Information layer
+
+Non-numeric sources (news, gov reports, research notes) land in a
+shared `document` surface keyed by a canonical subject vocabulary, so
+downstream callers can pull them alongside the macro timeseries through
+one API. The schema additions live in `src/storage/sqlite.py`:
+
+- `subjects` / `subject_aliases` / `item_subjects` — canonical subject
+  IDs (`econ.cpi`, `rate.us.sofr`, …) and the aliases that map
+  source-native identifiers (FRED series, calendar indicators, title
+  regex) back to them. Seeded from `src/storage/subjects.yaml`.
+- `document` extended with 11 LLM-extraction columns (`institution`,
+  `authors`, `asset_class`, `impact_level`, `contains_commentary`,
+  `confidence`, …) plus a `documents_fts` FTS5 virtual table.
+- `obs_enrichment` sidecar — derived labels keyed by `(obs_family_id,
+  date, key)`. Currently used for VIX regime classification.
+
+Ingestion paths:
+
+- `news` — `NewsIngestionClient` mirrors each article into `document`
+  (document_type='report', source_id='news') + documents_fts +
+  item_subjects, alongside the legacy `news_articles` row.
+- `gov_reports` — `GovReportIngestionClient` merges scraper metadata
+  with optional LLM extraction into the 17-field document surface.
+- `notes` — `python -m ingestion.notes.ingest --input <dir>` parses
+  YAML-frontmatter markdown into `document` (source_id='notes',
+  document_type='report', confidence=1.0).
+- `FEDWATCH_US` — CME-equivalent midpoint persisted daily from
+  `rateprobability.com`; bridges to the `rate.us.fedwatch` subject.
+- `VIX_US` — FRED `VIXCLS` close; `refresh_vix_regime` writes a
+  low/elevated/stressed label into `obs_enrichment` per date.
+
+Optional LLM enrichment of `institution`, `asset_class`, `impact_level`
+and the rest of the 17-field surface is controlled by
+`DOCUMENT_EXTRACT_API_KEY` (or `OPENAI_API_KEY`) plus
+`DOCUMENT_EXTRACT_MODEL` / `DOCUMENT_EXTRACT_BASE_URL`. Unset → ingestion
+falls back to scraper-supplied metadata without LLM calls.
 
 ## Data model
 

--- a/config/subjects.yaml
+++ b/config/subjects.yaml
@@ -1,0 +1,261 @@
+# Unified subject vocabulary — issue #2 v1 (20 seed subjects).
+#
+# Each subject has:
+#   id:              canonical flat identifier, stable across sources
+#   display:         human-readable label
+#   aliases:
+#     fred_series:       FRED series IDs (matched against macro_data series_id)
+#     calendar_indicator: calendar_events.indicator values
+#     title_regex:       regex patterns matched against news/newsletter titles
+#                        (word-boundary, case-insensitive, confidence 0.8)
+#
+# Keep flat. No parent hierarchy, no negative patterns, no disambiguation rules
+# in v1 — add only when observed false positives justify the complexity.
+
+subjects:
+
+  # ----- US economic indicators -----
+
+  # Geo-neutral subjects: regex matches the concept without a country prefix,
+  # so the subject ID avoids claiming a specific country. If you need
+  # country-scoped results, filter by `country` on the returned rows.
+
+  - id: econ.cpi
+    display: "CPI"
+    aliases:
+      fred_series: [CPIAUCSL, CPILFESL, CUUR0000SA0]
+      calendar_indicator: ["CPI", "Core CPI", "Consumer Price Index", "CPI MoM", "CPI YoY"]
+      title_regex:
+        - '\bCPI\b'
+        - '\bconsumer price(?:s|\s+index)\b'
+        - '\bheadline inflation\b'
+        - '\bcore inflation\b'
+
+  - id: econ.ppi
+    display: "PPI"
+    aliases:
+      fred_series: [PPIACO, PPIFIS]
+      calendar_indicator: ["PPI", "Producer Price Index", "PPI MoM", "PPI YoY"]
+      title_regex:
+        - '\bPPI\b'
+        - '\bproducer price(?:s|\s+index)\b'
+
+  - id: econ.us.core_pce
+    display: "US Core PCE"
+    aliases:
+      fred_series: [PCEPILFE, PCEPI]
+      calendar_indicator: ["Core PCE Price Index", "PCE Price Index", "Core PCE"]
+      title_regex:
+        - '\b(?:core\s+)?PCE\b'
+        - '\bpersonal consumption expenditures\b'
+
+  - id: econ.us.nfp
+    display: "US Nonfarm Payrolls"
+    aliases:
+      fred_series: [PAYEMS]
+      calendar_indicator: ["Nonfarm Payrolls", "Non-Farm Payrolls", "NFP"]
+      title_regex:
+        - '\bNFP\b'
+        - '\bnon[- ]?farm payroll'
+        - '\bjobs report\b'
+        - '\bpayrolls report\b'
+
+  - id: econ.unemployment
+    display: "Unemployment Rate"
+    aliases:
+      fred_series: [UNRATE]
+      calendar_indicator: ["Unemployment Rate"]
+      title_regex:
+        - '\bunemployment rate\b'
+        - '\bjobless rate\b'
+
+  - id: econ.gdp
+    display: "GDP"
+    aliases:
+      fred_series: [GDPC1, GDP]
+      calendar_indicator: ["GDP", "GDP Growth Rate", "GDP Annualized QoQ", "GDP QoQ"]
+      title_regex:
+        - '\bGDP\b'
+        - '\bgross domestic product\b'
+
+  - id: econ.retail_sales
+    display: "Retail Sales"
+    aliases:
+      fred_series: [RSAFS, RRSFS]
+      calendar_indicator: ["Retail Sales", "Retail Sales MoM", "Retail Sales YoY"]
+      title_regex:
+        - '\bretail sales\b'
+
+  # ----- Central bank rates -----
+
+  - id: rate.us.fed_funds
+    display: "US Fed Funds Rate"
+    aliases:
+      fred_series: [FEDFUNDS, DFF]
+      calendar_indicator: ["Fed Interest Rate Decision", "FOMC Rate Decision", "Federal Funds Rate"]
+      title_regex:
+        - '\bfed funds\b'
+        - '\bfederal funds rate\b'
+        - '\bFOMC\b'
+        - '\bfed(?:eral reserve)?\s+rate\b'
+
+  - id: rate.eu.ecb_depo
+    display: "ECB Deposit Rate"
+    aliases:
+      fred_series: [ECBDFR]
+      calendar_indicator: ["ECB Interest Rate Decision", "Deposit Facility Rate"]
+      title_regex:
+        - '\bECB\b'
+        - '\beuropean central bank\b'
+        - '\bdeposit (?:facility )?rate\b'
+
+  - id: rate.jp.boj
+    display: "BOJ Policy Rate"
+    aliases:
+      fred_series: [IRSTCI01JPM156N]
+      calendar_indicator: ["BoJ Interest Rate Decision", "BOJ Rate Decision"]
+      title_regex:
+        - '\bBOJ\b'
+        - '\bbank of japan\b'
+
+  # ----- Sovereign yields -----
+
+  - id: rate.us.2y
+    display: "US 2Y Treasury Yield"
+    aliases:
+      fred_series: [DGS2]
+      calendar_indicator: []
+      title_regex:
+        - '\b2[- ]?year (?:treasury|yield|note)\b'
+        - '\btwo[- ]year (?:treasury|yield|note)\b'
+        - '\b2Y\b'
+
+  - id: rate.us.10y
+    display: "US 10Y Treasury Yield"
+    aliases:
+      fred_series: [DGS10]
+      calendar_indicator: []
+      title_regex:
+        - '\b10[- ]?year (?:treasury|yield|note)\b'
+        - '\bten[- ]year (?:treasury|yield|note)\b'
+        - '\b10Y\b'
+
+  # ----- Reference rates (NY Fed) -----
+
+  # NY Fed rates store two alias forms for the same series: the natural
+  # name (SOFR/EFFR/OBFR) that humans and news titles use, plus the
+  # NYFED_-prefixed form that macro-data-service's concept_map records
+  # as provider_series_id. Listing both lets the query-time bridge
+  # resolve either direction without a normalization layer.
+
+  - id: rate.us.sofr
+    display: "US SOFR"
+    aliases:
+      ny_fed_series: [SOFR, NYFED_SOFR]
+      title_regex:
+        - '\bSOFR\b'
+        - '\bsecured overnight financing rate\b'
+
+  - id: rate.us.effr
+    display: "US EFFR"
+    aliases:
+      ny_fed_series: [EFFR, NYFED_EFFR]
+      title_regex:
+        - '\bEFFR\b'
+        - '\beffective fed(?:eral)? funds rate\b'
+
+  - id: rate.us.obfr
+    display: "US OBFR"
+    aliases:
+      ny_fed_series: [OBFR, NYFED_OBFR]
+      title_regex:
+        - '\bOBFR\b'
+        - '\bovernight bank funding rate\b'
+
+  - id: rate.us.fedwatch
+    display: "US FedWatch (rate expectations)"
+    aliases:
+      fedwatch_series: [FEDWATCH_MIDPOINT]
+      title_regex:
+        - '\bFedWatch\b'
+        - '\brate expectation'
+        - '\bimplied (?:fed )?rate'
+        - '\bFOMC probabilit'
+
+  # ----- Volatility & FX -----
+
+  - id: vol.vix
+    display: "VIX"
+    aliases:
+      fred_series: [VIXCLS]
+      calendar_indicator: []
+      title_regex:
+        - '\bVIX\b'
+        - '\bvolatility index\b'
+
+  - id: fx.dxy
+    display: "Dollar Index (DXY)"
+    aliases:
+      fred_series: [DTWEXBGS, DTWEXM]
+      calendar_indicator: []
+      title_regex:
+        - '\bDXY\b'
+        - '\bdollar index\b'
+
+  # ----- Commodities -----
+
+  - id: commodity.wti
+    display: "WTI Crude Oil"
+    aliases:
+      fred_series: [DCOILWTICO]
+      calendar_indicator: []
+      title_regex:
+        - '\bWTI\b'
+        - '\bwest texas intermediate\b'
+
+  - id: commodity.brent
+    display: "Brent Crude Oil"
+    aliases:
+      fred_series: [DCOILBRENTEU]
+      calendar_indicator: []
+      title_regex:
+        - '\bbrent(?:\s+crude)?\b'
+
+  - id: commodity.gold
+    display: "Gold"
+    aliases:
+      fred_series: [GOLDAMGBD228NLBM]
+      calendar_indicator: []
+      title_regex:
+        - '\bgold price(?:s)?\b'
+        - '\bgold futures\b'
+        - '\bspot gold\b'
+
+  # ----- Equities (US large-cap examples) -----
+
+  - id: equity.us.aapl
+    display: "Apple (AAPL)"
+    aliases:
+      fred_series: []
+      calendar_indicator: []
+      title_regex:
+        - '\bAAPL\b'
+        - '\bapple(?:\s+inc)?\b'
+
+  - id: equity.us.msft
+    display: "Microsoft (MSFT)"
+    aliases:
+      fred_series: []
+      calendar_indicator: []
+      title_regex:
+        - '\bMSFT\b'
+        - '\bmicrosoft\b'
+
+  - id: equity.us.nvda
+    display: "Nvidia (NVDA)"
+    aliases:
+      fred_series: []
+      calendar_indicator: []
+      title_regex:
+        - '\bNVDA\b'
+        - '\bnvidia\b'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+storage = ["*.yaml"]

--- a/src/ingestion/_shared/discovery.py
+++ b/src/ingestion/_shared/discovery.py
@@ -1,0 +1,197 @@
+"""Discovery helpers — ad-hoc web search + generic URL fetch.
+
+Ported from information-layer ``news/src/discovery/``. Used during
+ingestion to chase sources a newsletter or report references.
+
+Scope trimmed vs. the upstream module: the Playwright + Wayback paywall
+fallback (``paywall_fetcher``) is intentionally NOT ported here because
+it pulls Playwright as a runtime dependency. When a 4xx is returned and
+no caller-supplied ``paywall_fetcher`` is given, ``fetch_url`` returns
+an error result and lets the caller decide what to do.
+
+NOT agent-callable. Intended for internal ingestion code paths.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+import httpx
+
+from env import get_env_value
+
+logger = logging.getLogger(__name__)
+
+_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+
+_BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+_BRAVE_API_KEY_ENV = "BRAVE_API_KEY"
+
+_URL_RE = re.compile(
+    r"https?://[^\s<>()\"']+[^\s<>()\"'.,;:!?]",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FetchResult:
+    url: str
+    status: int
+    text: str
+    via_paywall: bool = False
+    error: str | None = None
+
+
+def fetch_url(
+    url: str,
+    *,
+    timeout: float = 20.0,
+    paywall_fetcher=None,
+    max_chars: int = 120_000,
+) -> FetchResult:
+    """GET ``url`` and return the decoded body text.
+
+    On a 4xx response and when ``paywall_fetcher`` is supplied, retry via
+    the paywall path (caller provides — this module does not bundle
+    Playwright).
+    """
+    try:
+        resp = httpx.get(
+            url,
+            timeout=timeout,
+            follow_redirects=True,
+            headers={"User-Agent": _USER_AGENT},
+        )
+    except httpx.HTTPError as exc:
+        return FetchResult(url=url, status=0, text="", error=str(exc))
+
+    if resp.status_code < 400:
+        return FetchResult(
+            url=url, status=resp.status_code, text=resp.text[:max_chars],
+        )
+
+    if paywall_fetcher is None:
+        return FetchResult(
+            url=url,
+            status=resp.status_code,
+            text="",
+            error=f"HTTP {resp.status_code}",
+        )
+
+    try:
+        article = paywall_fetcher.fetch_article(url, "")
+    except Exception as exc:  # defensive — paywall path is best-effort
+        return FetchResult(
+            url=url, status=resp.status_code, text="", error=f"paywall: {exc}",
+        )
+
+    return FetchResult(
+        url=url,
+        status=resp.status_code,
+        text=(getattr(article, "content", "") or "")[:max_chars],
+        via_paywall=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Search (Brave)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+
+
+def search(
+    query: str, *, limit: int = 5, timeout: float = 10.0
+) -> list[SearchResult]:
+    """Return up to ``limit`` Brave Search results for ``query``.
+
+    Returns ``[]`` when ``BRAVE_API_KEY`` is unset, the query is blank,
+    or the API errors out — callers can invoke unconditionally.
+    """
+    if not query or not query.strip():
+        return []
+    # Read via the shared env helper so .env files are picked up alongside
+    # process-environment exports — same path as FRED_API_KEY / LLM_API_KEY.
+    api_key = get_env_value(_BRAVE_API_KEY_ENV)
+    if not api_key:
+        logger.debug("discovery.search: %s not set; skipping", _BRAVE_API_KEY_ENV)
+        return []
+
+    try:
+        resp = httpx.get(
+            _BRAVE_ENDPOINT,
+            params={"q": query, "count": limit},
+            headers={
+                "Accept": "application/json",
+                "X-Subscription-Token": api_key,
+            },
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        # ValueError covers resp.json() on non-JSON 200s (CDN, rate-limit HTML).
+        logger.warning("discovery.search failed for %r: %s", query, exc)
+        return []
+
+    web = payload.get("web") or {}
+    results = web.get("results") or []
+    return [
+        SearchResult(
+            title=r.get("title") or "",
+            url=r.get("url") or "",
+            snippet=r.get("description") or "",
+        )
+        for r in results[:limit]
+        if r.get("url")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# URL extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_urls(markdown: str, *, limit: int | None = None) -> list[str]:
+    """Return unique http(s) URLs from ``markdown``, first-seen order.
+
+    Pure — no network — so parsers can call it unconditionally while
+    building up a list of sources to chase with :func:`fetch_url`.
+    """
+    if not markdown:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for match in _URL_RE.finditer(markdown):
+        url = match.group(0)
+        if url in seen:
+            continue
+        seen.add(url)
+        out.append(url)
+        if limit is not None and len(out) >= limit:
+            break
+    return out
+
+
+__all__ = [
+    "FetchResult",
+    "SearchResult",
+    "extract_urls",
+    "fetch_url",
+    "search",
+]

--- a/src/ingestion/documents/_extraction.py
+++ b/src/ingestion/documents/_extraction.py
@@ -1,0 +1,288 @@
+"""LLM-based 17-field entity extractor for documents.
+
+Ported from information-layer ``doc_parser/extraction.py``. Given a
+document title + markdown body, it calls an OpenAI-compatible chat
+completions endpoint and returns the structured fields the
+information-layer introduced (issue #3 + the 17-field schema).
+
+Designed to be **optional** — when no API key is configured,
+:func:`make_extractor_from_env` returns a :class:`NullDocumentExtractor`
+that yields empty fields, so ingestion pipelines continue to work
+with zero configuration. Scraper-provided metadata
+(``institution``, ``importance``, ``category``) is written directly by
+callers without going through the LLM.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Field definitions + prompt
+# ---------------------------------------------------------------------------
+
+
+EXTRACTION_FIELDS: list[dict[str, str]] = [
+    {"key": "title",          "description": "Document title or report title"},
+    {"key": "institution",    "description": "Publishing institution (e.g., Goldman Sachs, BLS, Federal Reserve, 国家统计局)"},
+    {"key": "authors",        "description": "Author names, analysts or spokespersons"},
+    {"key": "publish_date",   "description": "Publication date of the document"},
+    {"key": "data_period",    "description": "Data reference period if applicable (e.g., 2025-01, Q4 2024), distinct from publish_date"},
+    {"key": "country",        "description": "Country or region the document pertains to (e.g., US, CN, EU, Global)"},
+    {"key": "market",         "description": "Financial market dimension (e.g., A股, US Treasuries, S&P 500)"},
+    {"key": "asset_class",    "description": "High-level asset class (e.g., Fixed Income, Equity, FX, Commodity, Real Estate, Multi-Asset, Macro, Policy)"},
+    {"key": "sector",         "description": "Specific sector or topic (e.g., Inflation, Labor Market, Healthcare, Technology, Gold, Interest Rate)"},
+    {"key": "document_type",  "description": "Type of document (e.g., Research Report, Market Commentary, Official Press Release, Policy Statement, Meeting Minutes, Policy Report, Press Conference Transcript, Survey Report, News Article, Government Announcement)"},
+    {"key": "event_type",     "description": "Event classification if applicable (e.g., Economic Release, Policy Statement, Press Conference, Survey, News Article)"},
+    {"key": "subject",        "description": "Core subject or topic (e.g., CPI, Apple Inc., Federal Funds Rate, LPR)"},
+    {"key": "language",       "description": "Document language (en or zh)"},
+    {"key": "contains_commentary", "description": "true if the document contains a full paragraph of qualitative analysis from officials or analysts; false if purely numerical or a single boilerplate sentence"},
+    {"key": "impact_level",   "description": "Market impact level: 'critical' (bank failure, crash, currency crisis), 'high' (rate decision, CPI, NFP, tariff), 'medium' (inflation, yield moves, earnings, commodities), 'low' (housing, regulation, geopolitics), or 'info' (no significant impact)"},
+    {"key": "confidence",     "description": "Confidence in the impact_level classification, 0.0–1.0 (0.9 critical / 0.8 high / 0.7 medium / 0.6 low / 0.3 info; ±0.1 for clarity of fit)"},
+]
+
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+You are a financial document metadata extractor. The documents may be \
+broker research reports, government statistical releases, central bank \
+statements, press conference transcripts, news articles, or other \
+financial/economic publications. Extract the following fields from the \
+document text. Return ONLY valid JSON with these keys:
+
+{field_descriptions}
+
+The source text may contain OCR-style character errors. In Chinese text, \
+visually similar characters are often swapped (e.g., 周↔風, 辩↔牌, 宗↔资, \
+期↔朋). Use financial domain knowledge to correct likely mistakes — prefer \
+well-known financial terms and proper nouns over unlikely combinations.
+
+Today's date is {today}. For publish_date, extract the date exactly as it \
+appears in the document text — do not substitute a different year based on \
+assumptions.
+
+data_period refers to the period the data covers, not the publication date \
+(e.g., a CPI report published 2025-02-12 may cover data_period "2025-01"). \
+Normalize to these formats: monthly "YYYY-MM", quarterly "YYYY-QN", \
+annual "YYYY". Do not use spelled-out month names or other variations.
+
+For contains_commentary, return true only if the document contains at \
+least one full paragraph of qualitative analysis, interpretation, or \
+opinion from analysts or officials. A document that is purely numerical \
+tables, or that contains only a single sentence of boilerplate summary, \
+should be false.
+
+For language, use the primary language of the document body: "en" or "zh". \
+If the document has substantial content in both languages, use "en,zh".
+
+For impact_level, assess from a macro-finance trading perspective how \
+significant this document's content is for financial markets. document_type \
+describes the form of the document; event_type describes the event that \
+triggered it. They may coincide — that is expected.
+
+For any field you cannot determine, use null.\
+"""
+
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExtractionFields:
+    """The 11 structured columns we added to ``document`` in Step 2,
+    plus ``subject_freetext`` for the pre-resolution subject string."""
+
+    institution: str = ""
+    authors: str = ""
+    data_period: str = ""
+    market: str = ""
+    asset_class: str = ""
+    sector: str = ""
+    event_type: str = ""
+    impact_level: str = ""
+    contains_commentary: bool = False
+    confidence: float = 0.0
+    subject_freetext: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Interface + implementations
+# ---------------------------------------------------------------------------
+
+
+class DocumentExtractor(Protocol):
+    def extract(self, *, title: str, markdown: str) -> ExtractionFields:
+        ...
+
+
+class NullDocumentExtractor:
+    """Default extractor: returns empty fields. Used when no LLM is
+    configured. Ingestion fills the structured columns from scraper
+    metadata only."""
+
+    def extract(self, *, title: str, markdown: str) -> ExtractionFields:
+        del title, markdown
+        return ExtractionFields()
+
+
+class LLMDocumentExtractor:
+    """Calls an OpenAI-compatible chat.completions endpoint and parses the
+    JSON reply into :class:`ExtractionFields`. Any parse failure or API
+    error is logged and an empty result returned — the caller's flow
+    must never break because of extraction."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = "gpt-4o-mini",
+        base_url: str | None = None,
+        context_chars: int = 8000,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+        timeout_s: float = 120.0,
+    ) -> None:
+        from openai import OpenAI  # lazy import so tests can mock
+        self._model = model
+        self._context_chars = context_chars
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+        self._client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout_s,
+        )
+
+    def extract(self, *, title: str, markdown: str) -> ExtractionFields:
+        body = (markdown or "").strip()
+        if not body:
+            return ExtractionFields()
+        field_lines = "\n".join(
+            f'- "{f["key"]}": {f["description"]}' for f in EXTRACTION_FIELDS
+        )
+        system = _SYSTEM_PROMPT_TEMPLATE.format(
+            field_descriptions=field_lines,
+            today=date.today().isoformat(),
+        )
+        user = (
+            f"Title: {title}\n\n{body[: self._context_chars]}"
+            if title
+            else body[: self._context_chars]
+        )
+        try:
+            resp = self._client.chat.completions.create(
+                model=self._model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                max_tokens=self._max_tokens,
+                temperature=self._temperature,
+            )
+            content = resp.choices[0].message.content or "{}"
+            data = _parse_json_response(content)
+            # Guard against wrong-shaped replies ([], null, "string"): valid
+            # JSON but the wrong type. _coerce_fields expects a dict; any
+            # other top-level type becomes an empty result.
+            if not isinstance(data, dict):
+                return ExtractionFields()
+            return _coerce_fields(data)
+        except Exception:  # noqa: BLE001 — extraction is best-effort
+            logger.warning("LLM extraction failed for title=%r", title, exc_info=True)
+            return ExtractionFields()
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def make_extractor_from_env(env: dict[str, str] | None = None) -> DocumentExtractor:
+    """Return an :class:`LLMDocumentExtractor` if a key is available in the
+    environment, otherwise a :class:`NullDocumentExtractor`.
+
+    Recognized env vars (first wins):
+      * ``DOCUMENT_EXTRACT_API_KEY`` / ``OPENAI_API_KEY`` — required
+      * ``DOCUMENT_EXTRACT_MODEL``   — default ``gpt-4o-mini``
+      * ``DOCUMENT_EXTRACT_BASE_URL`` — optional (OpenRouter, Together, etc.)
+      * ``DOCUMENT_EXTRACT_CONTEXT_CHARS`` — default ``8000``
+    """
+    # Use `is None` so callers that pass an explicit empty mapping (common
+    # in tests) stay isolated from host env vars like OPENAI_API_KEY.
+    if env is None:
+        env = os.environ  # type: ignore[assignment]
+    api_key = env.get("DOCUMENT_EXTRACT_API_KEY") or env.get("OPENAI_API_KEY")
+    if not api_key:
+        return NullDocumentExtractor()
+    return LLMDocumentExtractor(
+        api_key=api_key,
+        model=env.get("DOCUMENT_EXTRACT_MODEL") or "gpt-4o-mini",
+        base_url=env.get("DOCUMENT_EXTRACT_BASE_URL") or None,
+        context_chars=int(env.get("DOCUMENT_EXTRACT_CONTEXT_CHARS") or 8000),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_json_response(text: str) -> dict[str, Any]:
+    """Parse a JSON object from an LLM reply, tolerating ```json fences."""
+    cleaned = (text or "").strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        lines = [l for l in lines[1:] if not l.strip().startswith("```")]
+        cleaned = "\n".join(lines)
+    return json.loads(cleaned) if cleaned else {}
+
+
+_VALID_IMPACT = {"critical", "high", "medium", "low", "info"}
+
+
+def _coerce_fields(data: dict[str, Any]) -> ExtractionFields:
+    """Coerce an LLM JSON dict into :class:`ExtractionFields`, tolerating
+    None / missing keys / type drift."""
+
+    def _s(key: str) -> str:
+        v = data.get(key)
+        return str(v).strip() if v not in (None, "") else ""
+
+    impact = _s("impact_level").lower()
+    if impact and impact not in _VALID_IMPACT:
+        impact = ""
+
+    try:
+        confidence = float(data.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(1.0, confidence))
+
+    commentary = data.get("contains_commentary")
+    if isinstance(commentary, str):
+        commentary = commentary.strip().lower() in ("true", "yes", "1")
+    else:
+        commentary = bool(commentary)
+
+    return ExtractionFields(
+        institution=_s("institution"),
+        authors=_s("authors"),
+        data_period=_s("data_period"),
+        market=_s("market"),
+        asset_class=_s("asset_class"),
+        sector=_s("sector"),
+        event_type=_s("event_type"),
+        impact_level=impact,
+        contains_commentary=commentary,
+        confidence=confidence,
+        subject_freetext=_s("subject"),
+    )

--- a/src/ingestion/documents/clients/_gov_report.py
+++ b/src/ingestion/documents/clients/_gov_report.py
@@ -8,6 +8,12 @@ import re
 from datetime import UTC, datetime
 
 from contracts import normalize_utc_iso, to_epoch_ms
+from ingestion.documents._extraction import (
+    DocumentExtractor,
+    ExtractionFields,
+    NullDocumentExtractor,
+    make_extractor_from_env,
+)
 from ingestion.scrapers.gov_report import GovReportClient, GovReportItem
 from ingestion.url_canon import canonicalize_url
 from storage import (
@@ -17,6 +23,7 @@ from storage import (
     NewsArticleRecord,
     SQLiteEngineStore,
 )
+from storage.subjects import SubjectTagger, sync_from_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +50,17 @@ class GovReportIngestionClient:
     document_blob / document_extra) **and** the legacy news_articles
     table so existing consumers keep working."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        extractor: DocumentExtractor | None = None,
+    ) -> None:
         self._client = GovReportClient()
         self._seeded = False
+        # Extractor enriches the 17-field surface. Defaults to env-driven
+        # LLM when DOCUMENT_EXTRACT_API_KEY / OPENAI_API_KEY is set,
+        # otherwise a no-op — the client always works without an LLM.
+        self._extractor: DocumentExtractor = extractor or make_extractor_from_env()
 
     def _ensure_seed(self, store: SQLiteEngineStore) -> None:
         if self._seeded:
@@ -62,6 +77,9 @@ class GovReportIngestionClient:
             "jp": _JP_SOURCES,
             "eu": _EU_SOURCES,
         })
+        # Make sure the subject vocabulary + aliases are loaded so ingest-
+        # time tagging has something to match against. Idempotent.
+        sync_from_yaml(store)
         self._seeded = True
 
     @staticmethod
@@ -84,6 +102,10 @@ class GovReportIngestionClient:
 
     def store_items(self, store: SQLiteEngineStore, items: list[GovReportItem]) -> int:
         self._ensure_seed(store)
+        # Build the subject tagger once per batch — it compiles title
+        # regex patterns and indexes non-regex aliases in memory.
+        with store._connection(commit=False) as c:
+            tagger = SubjectTagger(c)
         count = 0
         failures: list[str] = []
         now_dt = datetime.now(UTC)
@@ -126,6 +148,19 @@ class GovReportIngestionClient:
                     parts = item.source_id.split("_")
                     source_key = f"{parts[0]}.{parts[1]}" if len(parts) >= 2 else item.source_id
 
+                    # Scraper-supplied metadata goes into the structured
+                    # columns unconditionally. LLM extraction (if
+                    # configured) overrides blanks only — scraper values
+                    # are considered authoritative for the fields they
+                    # cover.
+                    extracted: ExtractionFields = ExtractionFields()
+                    if content and not isinstance(self._extractor, NullDocumentExtractor):
+                        extracted = self._extractor.extract(
+                            title=item.title, markdown=content,
+                        )
+                    institution = item.institution or extracted.institution
+                    impact_level = (item.importance or extracted.impact_level or "")
+
                     doc = DocumentRecord(
                         document_id=doc_id,
                         release_family_id=release_family_id,
@@ -150,6 +185,18 @@ class GovReportIngestionClient:
                         published_epoch_ms=published_epoch_ms,
                         created_epoch_ms=now_epoch_ms,
                         updated_epoch_ms=now_epoch_ms,
+                        # 17-field surface
+                        institution=institution,
+                        authors=extracted.authors,
+                        data_period=extracted.data_period,
+                        market=extracted.market,
+                        asset_class=extracted.asset_class,
+                        sector=extracted.sector,
+                        event_type=extracted.event_type,
+                        impact_level=impact_level,
+                        contains_commentary=extracted.contains_commentary,
+                        confidence=extracted.confidence,
+                        subject_freetext=extracted.subject_freetext,
                     )
                     store.upsert_document(doc)
 
@@ -168,6 +215,22 @@ class GovReportIngestionClient:
                             extracted_at=now_iso,
                         )
                         store.upsert_document_blob(blob)
+
+                    # Index into documents_fts so /items?q= can find this
+                    # row. No-op on sqlite builds without FTS5.
+                    store.upsert_document_fts(
+                        document_id=doc_id,
+                        title=item.title,
+                        body=content,
+                    )
+
+                    # Tag against the subject vocabulary via title regex
+                    # (confidence 0.8). data_category is scraper-native
+                    # terminology that rarely maps cleanly to a single
+                    # subject — the title carries the real signal.
+                    title_tags = tagger.tag_text(item.title)
+                    if title_tags:
+                        store.set_document_subjects(doc_id, dict(title_tags))
 
                     if item.raw_json or item.importance:
                         extra_data = dict(item.raw_json) if item.raw_json else {}

--- a/src/ingestion/news/client.py
+++ b/src/ingestion/news/client.py
@@ -18,10 +18,53 @@ from ingestion.news._config import get_feeds
 from ingestion.news._fetcher import ArticleFetcher
 from ingestion._shared.url_canon import canonicalize_url, content_hash
 from ingestion.news._types import PreparedNewsRecord, RawNewsEntry
-from storage import NewsArticleRecord, SQLiteEngineStore
+from storage import (
+    DocumentBlobRecord,
+    DocumentRecord,
+    NewsArticleRecord,
+    SQLiteEngineStore,
+)
+from storage.subjects import SubjectTagger, sync_from_yaml
 
 logger = logging.getLogger(__name__)
 _MIN_ARTICLE_CONTENT_CHARS = 100
+
+# News articles share the `document` table with gov reports and notes.
+# The document_type CHECK constraint already allows 'report' — news
+# articles fit there cleanly; feed-level attribution lives in
+# release_family_id (the feed name) and the structured columns.
+_NEWS_DOC_SOURCE_ID = "news"
+_NEWS_DOCUMENT_TYPE = "report"
+# ISO 3166 user-assigned placeholder used when the extractor reports a
+# blank or non-two-letter country (global/unknown feeds). 'US' would
+# wrongly bucket ECB / BoJ / global news under US filters.
+_UNKNOWN_COUNTRY_CODE = "XX"
+
+
+def _normalize_country_code(value: str | None) -> str:
+    """Coerce an extractor country string into a 2-letter ISO code.
+
+    Maps common human forms (e.g. 'Global', 'global', 'UK') to their
+    conventional codes and falls back to ``XX`` for blanks / unknowns so
+    downstream filters don't lie about provenance.
+    """
+    raw = (value or "").strip().upper()
+    if not raw or raw in {"GLOBAL", "WORLD", "INTERNATIONAL"}:
+        return _UNKNOWN_COUNTRY_CODE
+    # Aliases run before the len==2 shortcut so 'UK' normalizes to 'GB'
+    # instead of passing through as a non-ISO code.
+    aliases = {
+        "USA": "US", "UNITED STATES": "US", "AMERICA": "US",
+        "CHINA": "CN", "PRC": "CN",
+        "JAPAN": "JP",
+        "EUROPE": "EU", "EURO AREA": "EU", "EUROZONE": "EU", "EU": "EU",
+        "UK": "GB", "UNITED KINGDOM": "GB", "BRITAIN": "GB",
+    }
+    if raw in aliases:
+        return aliases[raw]
+    if len(raw) == 2:
+        return raw
+    return _UNKNOWN_COUNTRY_CODE
 
 
 class RefreshStats:
@@ -188,6 +231,22 @@ class NewsIngestionClient:
         return unique
 
     def store_articles(self, store: SQLiteEngineStore, entries: list[PreparedNewsRecord]) -> int:
+        # Seed the unified-document plumbing for the news channel and
+        # build the subject tagger once per batch. Both paths tolerate
+        # mock stores (regression tests) by swallowing the AttributeError
+        # / TypeError that Mock()._connection(...) raises when used as a
+        # context manager.
+        self._ensure_news_doc_source(store)
+        try:
+            sync_from_yaml(store)
+        except (AttributeError, TypeError):
+            pass
+        tagger: SubjectTagger | None
+        try:
+            with store._connection(commit=False) as c:
+                tagger = SubjectTagger(c)
+        except (AttributeError, TypeError):
+            tagger = None  # store didn't expose _connection (mock/double)
         count = 0
         failures: list[str] = []
         for entry in entries:
@@ -241,6 +300,16 @@ class NewsIngestionClient:
                     title=entry.raw_title,
                     source_feed=entry.source_feed,
                 )
+                # Mirror the article into the unified document surface so
+                # it's visible to /items and documents_fts alongside gov
+                # reports and notes.
+                self._mirror_as_document(
+                    store=store,
+                    tagger=tagger,
+                    entry=entry,
+                    extraction=extraction,
+                    article_content=article.content or "",
+                )
                 count += 1
                 time.sleep(0.5)
             except Exception as exc:
@@ -255,6 +324,128 @@ class NewsIngestionClient:
             subject="articles",
         )
         return count
+
+    # ── Unified document surface ────────────────────────────────────────
+
+    @staticmethod
+    def _ensure_news_doc_source(store: SQLiteEngineStore) -> None:
+        """Create the 'news' row in doc_source if it isn't there yet.
+
+        Every document.source_id is a FK into doc_source; gov reports seed
+        per-agency rows via seed_doc_sources_and_families, but news lives
+        under one umbrella 'news' source because individual feeds are
+        carried on release_family_id and the structured columns. Mock
+        stores used in regression tests raise on context-manager entry —
+        swallow and skip, since those tests don't exercise the unified-
+        document surface.
+        """
+        try:
+            with store._connection(commit=True) as c:
+                now = datetime.now(timezone.utc).isoformat()
+                # doc_source.source_type CHECK allowlist: government_agency,
+                # central_bank, intl_org, statistics_bureau, news_agency.
+                # News feeds land under 'news_agency' so the FK from
+                # document.source_id stays valid.
+                c.execute(
+                    "INSERT OR IGNORE INTO doc_source "
+                    "(source_id, source_code, source_name, source_type, "
+                    " country_code, is_active, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, 1, ?, ?)",
+                    (_NEWS_DOC_SOURCE_ID, "NEWS", "News feeds (aggregated)",
+                     "news_agency", "US", now, now),
+                )
+        except (AttributeError, TypeError):
+            return  # mock store — test harness only, skip
+
+    def _mirror_as_document(
+        self,
+        *,
+        store: SQLiteEngineStore,
+        tagger: SubjectTagger | None,
+        entry: PreparedNewsRecord,
+        extraction,
+        article_content: str,
+    ) -> None:
+        """Write one news article as a row in the document surface.
+
+        Idempotent: if a document with this canonical_url already exists,
+        skip the write (news_articles already deduped upstream, but a
+        simultaneous gov_report ingest can race on the same URL).
+        """
+        if store.document_exists(entry.canonical_url):
+            return
+        now_dt = datetime.now(timezone.utc)
+        now_iso = now_dt.isoformat()
+        now_epoch_ms = int(now_dt.timestamp() * 1000)
+        doc_id = entry.url_hash[:16]
+        published_at = format_epoch_iso(entry.timestamp)
+        published_date = published_at[:10]
+        published_epoch_ms = entry.timestamp * 1000
+
+        doc = DocumentRecord(
+            document_id=doc_id,
+            release_family_id="",
+            source_id=_NEWS_DOC_SOURCE_ID,
+            canonical_url=entry.canonical_url,
+            title=extraction.title or entry.raw_title,
+            subtitle=entry.source_feed,
+            document_type=_NEWS_DOCUMENT_TYPE,
+            mime_type="text/html",
+            language_code=(extraction.language or "en")[:5],
+            country_code=_normalize_country_code(extraction.country),
+            topic_code=(extraction.finance_category or entry.feed_category)[:50],
+            published_date=published_date,
+            published_at=published_at,
+            published_precision="exact",
+            status="published",
+            version_no=1,
+            parent_document_id="",
+            hash_sha256=entry.url_hash,
+            created_at=now_iso,
+            updated_at=now_iso,
+            published_epoch_ms=published_epoch_ms,
+            created_epoch_ms=now_epoch_ms,
+            updated_epoch_ms=now_epoch_ms,
+            institution=extraction.institution or "",
+            authors=extraction.authors or "",
+            data_period=extraction.data_period or "",
+            market=extraction.market or "",
+            asset_class=extraction.asset_class or "",
+            sector=extraction.sector or "",
+            event_type=extraction.event_type or "News Article",
+            impact_level=extraction.impact_level or "",
+            contains_commentary=bool(extraction.contains_commentary),
+            confidence=float(extraction.confidence or 0.0),
+            subject_freetext=extraction.subject or "",
+        )
+        store.upsert_document(doc)
+
+        if article_content:
+            blob = DocumentBlobRecord(
+                document_blob_id=f"{doc_id}_md",
+                document_id=doc_id,
+                blob_role="markdown",
+                storage_path="",
+                content_text=article_content,
+                content_bytes=None,
+                byte_size=len(article_content.encode("utf-8")),
+                encoding="utf-8",
+                parser_name="news_article_fetcher",
+                parser_version="",
+                extracted_at=now_iso,
+            )
+            store.upsert_document_blob(blob)
+
+        store.upsert_document_fts(
+            document_id=doc_id,
+            title=extraction.title or entry.raw_title,
+            body=article_content,
+        )
+
+        if tagger is not None:
+            tags = dict(tagger.tag_text(extraction.title or entry.raw_title))
+            if tags:
+                store.set_document_subjects(doc_id, tags)
 
     def close(self) -> None:
         self._article_fetcher.close()

--- a/src/ingestion/notes/__init__.py
+++ b/src/ingestion/notes/__init__.py
@@ -1,0 +1,16 @@
+"""Research-notes ingestion module.
+
+Ported from the information-layer ``notes`` package (issue #3 item 6).
+Reads YAML-frontmatter markdown files and writes them into the unified
+document surface alongside news + gov reports. The markdown export step
+that used to target Milvus (``6_information_layer/notes/``) is dropped
+in the merge — consumers query the DB directly.
+"""
+
+from ingestion.notes.ingest import (
+    NoteFrontmatter,
+    ingest_notes,
+    parse_note,
+)
+
+__all__ = ["NoteFrontmatter", "ingest_notes", "parse_note"]

--- a/src/ingestion/notes/ingest.py
+++ b/src/ingestion/notes/ingest.py
@@ -1,0 +1,303 @@
+"""Ingest research notes from a markdown input folder.
+
+Each input file must start with a YAML frontmatter block containing at
+minimum ``title``, ``date``, and ``subject_id``. The body below the
+second ``---`` fence is the note content. Ingesting a note:
+
+  * ensures the ``notes`` doc_source row exists,
+  * writes the note into ``document`` (document_type='report',
+    source_id='notes', event_type='Research Note'),
+  * stores the markdown body in ``document_blob``,
+  * indexes title + body into ``documents_fts``,
+  * tags ``item_subjects`` with the frontmatter ``subject_id`` at
+    confidence 1.0 (author already picked the canonical subject, so no
+    regex matching is needed).
+
+Already-ingested notes (same sha256 over the raw file) are skipped.
+Editing any part of the file — frontmatter or body — forces a fresh
+row because the hash changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from storage.sqlite import (
+    DocumentBlobRecord,
+    DocumentRecord,
+    SQLiteEngineStore,
+)
+
+logger = logging.getLogger(__name__)
+
+_FRONTMATTER_FENCE = "---"
+_NOTES_DOC_SOURCE_ID = "notes"
+# 'report' is the closest existing document_type allowed by the CHECK
+# constraint. event_type='Research Note' keeps notes distinguishable from
+# press releases and gov reports.
+_NOTES_DOCUMENT_TYPE = "report"
+_NOTES_EVENT_TYPE = "Research Note"
+
+
+@dataclass(frozen=True)
+class NoteFrontmatter:
+    title: str
+    publish_date: str
+    subject_id: str
+    author: str = ""
+    country: str = "XX"
+    language: str = "en"
+
+
+# ---------------------------------------------------------------------------
+# Parse
+# ---------------------------------------------------------------------------
+
+
+def parse_note(path: Path) -> tuple[NoteFrontmatter, str]:
+    """Split a note into ``(frontmatter, body_markdown)``.
+
+    Raises ``ValueError`` if frontmatter is missing or the required
+    fields (``title``, ``date``, ``subject_id``) aren't present.
+    """
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith(_FRONTMATTER_FENCE):
+        raise ValueError(f"{path}: missing YAML frontmatter fence")
+    rest = text[len(_FRONTMATTER_FENCE):].lstrip("\n")
+    try:
+        end = rest.index(f"\n{_FRONTMATTER_FENCE}")
+    except ValueError as exc:
+        raise ValueError(f"{path}: unterminated frontmatter") from exc
+    fm_text = rest[:end]
+    body = rest[end + len(_FRONTMATTER_FENCE) + 1:].lstrip("\n")
+
+    try:
+        fm: Any = yaml.safe_load(fm_text) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: malformed YAML frontmatter: {exc}") from exc
+    if not isinstance(fm, dict):
+        raise ValueError(f"{path}: frontmatter must be a mapping")
+
+    for required in ("title", "date", "subject_id"):
+        if not fm.get(required):
+            raise ValueError(f"{path}: frontmatter is missing '{required}'")
+
+    return (
+        NoteFrontmatter(
+            title=str(fm["title"]),
+            publish_date=str(fm["date"])[:10],
+            subject_id=str(fm["subject_id"]),
+            author=str(fm.get("author") or ""),
+            country=(str(fm.get("country") or "XX")[:2].upper() or "XX"),
+            language=(str(fm.get("language") or "en")[:5]),
+        ),
+        body,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ingest
+# ---------------------------------------------------------------------------
+
+
+def _ensure_notes_doc_source(store: SQLiteEngineStore) -> None:
+    """Idempotently seed the ``notes`` row in ``doc_source``.
+
+    ``source_type='news_agency'`` keeps the value inside the existing
+    CHECK allowlist — research notes aren't a central bank or gov
+    agency, and broadening the CHECK would cost a full table rebuild
+    (unnecessary for an ingestion category).
+    """
+    with store._connection(commit=True) as c:
+        now = datetime.now(timezone.utc).isoformat()
+        c.execute(
+            "INSERT OR IGNORE INTO doc_source "
+            "(source_id, source_code, source_name, source_type, "
+            " country_code, is_active, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, 1, ?, ?)",
+            (_NOTES_DOC_SOURCE_ID, "NOTES", "Research notes",
+             "news_agency", "XX", now, now),
+        )
+
+
+def _compute_sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _ingest_one(
+    store: SQLiteEngineStore,
+    *,
+    path: Path,
+    fm: NoteFrontmatter,
+    body: str,
+    sha: str,
+) -> bool:
+    """Write one note into the unified document surface.
+
+    Returns ``True`` if the note was persisted, ``False`` if a document
+    with the same canonical URL already existed (upstream dedup by sha).
+    """
+    now_dt = datetime.now(timezone.utc)
+    now_iso = now_dt.isoformat()
+    now_epoch_ms = int(now_dt.timestamp() * 1000)
+    try:
+        published_epoch_ms = int(datetime.fromisoformat(
+            fm.publish_date + "T00:00:00+00:00"
+        ).timestamp() * 1000)
+    except ValueError:
+        published_epoch_ms = now_epoch_ms
+
+    doc_id = sha[:16]
+    # canonical_url is derived from the content hash alone so two files
+    # with identical bytes but different names dedupe correctly — both
+    # map to the same document row instead of the second overwriting the
+    # first via INSERT OR REPLACE on document_id.
+    canonical_url = f"note:///{sha}"
+    if store.document_exists(canonical_url):
+        return False
+
+    doc = DocumentRecord(
+        document_id=doc_id,
+        release_family_id="",
+        source_id=_NOTES_DOC_SOURCE_ID,
+        canonical_url=canonical_url,
+        title=fm.title,
+        subtitle=path.name,
+        document_type=_NOTES_DOCUMENT_TYPE,
+        mime_type="text/markdown",
+        language_code=fm.language,
+        country_code=fm.country,
+        topic_code="research_note",
+        published_date=fm.publish_date,
+        published_at=fm.publish_date,
+        published_precision="date_only",
+        status="published",
+        version_no=1,
+        parent_document_id="",
+        hash_sha256=sha,
+        created_at=now_iso,
+        updated_at=now_iso,
+        published_epoch_ms=published_epoch_ms,
+        created_epoch_ms=now_epoch_ms,
+        updated_epoch_ms=now_epoch_ms,
+        institution=fm.author,
+        authors=fm.author,
+        event_type=_NOTES_EVENT_TYPE,
+        # Author pre-resolved the subject, so confidence is the
+        # structured-alias value (1.0) downstream.
+        confidence=1.0,
+        subject_freetext=fm.subject_id,
+    )
+    store.upsert_document(doc)
+
+    if body.strip():
+        blob = DocumentBlobRecord(
+            document_blob_id=f"{doc_id}_md",
+            document_id=doc_id,
+            blob_role="markdown",
+            storage_path=str(path),
+            content_text=body,
+            content_bytes=None,
+            byte_size=len(body.encode("utf-8")),
+            encoding="utf-8",
+            parser_name="notes.ingest",
+            parser_version="",
+            extracted_at=now_iso,
+        )
+        store.upsert_document_blob(blob)
+
+    store.upsert_document_fts(
+        document_id=doc_id,
+        title=fm.title,
+        body=body,
+    )
+
+    # Author-assigned subject: straight 1.0, no tagger regex round-trip.
+    store.set_document_subjects(doc_id, {fm.subject_id: 1.0})
+    return True
+
+
+def ingest_notes(
+    input_dir: Path,
+    *,
+    store: SQLiteEngineStore,
+) -> dict[str, int]:
+    """Ingest every ``*.md`` file under ``input_dir``.
+
+    Returns ``{"ingested": N, "skipped": M, "failed": K}``. Already-
+    stored notes (same sha256) count as ``skipped``; files with missing
+    or malformed frontmatter count as ``failed``.
+    """
+    _ensure_notes_doc_source(store)
+
+    stats = {"ingested": 0, "skipped": 0, "failed": 0}
+    for md in sorted(Path(input_dir).glob("*.md")):
+        try:
+            fm, body = parse_note(md)
+        except ValueError as exc:
+            logger.error("skip %s: %s", md, exc)
+            stats["failed"] += 1
+            continue
+
+        sha = _compute_sha(md)
+        try:
+            persisted = _ingest_one(store, path=md, fm=fm, body=body, sha=sha)
+        except Exception:  # noqa: BLE001 — log & continue so one bad file doesn't halt the batch
+            logger.warning("note storage failed: %s", md, exc_info=True)
+            stats["failed"] += 1
+            continue
+        if persisted:
+            stats["ingested"] += 1
+        else:
+            stats["skipped"] += 1
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Ingest research notes into the engine store.",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Folder containing *.md notes with YAML frontmatter.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="SQLite path (defaults to .macro-data/engine.db).",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    if not args.input.exists():
+        print(f"input dir does not exist: {args.input}", file=sys.stderr)
+        return 2
+
+    store = SQLiteEngineStore(db_path=args.db)
+    stats = ingest_notes(args.input, store=store)
+    print(
+        f"ingested={stats['ingested']} skipped={stats['skipped']}"
+        f" failed={stats['failed']}"
+    )
+    return 0 if stats["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ingestion/sources.py
+++ b/src/ingestion/sources.py
@@ -629,13 +629,32 @@ class IngestionOrchestrator:
 
     def _fetch_rate_probability_observations(self) -> list[IndicatorObservationRecord]:
         prob = self.rate_probability.fetch_probabilities()
+        as_of = prob.as_of[:10] if len(prob.as_of) >= 10 else prob.as_of
         observations: list[IndicatorObservationRecord] = []
+        # Concept-mapped daily midpoint: this is the series resolve_indicator
+        # returns for concept FEDWATCH_US and that the subject vocabulary
+        # aliases under rate.us.fedwatch.
+        if as_of and prob.midpoint is not None:
+            observations.append(
+                IndicatorObservationRecord(
+                    series_id="FEDWATCH_MIDPOINT",
+                    source="rateprobability",
+                    date=as_of,
+                    value=float(prob.midpoint),
+                    metadata={
+                        "current_band": prob.current_band,
+                        "effr": prob.effr,
+                    },
+                )
+            )
+        # Per-meeting forward curve: one observation per FOMC meeting, not
+        # concept-mapped because the meeting set rolls over each cycle.
         for meeting in prob.meetings:
             observations.append(
                 IndicatorObservationRecord(
                     series_id=f"FEDPROB_{meeting.meeting_date}",
                     source="rateprobability",
-                    date=prob.as_of[:10] if len(prob.as_of) >= 10 else prob.as_of,
+                    date=as_of,
                     value=meeting.implied_rate,
                     metadata={
                         "prob_move_pct": meeting.prob_move_pct,

--- a/src/ingestion/timeseries/_config.py
+++ b/src/ingestion/timeseries/_config.py
@@ -62,6 +62,11 @@ MACRO_SERIES = {
     "DTWEXBGS": {"name": "Broad Dollar Index", "category": "fx", "freq": "daily"},
     "DEXCHUS": {"name": "CNY/USD Exchange Rate", "category": "fx", "freq": "daily"},
     "BAMLH0A0HYM2": {"name": "High Yield OAS", "category": "credit", "freq": "daily"},
+    # VIXCLS is required here (not just in _CONCEPT_MAP_DEFS) because
+    # FredFetcher.fetch_series reads MACRO_SERIES directly — omitting it
+    # would leave VIX_US empty after fred_daily / fred_full cycles, and
+    # refresh_vix_regime() would have nothing to classify.
+    "VIXCLS":       {"name": "CBOE VIX",       "category": "markets",  "freq": "daily"},
 }
 
 VINTAGE_SERIES = ["GDP", "GDPC1", "CPIAUCSL", "PAYEMS", "UNRATE", "INDPRO", "RSAFS"]

--- a/src/ingestion/timeseries/regimes.py
+++ b/src/ingestion/timeseries/regimes.py
@@ -1,0 +1,43 @@
+"""Regime classifiers for timeseries observations.
+
+Ported from information-layer ``data/macro_data_layer/src/vix_regime.py``
+(issue #3 item 5). One series, two thresholds, three labels — deliberately
+not a generic operator framework. Add new regimes here as separate small
+classifiers when they're needed.
+
+The resulting labels are written to ``obs_enrichment`` with ``key='regime'``
+so downstream consumers can filter / group by market-stress state without
+recomputing the threshold logic every query.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+# VIX thresholds — see information/data/macro_data_layer/src/vix_regime.py
+VIX_LOW_THRESHOLD = 15.0
+VIX_STRESSED_THRESHOLD = 25.0
+
+
+def classify_vix_regime(value: float | None) -> str | None:
+    """Classify a VIX close into a regime label.
+
+    Returns ``"low"`` (<15), ``"elevated"`` (15-25), or ``"stressed"``
+    (>=25). ``None`` / NaN / inf → ``None`` so missing or malformed
+    prints don't get a synthetic label — FRED returns NaN for
+    closed-market or blank observations.
+    """
+    if value is None:
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(v):
+        return None
+    if v < VIX_LOW_THRESHOLD:
+        return "low"
+    if v < VIX_STRESSED_THRESHOLD:
+        return "elevated"
+    return "stressed"

--- a/src/ingestion/timeseries/scrapers/rateprobability.py
+++ b/src/ingestion/timeseries/scrapers/rateprobability.py
@@ -25,11 +25,17 @@ class FedMeetingProbability:
 
 @dataclass(frozen=True)
 class FedRateProbability:
-    """Full snapshot of Fed rate probabilities from rateprobability.com."""
+    """Full snapshot of Fed rate probabilities from rateprobability.com.
+
+    ``midpoint`` is ``None`` when the upstream payload omits the field,
+    so downstream ingestion can skip publishing a synthetic 0% value to
+    ``FEDWATCH_US`` / ``FEDWATCH_MIDPOINT`` — the concept resolver would
+    otherwise return 0.0 as if it were a real rate.
+    """
 
     as_of: str
     current_band: str
-    midpoint: float
+    midpoint: float | None
     effr: float
     meetings: list[FedMeetingProbability]
     snapshots: dict[str, list[FedMeetingProbability]] = field(default_factory=dict)
@@ -58,7 +64,15 @@ class RateProbabilityClient:
         today = data.get("today", {})
         as_of = today.get("as_of", "")
         current_band = today.get("current band", "")
-        midpoint = float(today.get("midpoint", 0))
+        # Preserve None for a missing midpoint — a concept-mapped series
+        # must not publish a synthetic 0% rate when the upstream field is
+        # absent. See codex review of the FedWatch ingestion commit.
+        raw_midpoint = today.get("midpoint")
+        midpoint: float | None
+        try:
+            midpoint = float(raw_midpoint) if raw_midpoint is not None else None
+        except (TypeError, ValueError):
+            midpoint = None
         effr = float(today.get("most_recent_effr", 0))
 
         meetings = self._parse_meetings(today.get("rows", []))

--- a/src/macro_data/service.py
+++ b/src/macro_data/service.py
@@ -79,6 +79,122 @@ class LocalMacroDataService:
             return {"error": "calendar refresh unavailable"}
         return dict(self._ingestion.refresh_calendar())
 
+    # ── Unified document queries (issue #2 / #3) ────────────────────────
+
+    def _op_list_items(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Merged feed across the unified document surface.
+
+        Arguments:
+          subject         — subject_id to filter on (e.g. "econ.cpi")
+          q               — free-text query (FTS5 over title + body)
+          min_confidence  — default 0.0; filters item_subjects rows
+          limit           — default 50, capped at 500
+          document_type   — optional exact match (e.g. "report")
+          country_code    — optional 2-letter ISO filter
+
+        Returns ``{"items": [...], "total": N}`` with summary rows
+        (no body) — use get_document to fetch a single markdown.
+        """
+        subject = (arguments.get("subject") or "").strip() or None
+        query = (arguments.get("q") or "").strip() or None
+        document_type = (arguments.get("document_type") or "").strip() or None
+        country_code = (arguments.get("country_code") or "").strip() or None
+        try:
+            limit = int(arguments.get("limit") or 50)
+        except (TypeError, ValueError):
+            limit = 50
+        limit = max(1, min(limit, 500))
+        # min_confidence matches the `limit` handling: malformed input
+        # falls back to the default so a string-typed argument never
+        # bubbles up as a 500 from the HTTP handler.
+        raw_conf = arguments.get("min_confidence")
+        try:
+            min_conf = float(raw_conf) if raw_conf is not None else 0.0
+        except (TypeError, ValueError):
+            min_conf = 0.0
+
+        # Filters live in SQL via list_items_combined so the limit
+        # bounds the final result set — no pre-intersection cap that
+        # could hide matches beyond the candidate window.
+        candidates = self._store.list_items_combined(
+            subject_id=subject,
+            query=query,
+            limit=limit,
+            min_confidence=min_conf,
+            document_type=document_type,
+            country_code=country_code,
+        )
+
+        items = [self._document_summary(d) for d in candidates]
+        return {"total": len(items), "items": items}
+
+    def _op_get_document(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Fetch one document (metadata + markdown body + subject tags).
+
+        Accepts either ``document_id`` (internal TEXT id) or
+        ``hash_sha256`` (content hash stored on the row).
+        """
+        document_id = (arguments.get("document_id") or "").strip()
+        sha = (arguments.get("hash_sha256") or "").strip()
+        if not document_id and not sha:
+            return {"error": "document_id or hash_sha256 is required"}
+        doc = (
+            self._store.get_document(document_id)
+            if document_id
+            else self._store.get_document_by_sha(sha)
+        )
+        if doc is None:
+            return {"document": None}
+        body = self._store.get_document_body(doc.document_id)
+        subjects = self._store.list_document_subjects(doc.document_id)
+        return {
+            "document": self._document_summary(doc),
+            "body": body,
+            "subjects": [{"subject_id": s, "confidence": c} for s, c in subjects],
+        }
+
+    def _op_list_subjects(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """List the subject vocabulary. Seeds the yaml on first call so
+        the response is always complete on a fresh DB."""
+        del arguments
+        try:
+            from storage.subjects import sync_from_yaml
+            sync_from_yaml(self._store)
+        except (AttributeError, TypeError, FileNotFoundError):
+            pass  # best-effort; yaml may be unavailable in test environments
+        return {"subjects": self._store.list_subjects()}
+
+    @staticmethod
+    def _document_summary(doc: Any) -> dict[str, Any]:
+        """Shape a DocumentRecord for API responses — omit internal-only
+        fields (epoch_ms duplicates, release_family_id) to keep the
+        payload lean."""
+        return {
+            "document_id": doc.document_id,
+            "hash_sha256": doc.hash_sha256,
+            "title": doc.title,
+            "subtitle": doc.subtitle,
+            "source_id": doc.source_id,
+            "document_type": doc.document_type,
+            "country_code": doc.country_code,
+            "language_code": doc.language_code,
+            "topic_code": doc.topic_code,
+            "published_date": doc.published_date,
+            "published_at": doc.published_at,
+            "institution": doc.institution,
+            "authors": doc.authors,
+            "data_period": doc.data_period,
+            "market": doc.market,
+            "asset_class": doc.asset_class,
+            "sector": doc.sector,
+            "event_type": doc.event_type,
+            "impact_level": doc.impact_level,
+            "contains_commentary": doc.contains_commentary,
+            "confidence": doc.confidence,
+            "subject_freetext": doc.subject_freetext,
+            "canonical_url": doc.canonical_url,
+        }
+
     def _op_refresh_news(self, arguments: dict[str, Any]) -> dict[str, Any]:
         if self._ingestion is None:
             return {"error": "news refresh unavailable"}

--- a/src/macro_data/service.py
+++ b/src/macro_data/service.py
@@ -164,6 +164,29 @@ class LocalMacroDataService:
             pass  # best-effort; yaml may be unavailable in test environments
         return {"subjects": self._store.list_subjects()}
 
+    def _op_backfill_document_indexes(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Run the one-shot FTS + subject-tag backfills.
+
+        Needed on DBs that accumulated ``document`` rows before Step 2
+        added ``documents_fts`` and Step 3 started calling
+        ``set_document_subjects`` at ingest. Both helpers are idempotent,
+        so calling this on a fresh DB does no work.
+        """
+        del arguments
+        # Ensure the vocabulary is seeded before tagging runs — otherwise
+        # the tagger sees an empty alias list and nothing gets tagged.
+        try:
+            from storage.subjects import sync_from_yaml
+            sync_from_yaml(self._store)
+        except (AttributeError, TypeError, FileNotFoundError):
+            pass
+        fts_written = self._store.backfill_documents_fts()
+        subjects_tagged = self._store.backfill_document_subjects()
+        return {
+            "fts_rows_written": fts_written,
+            "documents_subject_tagged": subjects_tagged,
+        }
+
     @staticmethod
     def _document_summary(doc: Any) -> dict[str, Any]:
         """Shape a DocumentRecord for API responses — omit internal-only

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -619,6 +619,7 @@ _FRED_FAMILY_MAP: dict[str, tuple[str, str, str, str, str]] = {
     "DTWEXBGS":     ("us.fx.dollar_index_broad",       "Broad Dollar Index",          "index",        "daily",     "none"),
     "DEXCHUS":      ("us.fx.cny_usd",                  "CNY/USD Exchange Rate",       "ratio",        "daily",     "none"),
     "BAMLH0A0HYM2": ("us.credit.hy_oas",              "High Yield OAS",              "percent",      "daily",     "none"),
+    "VIXCLS":       ("us.markets.vix",                 "CBOE VIX",                    "index",        "daily",     "none"),
 }
 
 _EIA_FAMILY_MAP: dict[str, tuple[str, str, str, str, str]] = {
@@ -2166,6 +2167,28 @@ class SQLiteEngineStore:
             connection.execute(
                 "CREATE INDEX IF NOT EXISTS idx_calendar_events_indicator_id "
                 "ON calendar_events(indicator_id)"
+            )
+            # ── Observation enrichment sidecar ─────────────────────────
+            # Stores derived labels / computed tags alongside an observation
+            # family + date without polluting the indicators schema. Used
+            # today for VIX regime classification (key='regime'); future
+            # enrichments (drawdown buckets, surprise z-scores, etc.) land
+            # under their own `key` values with the same (family, date) PK.
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS obs_enrichment (
+                    obs_family_id TEXT NOT NULL,
+                    date          TEXT NOT NULL,
+                    key           TEXT NOT NULL,
+                    value         TEXT NOT NULL,
+                    created_at    TEXT NOT NULL,
+                    PRIMARY KEY (obs_family_id, date, key)
+                )
+                """
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_obs_enrichment_family_key "
+                "ON obs_enrichment(obs_family_id, key)"
             )
             # ── Unified subject vocabulary (issue #2) ──────────────────
             # subject_id is the canonical cross-source identifier (e.g.
@@ -6007,6 +6030,7 @@ class SQLiteEngineStore:
         #
         # ── US Credit ────────────────────────────────────────────────
         ("HY_OAS_US",           "fred",           "BAMLH0A0HYM2",  "us.credit.hy_oas",              1, "primary",     "ICE BofA HY OAS"),
+        ("VIX_US",              "fred",           "VIXCLS",         "us.markets.vix",                1, "primary",     "CBOE VIX close, regime-classified via obs_enrichment"),
         ("CREDIT_GAP_US",       "bis",            "BIS_CREDIT_GAP_US","us.credit.gap",               1, "primary",     "Credit-to-GDP gap"),
         #
         # ── US Property ──────────────────────────────────────────────
@@ -6157,6 +6181,92 @@ class SQLiteEngineStore:
                     (subject_id,),
                 ).fetchall()
             return [r[0] for r in rows]
+
+    # ── Observation enrichment (regime labels, etc.) ────────────────────
+
+    def set_obs_enrichment(
+        self, *, obs_family_id: str, date: str, key: str, value: str,
+    ) -> None:
+        """Upsert a single (family, date, key) enrichment row.
+
+        ``value`` is stored as text so the same sidecar can hold regime
+        labels, boolean-as-string flags, or numeric buckets without a
+        type-specific column.
+        """
+        now = utc_now().isoformat()
+        with self._connection(commit=True) as connection:
+            connection.execute(
+                "INSERT OR REPLACE INTO obs_enrichment "
+                "(obs_family_id, date, key, value, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (obs_family_id, date, key, value, now),
+            )
+
+    def get_obs_enrichment(
+        self, *, obs_family_id: str, date: str, key: str,
+    ) -> str | None:
+        """Return the enrichment value for one (family, date, key) tuple,
+        or ``None`` if no row exists."""
+        with self._connection(commit=False) as connection:
+            row = connection.execute(
+                "SELECT value FROM obs_enrichment "
+                "WHERE obs_family_id = ? AND date = ? AND key = ?",
+                (obs_family_id, date, key),
+            ).fetchone()
+        return row["value"] if row else None
+
+    def list_obs_enrichment_for_family(
+        self, obs_family_id: str, *, key: str | None = None,
+    ) -> list[tuple[str, str, str]]:
+        """Return ``(date, key, value)`` rows for a family, optionally
+        filtered by ``key``, ordered by date descending."""
+        with self._connection(commit=False) as connection:
+            if key is not None:
+                rows = connection.execute(
+                    "SELECT date, key, value FROM obs_enrichment "
+                    "WHERE obs_family_id = ? AND key = ? "
+                    "ORDER BY date DESC",
+                    (obs_family_id, key),
+                ).fetchall()
+            else:
+                rows = connection.execute(
+                    "SELECT date, key, value FROM obs_enrichment "
+                    "WHERE obs_family_id = ? ORDER BY date DESC, key",
+                    (obs_family_id,),
+                ).fetchall()
+        return [(r["date"], r["key"], r["value"]) for r in rows]
+
+    def refresh_vix_regime(
+        self, *, source: str = "fred", series_id: str = "VIXCLS",
+        obs_family_id: str = "us.markets.vix",
+    ) -> int:
+        """Compute regime labels for every VIX close stored so far and
+        upsert them into obs_enrichment under key='regime'.
+
+        Callers can invoke this after a FRED refresh (or on a schedule)
+        so the latest snapshot always has a classification. Returns the
+        number of rows written.
+        """
+        from ingestion.timeseries.regimes import classify_vix_regime
+        with self._connection(commit=False) as connection:
+            rows = connection.execute(
+                "SELECT date, value FROM indicators "
+                "WHERE series_id = ? AND source = ?",
+                (series_id, source),
+            ).fetchall()
+        written = 0
+        for row in rows:
+            label = classify_vix_regime(row["value"])
+            if label is None:
+                continue
+            self.set_obs_enrichment(
+                obs_family_id=obs_family_id,
+                date=row["date"],
+                key="regime",
+                value=label,
+            )
+            written += 1
+        return written
 
     def set_document_subjects(
         self, document_id: str, subjects: dict[str, float]

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -6300,6 +6300,211 @@ class SQLiteEngineStore:
             ).fetchall()
         return [(r[0], float(r[1])) for r in rows]
 
+    def list_items_for_subject(
+        self,
+        subject_id: str,
+        *,
+        limit: int = 50,
+        min_confidence: float = 0.0,
+        document_type: str | None = None,
+        country_code: str | None = None,
+    ) -> list[DocumentRecord]:
+        """Return documents tagged with ``subject_id`` (confidence >= the
+        filter), most-recent first. Joins item_subjects + document and
+        applies document_type / country_code predicates in SQL so the
+        caller doesn't have to post-filter a capped window."""
+        sql = [
+            "SELECT document.*",
+            "FROM item_subjects",
+            "JOIN document",
+            "  ON document.document_id = item_subjects.item_sha",
+            "WHERE item_subjects.subject_id = ?",
+            "  AND item_subjects.confidence >= ?",
+        ]
+        params: list[Any] = [subject_id, min_confidence]
+        if document_type:
+            sql.append("  AND document.document_type = ?")
+            params.append(document_type)
+        if country_code:
+            sql.append("  AND document.country_code = ?")
+            params.append(country_code)
+        sql.append("ORDER BY document.published_epoch_ms DESC,")
+        sql.append("         document.published_date DESC")
+        sql.append("LIMIT ?")
+        params.append(limit)
+        with self._connection(commit=False) as connection:
+            rows = connection.execute("\n".join(sql), params).fetchall()
+        return [self._row_to_document(r) for r in rows]
+
+    def list_items_combined(
+        self,
+        *,
+        subject_id: str | None,
+        query: str | None,
+        limit: int = 50,
+        min_confidence: float = 0.0,
+        document_type: str | None = None,
+        country_code: str | None = None,
+    ) -> list[DocumentRecord]:
+        """Return documents matching both a subject tag AND an FTS query.
+
+        Filters are applied in SQL so the limit bounds the *final*
+        result set — not a candidate pool that might miss valid matches
+        beyond the window. Falls back to LIKE when FTS5 is unavailable
+        or the MATCH query fails after quoting. When only one of
+        ``subject_id`` / ``query`` is given, routes to
+        :meth:`list_items_for_subject` or :meth:`search_documents`
+        respectively (with the same extra predicates applied).
+        """
+        subject_id = (subject_id or "").strip() or None
+        query = (query or "").strip() or None
+
+        if subject_id and not query:
+            return self.list_items_for_subject(
+                subject_id, limit=limit, min_confidence=min_confidence,
+                document_type=document_type, country_code=country_code,
+            )
+        if query and not subject_id:
+            return self._search_documents_filtered(
+                query, limit=limit,
+                document_type=document_type, country_code=country_code,
+            )
+        if not subject_id and not query:
+            return self.list_documents(
+                document_type=document_type, country_code=country_code,
+                limit=limit,
+            )
+
+        # Both set — combine in one query so the limit isn't eaten by a
+        # pre-intersection cap.
+        type_clause = " AND document.document_type = ?" if document_type else ""
+        country_clause = " AND document.country_code = ?" if country_code else ""
+        extra_params: list[Any] = []
+        if document_type:
+            extra_params.append(document_type)
+        if country_code:
+            extra_params.append(country_code)
+
+        with self._connection(commit=False) as connection:
+            if self._fts5_available(connection):
+                sanitized = self._quote_fts_query(query or "")
+                if sanitized:
+                    try:
+                        rows = connection.execute(
+                            f"""
+                            SELECT document.*
+                            FROM documents_fts
+                            JOIN document
+                              ON document.document_id = documents_fts.document_id
+                            JOIN item_subjects
+                              ON item_subjects.item_sha = document.document_id
+                            WHERE documents_fts MATCH ?
+                              AND item_subjects.subject_id = ?
+                              AND item_subjects.confidence >= ?
+                              {type_clause}{country_clause}
+                            ORDER BY rank
+                            LIMIT ?
+                            """,
+                            [sanitized, subject_id, min_confidence, *extra_params, limit],
+                        ).fetchall()
+                        return [self._row_to_document(r) for r in rows]
+                    except sqlite3.OperationalError:
+                        pass  # fall through to LIKE
+            like = f"%{query}%"
+            rows = connection.execute(
+                f"""
+                SELECT document.*
+                FROM document
+                JOIN item_subjects
+                  ON item_subjects.item_sha = document.document_id
+                WHERE item_subjects.subject_id = ?
+                  AND item_subjects.confidence >= ?
+                  AND (document.title LIKE ? OR document.subtitle LIKE ?)
+                  {type_clause}{country_clause}
+                ORDER BY document.published_epoch_ms DESC,
+                         document.published_date DESC
+                LIMIT ?
+                """,
+                [subject_id, min_confidence, like, like, *extra_params, limit],
+            ).fetchall()
+        return [self._row_to_document(r) for r in rows]
+
+    def _search_documents_filtered(
+        self,
+        query: str,
+        *,
+        limit: int,
+        document_type: str | None,
+        country_code: str | None,
+    ) -> list[DocumentRecord]:
+        """Like :meth:`search_documents` but with document_type / country
+        predicates applied in SQL so the limit counts post-filter rows."""
+        if not (document_type or country_code):
+            return self.search_documents(query, limit=limit)
+        query = query.strip()
+        if not query:
+            return []
+        type_clause = " AND document.document_type = ?" if document_type else ""
+        country_clause = " AND document.country_code = ?" if country_code else ""
+        extra_params: list[Any] = []
+        if document_type:
+            extra_params.append(document_type)
+        if country_code:
+            extra_params.append(country_code)
+        with self._connection(commit=False) as connection:
+            if self._fts5_available(connection):
+                sanitized = self._quote_fts_query(query)
+                if sanitized:
+                    try:
+                        rows = connection.execute(
+                            f"""
+                            SELECT document.*
+                            FROM documents_fts
+                            JOIN document
+                              ON document.document_id = documents_fts.document_id
+                            WHERE documents_fts MATCH ?
+                              {type_clause}{country_clause}
+                            ORDER BY rank
+                            LIMIT ?
+                            """,
+                            [sanitized, *extra_params, limit],
+                        ).fetchall()
+                        return [self._row_to_document(r) for r in rows]
+                    except sqlite3.OperationalError:
+                        pass
+            like = f"%{query}%"
+            rows = connection.execute(
+                f"""
+                SELECT * FROM document
+                WHERE (title LIKE ? OR subtitle LIKE ?)
+                  {type_clause}{country_clause}
+                ORDER BY published_epoch_ms DESC, published_date DESC
+                LIMIT ?
+                """,
+                [like, like, *extra_params, limit],
+            ).fetchall()
+        return [self._row_to_document(r) for r in rows]
+
+    def get_document_body(self, document_id: str) -> str:
+        """Return the markdown body text for a document, empty string
+        when no blob has been persisted yet."""
+        with self._connection(commit=False) as connection:
+            row = connection.execute(
+                "SELECT content_text FROM document_blob "
+                "WHERE document_id = ? AND blob_role = 'markdown' "
+                "ORDER BY extracted_at DESC LIMIT 1",
+                (document_id,),
+            ).fetchone()
+        return row["content_text"] if row and row["content_text"] else ""
+
+    def get_document_by_sha(self, hash_sha256: str) -> DocumentRecord | None:
+        with self._connection(commit=False) as connection:
+            row = connection.execute(
+                "SELECT * FROM document WHERE hash_sha256 = ? LIMIT 1",
+                (hash_sha256,),
+            ).fetchone()
+        return self._row_to_document(row) if row else None
+
     def resolve_subjects_for_concept(self, concept_id: str) -> list[str]:
         """Find subject_ids that alias any provider_series_id registered for
         ``concept_id`` in concept_map. Used at query time to pivot between

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -6142,6 +6142,38 @@ class SQLiteEngineStore:
                 ).fetchall()
             return [r[0] for r in rows]
 
+    def set_document_subjects(
+        self, document_id: str, subjects: dict[str, float]
+    ) -> None:
+        """Replace the item_subjects rows for ``document_id``.
+
+        ``subjects`` is a ``{subject_id: confidence}`` mapping produced by
+        :class:`storage.subjects.SubjectTagger` at ingest time. Rewriting
+        on every upsert keeps tagging idempotent.
+        """
+        with self._connection(commit=True) as connection:
+            connection.execute(
+                "DELETE FROM item_subjects WHERE item_sha = ?",
+                (document_id,),
+            )
+            if subjects:
+                connection.executemany(
+                    "INSERT INTO item_subjects "
+                    "(item_sha, subject_id, confidence) VALUES (?, ?, ?)",
+                    [(document_id, sid, float(c)) for sid, c in subjects.items()],
+                )
+
+    def list_document_subjects(self, document_id: str) -> list[tuple[str, float]]:
+        """Return ``(subject_id, confidence)`` tags for a document,
+        ordered by confidence descending."""
+        with self._connection(commit=False) as connection:
+            rows = connection.execute(
+                "SELECT subject_id, confidence FROM item_subjects "
+                "WHERE item_sha = ? ORDER BY confidence DESC, subject_id",
+                (document_id,),
+            ).fetchall()
+        return [(r[0], float(r[1])) for r in rows]
+
     def resolve_subjects_for_concept(self, concept_id: str) -> list[str]:
         """Find subject_ids that alias any provider_series_id registered for
         ``concept_id`` in concept_map. Used at query time to pivot between

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -6300,6 +6300,73 @@ class SQLiteEngineStore:
             ).fetchall()
         return [(r[0], float(r[1])) for r in rows]
 
+    def backfill_documents_fts(self) -> int:
+        """Populate ``documents_fts`` for documents missing an index row.
+
+        Needed on upgraded DBs that accumulated rows before Step 2 added
+        the virtual table. Rebuilds ``(document_id, title, body)`` from
+        ``document`` + the most recent ``document_blob`` markdown per
+        document. Idempotent: subsequent calls are no-ops once every
+        document has an FTS row.
+        """
+        with self._connection(commit=False) as connection:
+            if not self._fts5_available(connection):
+                return 0
+            rows = connection.execute(
+                """
+                SELECT d.document_id, d.title,
+                       COALESCE(
+                           (SELECT content_text FROM document_blob b
+                            WHERE b.document_id = d.document_id
+                              AND b.blob_role = 'markdown'
+                            ORDER BY b.extracted_at DESC LIMIT 1),
+                           ''
+                       ) AS body
+                FROM document d
+                WHERE d.document_id NOT IN (
+                    SELECT document_id FROM documents_fts
+                )
+                """
+            ).fetchall()
+        written = 0
+        for row in rows:
+            self.upsert_document_fts(
+                document_id=row["document_id"],
+                title=row["title"] or "",
+                body=row["body"] or "",
+            )
+            written += 1
+        return written
+
+    def backfill_document_subjects(self) -> int:
+        """Tag documents that have no ``item_subjects`` rows.
+
+        Runs the current :class:`storage.subjects.SubjectTagger` against
+        each untagged document's title and writes any title-regex matches.
+        Used by upgraded DBs to fill in subject tags for pre-merge rows;
+        new ingestion already tags at write time. Idempotent: documents
+        that are already tagged (even with zero matches left after a
+        re-tag) are skipped via the NOT IN filter.
+        """
+        from storage.subjects import SubjectTagger
+        with self._connection(commit=False) as connection:
+            tagger = SubjectTagger(connection)
+            untagged = connection.execute(
+                """
+                SELECT document_id, title FROM document
+                WHERE document_id NOT IN (
+                    SELECT item_sha FROM item_subjects
+                )
+                """
+            ).fetchall()
+        written = 0
+        for row in untagged:
+            tags = dict(tagger.tag_text(row["title"] or ""))
+            if tags:
+                self.set_document_subjects(row["document_id"], tags)
+                written += 1
+        return written
+
     def list_items_for_subject(
         self,
         subject_id: str,

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -644,6 +644,20 @@ _NYFED_FAMILY_MAP: dict[str, tuple[str, str, str, str, str]] = {
     "NYFED_OBFR": ("us.rates.obfr", "Overnight Bank Funding Rate",     "percent", "daily", "none"),
 }
 
+_RATEPROBABILITY_FAMILY_MAP: dict[str, tuple[str, str, str, str, str]] = {
+    # series_id: (family_id, canonical_name, unit, frequency, seasonal_adjustment)
+    # FedWatch midpoint (CME-equivalent forward rate expectations). Per-meeting
+    # FEDPROB_<date> observations are also emitted for the forward curve but
+    # aren't concept-mapped — the meeting set rolls over each FOMC cycle.
+    "FEDWATCH_MIDPOINT": (
+        "us.rates.fedwatch_midpoint",
+        "FedWatch Midpoint (CME-equivalent)",
+        "percent",
+        "daily",
+        "none",
+    ),
+}
+
 _IMF_FAMILY_MAP: dict[str, tuple[str, str, str, str, str]] = {
     # series_id: (family_id, canonical_name, unit, frequency, seasonal_adjustment)
     "IMF_CN_CPI":         ("cn.inflation.cpi",          "China CPI Index",              "index",        "monthly",    "none"),
@@ -5830,6 +5844,7 @@ class SQLiteEngineStore:
             ("eia", _EIA_FAMILY_MAP),
             ("treasury_fiscal", _TREASURY_FAMILY_MAP),
             ("nyfed", _NYFED_FAMILY_MAP),
+            ("rateprobability", _RATEPROBABILITY_FAMILY_MAP),
             ("imf", _IMF_FAMILY_MAP),
             ("eurostat", _EUROSTAT_FAMILY_MAP),
             ("bis", _BIS_FAMILY_MAP),
@@ -5969,6 +5984,7 @@ class SQLiteEngineStore:
         ("POLICY_RATE_US",      "nyfed",          "NYFED_EFFR",     "us.rates.effr",                 1, "primary",     "NY Fed EFFR"),
         ("POLICY_RATE_US",      "fred",           "DFF",            "us.rates.fed_funds",            2, "secondary",   "Daily effective rate"),
         ("POLICY_RATE_US",      "bis",            "BIS_POLICY_US",  "us.rates.policy_bis",           3, "cross_check", "BIS central bank policy"),
+        ("FEDWATCH_US",         "rateprobability","FEDWATCH_MIDPOINT","us.rates.fedwatch_midpoint",  1, "primary",     "CME-equivalent midpoint, daily snapshot"),
         ("SOFR_US",             "nyfed",          "NYFED_SOFR",     "us.rates.sofr",                 1, "primary",     "Secured overnight"),
         ("OBFR_US",             "nyfed",          "NYFED_OBFR",     "us.rates.obfr",                 1, "primary",     "Overnight bank funding"),
         ("TREASURY_2Y_US",      "fred",           "DGS2",           "us.rates.treasury_2y",          1, "primary",     "Daily constant maturity"),

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -526,6 +526,20 @@ class DocumentRecord:
     published_epoch_ms: int = 0
     created_epoch_ms: int = 0
     updated_epoch_ms: int = 0
+    # 17-field LLM extraction surface (information-layer port).
+    # All default blank/zero so gov_report / SDMX ingestion paths that
+    # never populate them stay valid.
+    institution: str = ""
+    authors: str = ""
+    data_period: str = ""
+    market: str = ""
+    asset_class: str = ""
+    sector: str = ""
+    event_type: str = ""
+    impact_level: str = ""
+    contains_commentary: bool = False
+    confidence: float = 0.0
+    subject_freetext: str = ""
 
 
 @dataclass(frozen=True)
@@ -1698,6 +1712,25 @@ class SQLiteEngineStore:
                     "published_epoch_ms": "INTEGER NOT NULL DEFAULT 0",
                     "created_epoch_ms": "INTEGER NOT NULL DEFAULT 0",
                     "updated_epoch_ms": "INTEGER NOT NULL DEFAULT 0",
+                    # ── 17-field LLM-extraction fields (information-layer) ──
+                    # Added for issue #3: port doc_parser / gov_report / news
+                    # pipelines onto the unified document table. All default
+                    # blank/zero so existing rows and non-LLM-extracted
+                    # sources stay valid.
+                    "institution": "TEXT NOT NULL DEFAULT ''",
+                    "authors": "TEXT NOT NULL DEFAULT ''",
+                    "data_period": "TEXT NOT NULL DEFAULT ''",
+                    "market": "TEXT NOT NULL DEFAULT ''",
+                    "asset_class": "TEXT NOT NULL DEFAULT ''",
+                    "sector": "TEXT NOT NULL DEFAULT ''",
+                    "event_type": "TEXT NOT NULL DEFAULT ''",
+                    "impact_level": "TEXT NOT NULL DEFAULT ''",
+                    "contains_commentary": "INTEGER NOT NULL DEFAULT 0",
+                    "confidence": "REAL NOT NULL DEFAULT 0",
+                    # Free-text subject string produced by the LLM before it is
+                    # resolved to a canonical subject_id. Stored for audit;
+                    # queries go through item_subjects / subject_aliases.
+                    "subject_freetext": "TEXT NOT NULL DEFAULT ''",
                 },
             )
             connection.execute(
@@ -1770,6 +1803,38 @@ class SQLiteEngineStore:
                 "CREATE INDEX IF NOT EXISTS idx_blob_document_role "
                 "ON document_blob(document_id, blob_role)"
             )
+            # -- Filter indexes for the 17-field extension --------------------
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_document_impact_level "
+                "ON document(impact_level)"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_document_asset_class "
+                "ON document(asset_class)"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_document_event_type "
+                "ON document(event_type)"
+            )
+            # -- FTS5 over document title + body ------------------------------
+            # Contentless (no content= link) — body lives in document_blob,
+            # so upsert_document_fts() writes the denormalized title+body
+            # row whenever a document or its markdown blob changes. Guarded
+            # against SQLite builds without FTS5; search_documents() falls
+            # back to LIKE if the virtual table is absent.
+            try:
+                connection.execute(
+                    """
+                    CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
+                        document_id UNINDEXED,
+                        title,
+                        body,
+                        tokenize = 'porter unicode61'
+                    )
+                    """
+                )
+            except sqlite3.OperationalError:
+                pass  # FTS5 unavailable; document search falls back to LIKE
             # -- Observation family: 3-table hierarchy --------------------------
             connection.execute(
                 """
@@ -5055,8 +5120,11 @@ class SQLiteEngineStore:
                     language_code, country_code, topic_code,
                     published_date, published_at, published_precision, published_epoch_ms, status, version_no,
                     parent_document_id, hash_sha256,
-                    created_at, updated_at, created_epoch_ms, updated_epoch_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    created_at, updated_at, created_epoch_ms, updated_epoch_ms,
+                    institution, authors, data_period, market, asset_class,
+                    sector, event_type, impact_level,
+                    contains_commentary, confidence, subject_freetext
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     record.document_id,
@@ -5082,6 +5150,17 @@ class SQLiteEngineStore:
                     record.updated_at,
                     created_epoch_ms,
                     updated_epoch_ms,
+                    record.institution,
+                    record.authors,
+                    record.data_period,
+                    record.market,
+                    record.asset_class,
+                    record.sector,
+                    record.event_type,
+                    record.impact_level,
+                    1 if record.contains_commentary else 0,
+                    record.confidence,
+                    record.subject_freetext,
                 ),
             )
 
@@ -5208,6 +5287,17 @@ class SQLiteEngineStore:
                 if row["updated_epoch_ms"]
                 else _safe_epoch_ms(row["updated_at"])
             ),
+            institution=row["institution"] or "",
+            authors=row["authors"] or "",
+            data_period=row["data_period"] or "",
+            market=row["market"] or "",
+            asset_class=row["asset_class"] or "",
+            sector=row["sector"] or "",
+            event_type=row["event_type"] or "",
+            impact_level=row["impact_level"] or "",
+            contains_commentary=bool(row["contains_commentary"] or 0),
+            confidence=float(row["confidence"] or 0),
+            subject_freetext=row["subject_freetext"] or "",
         )
 
     def upsert_document_blob(self, record: DocumentBlobRecord) -> None:
@@ -5299,6 +5389,107 @@ class SQLiteEngineStore:
             document_id=row["document_id"],
             extra_json=json.loads(row["extra_json"]),
         )
+
+    # ── Document FTS5 ───────────────────────────────────────────────────
+
+    def _fts5_available(self, connection: sqlite3.Connection) -> bool:
+        row = connection.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='documents_fts' LIMIT 1"
+        ).fetchone()
+        return row is not None
+
+    def upsert_document_fts(
+        self, *, document_id: str, title: str, body: str
+    ) -> None:
+        """Rewrite a document's row in the documents_fts index.
+
+        Contentless FTS5 — the virtual table owns its own copy of
+        (document_id, title, body). Callers invoke this after writing the
+        document + its markdown blob. No-op if FTS5 is unavailable.
+        """
+        with self._connection(commit=True) as connection:
+            if not self._fts5_available(connection):
+                return
+            connection.execute(
+                "DELETE FROM documents_fts WHERE document_id = ?",
+                (document_id,),
+            )
+            connection.execute(
+                "INSERT INTO documents_fts(document_id, title, body) "
+                "VALUES (?, ?, ?)",
+                (document_id, title or "", body or ""),
+            )
+
+    def delete_document_fts(self, document_id: str) -> None:
+        with self._connection(commit=True) as connection:
+            if not self._fts5_available(connection):
+                return
+            connection.execute(
+                "DELETE FROM documents_fts WHERE document_id = ?",
+                (document_id,),
+            )
+
+    @staticmethod
+    def _quote_fts_query(query: str) -> str:
+        """Wrap each whitespace-separated token in double quotes so FTS5
+        metacharacters (``-``, ``:``, ``"``, ``/``, ``%``, unmatched quotes,
+        etc.) never reach the MATCH parser. Callers get literal phrase
+        matching per token joined by implicit AND, which is what a
+        user-facing keyword search expects.
+        """
+        tokens = (query or "").split()
+        if not tokens:
+            return ""
+        return " ".join(f'"{t.replace(chr(34), chr(34) * 2)}"' for t in tokens)
+
+    def search_documents(
+        self,
+        query: str,
+        *,
+        limit: int = 50,
+    ) -> list[DocumentRecord]:
+        """BM25-ranked full-text search across document title + body.
+
+        Falls back to LIKE over title + subtitle if FTS5 is unavailable or
+        if the MATCH query still fails after sanitization. Pass an empty
+        ``query`` to get the empty list — use :meth:`list_documents` for
+        the unfiltered recency feed.
+        """
+        query = (query or "").strip()
+        if not query:
+            return []
+        with self._connection(commit=False) as connection:
+            if self._fts5_available(connection):
+                sanitized = self._quote_fts_query(query)
+                if sanitized:
+                    try:
+                        rows = connection.execute(
+                            """
+                            SELECT document.*
+                            FROM documents_fts
+                            JOIN document
+                              ON document.document_id = documents_fts.document_id
+                            WHERE documents_fts MATCH ?
+                            ORDER BY rank
+                            LIMIT ?
+                            """,
+                            (sanitized, limit),
+                        ).fetchall()
+                        return [self._row_to_document(r) for r in rows]
+                    except sqlite3.OperationalError:
+                        pass  # defensive: fall through to LIKE
+            like = f"%{query}%"
+            rows = connection.execute(
+                """
+                SELECT * FROM document
+                WHERE title LIKE ? OR subtitle LIKE ?
+                ORDER BY published_epoch_ms DESC, published_date DESC
+                LIMIT ?
+                """,
+                (like, like, limit),
+            ).fetchall()
+        return [self._row_to_document(row) for row in rows]
 
     def seed_doc_sources_and_families(self, source_configs: dict[str, dict[str, dict[str, Any]]]) -> None:
         """Populate doc_source and doc_release_family from scraper config dicts.

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -2088,6 +2088,49 @@ class SQLiteEngineStore:
                 "CREATE INDEX IF NOT EXISTS idx_calendar_events_indicator_id "
                 "ON calendar_events(indicator_id)"
             )
+            # ── Unified subject vocabulary (issue #2) ──────────────────
+            # subject_id is the canonical cross-source identifier (e.g.
+            # 'econ.cpi', 'rate.us.sofr'). Aliases map source-native keys
+            # (FRED series, calendar indicator strings, title regex, ...)
+            # back to a subject. item_subjects tags documents at ingest;
+            # calendar_events and observations are resolved at query time
+            # via subject_alias lookups.
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS subjects (
+                    subject_id   TEXT PRIMARY KEY,
+                    display_name TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS subject_aliases (
+                    subject_id  TEXT NOT NULL,
+                    alias_type  TEXT NOT NULL,
+                    alias_value TEXT NOT NULL,
+                    PRIMARY KEY (subject_id, alias_type, alias_value)
+                )
+                """
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_subject_aliases_lookup "
+                "ON subject_aliases(alias_type, alias_value)"
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS item_subjects (
+                    item_sha   TEXT NOT NULL,
+                    subject_id TEXT NOT NULL,
+                    confidence REAL NOT NULL,
+                    PRIMARY KEY (item_sha, subject_id)
+                )
+                """
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_item_subjects_subject "
+                "ON item_subjects(subject_id)"
+            )
 
     def _ensure_table_columns(
         self,
@@ -5846,6 +5889,85 @@ class SQLiteEngineStore:
                     """,
                     (priority, role, concept_id, source_id, series_id),
                 )
+
+    # ── Unified subject vocabulary ───────────────────────────────────
+
+    def sync_subjects(self, subjects: list[dict]) -> None:
+        """Upsert the subject vocabulary and its aliases.
+
+        ``subjects`` is the list parsed from ``config/subjects.yaml`` — each
+        dict has ``id``, ``display``, and an ``aliases`` mapping of
+        alias_type → list of alias values. Existing subjects are replaced
+        and their alias rows rebuilt; subjects not in the input are left
+        alone so removal is always explicit.
+        """
+        with self._connection(commit=True) as connection:
+            for sub in subjects:
+                sid = sub["id"]
+                connection.execute(
+                    "INSERT OR REPLACE INTO subjects (subject_id, display_name) "
+                    "VALUES (?, ?)",
+                    (sid, sub["display"]),
+                )
+                connection.execute(
+                    "DELETE FROM subject_aliases WHERE subject_id = ?",
+                    (sid,),
+                )
+                alias_rows: list[tuple[str, str, str]] = []
+                for alias_type, values in (sub.get("aliases") or {}).items():
+                    for value in values or []:
+                        alias_rows.append((sid, alias_type, value))
+                if alias_rows:
+                    connection.executemany(
+                        "INSERT OR IGNORE INTO subject_aliases "
+                        "(subject_id, alias_type, alias_value) VALUES (?, ?, ?)",
+                        alias_rows,
+                    )
+
+    def list_subjects(self) -> list[dict[str, str]]:
+        """Return all subjects with their display names, ordered by id."""
+        with self._connection(commit=False) as connection:
+            rows = connection.execute(
+                "SELECT subject_id, display_name FROM subjects ORDER BY subject_id"
+            ).fetchall()
+            return [{"subject_id": r["subject_id"], "display_name": r["display_name"]}
+                    for r in rows]
+
+    def get_subject_aliases(
+        self, subject_id: str, *, alias_type: str | None = None
+    ) -> list[str]:
+        """Return alias values for a subject, optionally filtered by type."""
+        with self._connection(commit=False) as connection:
+            if alias_type:
+                rows = connection.execute(
+                    "SELECT alias_value FROM subject_aliases "
+                    "WHERE subject_id = ? AND alias_type = ?",
+                    (subject_id, alias_type),
+                ).fetchall()
+            else:
+                rows = connection.execute(
+                    "SELECT alias_value FROM subject_aliases WHERE subject_id = ?",
+                    (subject_id,),
+                ).fetchall()
+            return [r[0] for r in rows]
+
+    def resolve_subjects_for_concept(self, concept_id: str) -> list[str]:
+        """Find subject_ids that alias any provider_series_id registered for
+        ``concept_id`` in concept_map. Used at query time to pivot between
+        the timeseries vocabulary (CPI_US) and the subject vocabulary
+        (econ.cpi) without a dedicated bridge table.
+        """
+        with self._connection(commit=False) as connection:
+            rows = connection.execute(
+                """
+                SELECT DISTINCT sa.subject_id
+                FROM concept_map cm
+                JOIN subject_aliases sa ON sa.alias_value = cm.provider_series_id
+                WHERE cm.concept_id = ?
+                """,
+                (concept_id,),
+            ).fetchall()
+            return [r[0] for r in rows]
 
     def get_concept_series(self, concept_id: str) -> list[ConceptMapRecord]:
         """Return all source mappings for a given concept, ordered by priority."""

--- a/src/storage/subjects.py
+++ b/src/storage/subjects.py
@@ -22,9 +22,7 @@ from typing import Any, Iterable
 import yaml
 
 
-_DEFAULT_YAML = (
-    Path(__file__).resolve().parents[2] / "config" / "subjects.yaml"
-)
+_DEFAULT_YAML = Path(__file__).resolve().parent / "subjects.yaml"
 
 STRUCTURED_CONFIDENCE = 1.0
 TITLE_CONFIDENCE = 0.8
@@ -118,6 +116,8 @@ class SubjectTagger:
         self,
         *,
         fred_series: str | Iterable[str] | None = None,
+        bls_series: str | Iterable[str] | None = None,
+        eia_series: str | Iterable[str] | None = None,
         ny_fed_series: str | Iterable[str] | None = None,
         fedwatch_series: str | Iterable[str] | None = None,
         calendar_indicator: str | None = None,
@@ -127,6 +127,8 @@ class SubjectTagger:
         hits: dict[str, float] = {}
         pairs = (
             ("fred_series", fred_series),
+            ("bls_series", bls_series),
+            ("eia_series", eia_series),
             ("ny_fed_series", ny_fed_series),
             ("fedwatch_series", fedwatch_series),
             ("calendar_indicator", calendar_indicator),

--- a/src/storage/subjects.py
+++ b/src/storage/subjects.py
@@ -1,0 +1,138 @@
+"""Subject vocabulary: YAML loader + runtime tagger.
+
+The canonical subject list lives in ``config/subjects.yaml`` at the repo
+root. It is synced into the ``subjects`` + ``subject_aliases`` tables
+through :func:`sync_from_yaml`. Ingestion code tags text and structured
+identifiers with :class:`SubjectTagger`, built from the DB.
+
+See issue #2 for the vocabulary model. v1 is lean:
+  * structured alias match → confidence 1.0
+  * title_regex match → confidence 0.8
+No disambiguation rules, no body scoring, no LLM fallback — add only when
+measured false positives justify them.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+
+_DEFAULT_YAML = (
+    Path(__file__).resolve().parents[2] / "config" / "subjects.yaml"
+)
+
+STRUCTURED_CONFIDENCE = 1.0
+TITLE_CONFIDENCE = 0.8
+
+
+def load_subjects_yaml(path: str | Path | None = None) -> list[dict[str, Any]]:
+    """Parse ``config/subjects.yaml`` and return the ``subjects:`` list."""
+    src = Path(path) if path else _DEFAULT_YAML
+    with src.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    subjects = data.get("subjects") or []
+    if not isinstance(subjects, list):
+        raise ValueError(f"{src}: top-level 'subjects' must be a list")
+    return subjects
+
+
+def sync_from_yaml(store, path: str | Path | None = None) -> int:
+    """Load the YAML and push it through ``store.sync_subjects``.
+
+    Returns the number of subjects synced.
+    """
+    subjects = load_subjects_yaml(path)
+    store.sync_subjects(subjects)
+    return len(subjects)
+
+
+class SubjectTagger:
+    """Compiled view over the subject-alias tables.
+
+    Build once per process — the regex list is small but compiling per call
+    wastes work. Rebuild by constructing a new instance after a yaml re-sync.
+    """
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._conn = connection
+        self._title_patterns: list[tuple[str, re.Pattern[str]]] = []
+        self._exact_index: dict[tuple[str, str], str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        rows = self._conn.execute(
+            "SELECT subject_id, alias_type, alias_value FROM subject_aliases"
+        ).fetchall()
+        for sid, atype, aval in rows:
+            if atype == "title_regex":
+                self._title_patterns.append(
+                    (sid, re.compile(aval, re.IGNORECASE))
+                )
+            else:
+                # Case-insensitive exact match for all non-regex alias types
+                # (fred_series, ny_fed_series, fedwatch_series,
+                # calendar_indicator, te_indicator, news_category, ...).
+                self._exact_index[(atype, aval.lower())] = sid
+
+    # ---- public API -------------------------------------------------------
+
+    def tag_text(self, title: str | None) -> list[tuple[str, float]]:
+        """Return ``(subject_id, 0.8)`` for every title_regex hit.
+
+        Dedup on subject_id; no confidence scoring beyond the flat 0.8.
+        """
+        if not title:
+            return []
+        hits: set[str] = set()
+        for sid, pat in self._title_patterns:
+            if pat.search(title):
+                hits.add(sid)
+        return [(sid, TITLE_CONFIDENCE) for sid in sorted(hits)]
+
+    def tag_alias(
+        self, alias_type: str, values: str | Iterable[str] | None
+    ) -> list[tuple[str, float]]:
+        """Resolve one or more alias values of a given type to subjects.
+
+        Returns ``(subject_id, 1.0)`` per matched subject, deduped.
+        """
+        if not values:
+            return []
+        if isinstance(values, str):
+            values = [values]
+        hits: set[str] = set()
+        for v in values:
+            if not v:
+                continue
+            mapped = self._exact_index.get((alias_type, v.lower()))
+            if mapped:
+                hits.add(mapped)
+        return [(sid, STRUCTURED_CONFIDENCE) for sid in sorted(hits)]
+
+    def tag_structured(
+        self,
+        *,
+        fred_series: str | Iterable[str] | None = None,
+        ny_fed_series: str | Iterable[str] | None = None,
+        fedwatch_series: str | Iterable[str] | None = None,
+        calendar_indicator: str | None = None,
+        te_indicator: str | None = None,
+    ) -> list[tuple[str, float]]:
+        """Resolve any structured alias (confidence 1.0), deduped."""
+        hits: dict[str, float] = {}
+        pairs = (
+            ("fred_series", fred_series),
+            ("ny_fed_series", ny_fed_series),
+            ("fedwatch_series", fedwatch_series),
+            ("calendar_indicator", calendar_indicator),
+            ("te_indicator", te_indicator),
+        )
+        for atype, val in pairs:
+            for sid, conf in self.tag_alias(atype, val):
+                hits[sid] = conf
+        return sorted(hits.items())

--- a/src/storage/subjects.yaml
+++ b/src/storage/subjects.yaml
@@ -35,6 +35,7 @@ subjects:
     display: "PPI"
     aliases:
       fred_series: [PPIACO, PPIFIS]
+      bls_series: [WPSFD4, WPSFD49116]   # PPI_US, PPI_CORE_US in concept_map
       calendar_indicator: ["PPI", "Producer Price Index", "PPI MoM", "PPI YoY"]
       title_regex:
         - '\bPPI\b'
@@ -208,6 +209,7 @@ subjects:
     display: "WTI Crude Oil"
     aliases:
       fred_series: [DCOILWTICO]
+      eia_series: [EIA_WTI]               # WTI_CRUDE in concept_map
       calendar_indicator: []
       title_regex:
         - '\bWTI\b'
@@ -217,6 +219,7 @@ subjects:
     display: "Brent Crude Oil"
     aliases:
       fred_series: [DCOILBRENTEU]
+      eia_series: [EIA_BRENT]             # BRENT_CRUDE in concept_map
       calendar_indicator: []
       title_regex:
         - '\bbrent(?:\s+crude)?\b'

--- a/tests/test_backfill_indexes.py
+++ b/tests/test_backfill_indexes.py
@@ -1,0 +1,195 @@
+"""Tests for the one-shot document-index backfills (Step 9 review fix).
+
+Covers the upgrade path: a DB that accumulated document rows before
+documents_fts / item_subjects were populated by ingestion should still
+become queryable once backfill_document_indexes runs."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from macro_data.service import LocalMacroDataService
+from storage.sqlite import (
+    DocumentBlobRecord,
+    DocumentRecord,
+    SQLiteEngineStore,
+)
+
+
+def _seed_doc_source(store: SQLiteEngineStore) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    with store._connection(commit=True) as c:
+        c.execute(
+            "INSERT OR IGNORE INTO doc_source "
+            "(source_id, source_code, source_name, source_type, "
+            " country_code, is_active, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, 1, ?, ?)",
+            ("news", "NEWS", "News feeds", "news_agency", "US", now, now),
+        )
+
+
+def _write_legacy_doc(
+    store: SQLiteEngineStore,
+    *,
+    doc_id: str,
+    title: str,
+    body: str,
+    published_date: str = "2026-04-10",
+) -> None:
+    """Write a document WITHOUT calling upsert_document_fts / set_document_
+    subjects — simulates a row that landed before those sidecars existed."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    store.upsert_document(DocumentRecord(
+        document_id=doc_id,
+        release_family_id="",
+        source_id="news",
+        canonical_url=f"https://example.com/{doc_id}",
+        title=title,
+        subtitle="",
+        document_type="report",
+        mime_type="text/html",
+        language_code="en",
+        country_code="US",
+        topic_code="markets",
+        published_date=published_date,
+        published_at=published_date,
+        status="published",
+        version_no=1,
+        parent_document_id="",
+        hash_sha256=doc_id + "0" * (64 - len(doc_id)),
+        created_at=now_iso,
+        updated_at=now_iso,
+    ))
+    store.upsert_document_blob(DocumentBlobRecord(
+        document_blob_id=f"{doc_id}_md",
+        document_id=doc_id,
+        blob_role="markdown",
+        storage_path="",
+        content_text=body,
+        content_bytes=None,
+        byte_size=len(body.encode("utf-8")),
+        encoding="utf-8",
+        parser_name="legacy",
+        parser_version="",
+        extracted_at=now_iso,
+    ))
+
+
+@pytest.fixture()
+def legacy_store(tmp_path: Path) -> SQLiteEngineStore:
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    _seed_doc_source(store)
+    _write_legacy_doc(store, doc_id="d_cpi",
+                      title="Hot CPI print shakes markets",
+                      body="Headline CPI rose 0.5 percent in March.")
+    _write_legacy_doc(store, doc_id="d_nfp",
+                      title="Nonfarm payrolls beat forecasts",
+                      body="NFP added 300k jobs.",
+                      published_date="2026-04-08")
+    _write_legacy_doc(store, doc_id="d_misc",
+                      title="Boring regulatory memo",
+                      body="Nothing matches the subject vocabulary here.")
+    return store
+
+
+# ── backfill_documents_fts ──────────────────────────────────────────────
+
+
+def test_legacy_documents_are_invisible_to_fts_before_backfill(
+    legacy_store: SQLiteEngineStore,
+) -> None:
+    """Baseline: documents written without calling upsert_document_fts
+    don't appear in search_documents — demonstrates the bug."""
+    assert legacy_store.search_documents("CPI") == []
+
+
+def test_backfill_documents_fts_populates_index(
+    legacy_store: SQLiteEngineStore,
+) -> None:
+    written = legacy_store.backfill_documents_fts()
+    assert written == 3
+    hits = legacy_store.search_documents("CPI")
+    assert [h.document_id for h in hits] == ["d_cpi"]
+    # Body content is indexed too
+    hits = legacy_store.search_documents("300k jobs")
+    assert [h.document_id for h in hits] == ["d_nfp"]
+
+
+def test_backfill_documents_fts_is_idempotent(
+    legacy_store: SQLiteEngineStore,
+) -> None:
+    assert legacy_store.backfill_documents_fts() == 3
+    # Second call sees no missing rows → writes nothing
+    assert legacy_store.backfill_documents_fts() == 0
+    # Index still intact
+    assert len(legacy_store.search_documents("CPI")) == 1
+
+
+# ── backfill_document_subjects ──────────────────────────────────────────
+
+
+def test_legacy_documents_have_no_subject_tags_before_backfill(
+    legacy_store: SQLiteEngineStore,
+) -> None:
+    assert legacy_store.list_document_subjects("d_cpi") == []
+
+
+def test_backfill_document_subjects_tags_by_title_regex(
+    legacy_store: SQLiteEngineStore,
+) -> None:
+    # Vocabulary needs to exist before tagging runs.
+    from storage.subjects import sync_from_yaml
+    sync_from_yaml(legacy_store)
+
+    tagged = legacy_store.backfill_document_subjects()
+    # d_cpi → econ.cpi, d_nfp → econ.us.nfp. d_misc has no matching regex.
+    assert tagged == 2
+    assert dict(legacy_store.list_document_subjects("d_cpi")) == {"econ.cpi": 0.8}
+    assert dict(legacy_store.list_document_subjects("d_nfp")) == {"econ.us.nfp": 0.8}
+    assert legacy_store.list_document_subjects("d_misc") == []
+
+
+def test_backfill_document_subjects_is_idempotent(
+    legacy_store: SQLiteEngineStore,
+) -> None:
+    from storage.subjects import sync_from_yaml
+    sync_from_yaml(legacy_store)
+    legacy_store.backfill_document_subjects()
+    # Already-tagged documents are excluded from the second pass.
+    assert legacy_store.backfill_document_subjects() == 0
+
+
+# ── service op wrapper ─────────────────────────────────────────────────
+
+
+def test_backfill_op_runs_both_and_makes_list_items_work(
+    legacy_store: SQLiteEngineStore,
+) -> None:
+    """End-to-end: after running the op, list_items(subject=...) and
+    list_items(q=...) both return the legacy rows they previously missed."""
+    svc = LocalMacroDataService(store=legacy_store)
+
+    resp = svc.invoke("backfill_document_indexes", {})
+    assert resp == {"fts_rows_written": 3, "documents_subject_tagged": 2}
+
+    by_text = svc.invoke("list_items", {"q": "CPI"})
+    assert [i["document_id"] for i in by_text["items"]] == ["d_cpi"]
+
+    by_subject = svc.invoke("list_items", {"subject": "econ.cpi"})
+    assert [i["document_id"] for i in by_subject["items"]] == ["d_cpi"]
+
+
+def test_backfill_op_on_fresh_db_is_a_noop(tmp_path: Path) -> None:
+    """Calling the op on a DB with no documents must not error and
+    reports zero work done."""
+    store = SQLiteEngineStore(db_path=tmp_path / "fresh.db")
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke("backfill_document_indexes", {})
+    assert resp == {"fts_rows_written": 0, "documents_subject_tagged": 0}

--- a/tests/test_document_extension.py
+++ b/tests/test_document_extension.py
@@ -1,0 +1,209 @@
+"""Tests for the information-layer document extension: 17-field columns +
+FTS5 (issue #3 item 4 + port of doc_parser / gov_report / news)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from storage.sqlite import DocumentRecord, SQLiteEngineStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteEngineStore:
+    s = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    # A doc_source row is required by the document.source_id FK.
+    with s._connection(commit=True) as c:
+        c.execute(
+            "INSERT INTO doc_source(source_id, source_code, source_name, "
+            "source_type, country_code, is_active, created_at, updated_at) "
+            "VALUES (?,?,?,?,?,?,?,?)",
+            ("us.bls", "BLS", "US Bureau of Labor Statistics",
+             "government_agency", "US", 1, "2026-04-19", "2026-04-19"),
+        )
+    return s
+
+
+def _doc(**overrides) -> DocumentRecord:
+    base = dict(
+        document_id="doc-1",
+        release_family_id="",
+        source_id="us.bls",
+        canonical_url="https://bls.gov/cpi/2026-04.htm",
+        title="CPI rose 0.5% in March",
+        subtitle="",
+        document_type="release",
+        mime_type="text/html",
+        language_code="en",
+        country_code="US",
+        topic_code="inflation",
+        published_date="2026-04-10",
+        published_at="",
+        status="published",
+        version_no=1,
+        parent_document_id="",
+        hash_sha256="a" * 64,
+        created_at="2026-04-10T12:00:00Z",
+        updated_at="2026-04-10T12:00:00Z",
+    )
+    base.update(overrides)
+    return DocumentRecord(**base)
+
+
+def test_schema_has_17_field_columns(store: SQLiteEngineStore) -> None:
+    with store._connection(commit=False) as c:
+        cols = {r["name"] for r in c.execute("PRAGMA table_info(document)")}
+    for col in (
+        "institution", "authors", "data_period", "market", "asset_class",
+        "sector", "event_type", "impact_level", "contains_commentary",
+        "confidence", "subject_freetext",
+    ):
+        assert col in cols, f"missing column: {col}"
+
+
+def test_filter_indexes_created(store: SQLiteEngineStore) -> None:
+    with store._connection(commit=False) as c:
+        names = {r["name"] for r in c.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()}
+    assert {"idx_document_impact_level",
+            "idx_document_asset_class",
+            "idx_document_event_type"} <= names
+
+
+def test_documents_fts_virtual_table_exists(store: SQLiteEngineStore) -> None:
+    with store._connection(commit=False) as c:
+        row = c.execute(
+            "SELECT name FROM sqlite_master WHERE name='documents_fts'"
+        ).fetchone()
+    assert row is not None
+
+
+def test_extended_fields_round_trip(store: SQLiteEngineStore) -> None:
+    store.upsert_document(_doc(
+        institution="US Bureau of Labor Statistics",
+        authors="BLS Commissioner",
+        data_period="2026-03",
+        market="US",
+        asset_class="macro",
+        sector="consumer_prices",
+        event_type="data_release",
+        impact_level="high",
+        contains_commentary=True,
+        confidence=0.95,
+        subject_freetext="consumer inflation",
+    ))
+    got = store.get_document("doc-1")
+    assert got is not None
+    assert got.institution == "US Bureau of Labor Statistics"
+    assert got.authors == "BLS Commissioner"
+    assert got.data_period == "2026-03"
+    assert got.market == "US"
+    assert got.asset_class == "macro"
+    assert got.sector == "consumer_prices"
+    assert got.event_type == "data_release"
+    assert got.impact_level == "high"
+    assert got.contains_commentary is True
+    assert got.confidence == 0.95
+    assert got.subject_freetext == "consumer inflation"
+
+
+def test_defaults_preserved_for_legacy_callers(store: SQLiteEngineStore) -> None:
+    """Ingestion paths that don't populate the 17-field surface still work;
+    missing fields come back as '' / 0 / False rather than None."""
+    store.upsert_document(_doc())
+    got = store.get_document("doc-1")
+    assert got is not None
+    assert got.institution == ""
+    assert got.impact_level == ""
+    assert got.contains_commentary is False
+    assert got.confidence == 0.0
+    assert got.subject_freetext == ""
+
+
+def test_fts_indexes_title_and_body(store: SQLiteEngineStore) -> None:
+    store.upsert_document(_doc())
+    store.upsert_document_fts(
+        document_id="doc-1",
+        title="CPI rose 0.5% in March",
+        body="Consumer prices rose 0.5 percent in March after a flat February.",
+    )
+    hits = store.search_documents("CPI")
+    assert [h.document_id for h in hits] == ["doc-1"]
+    # BM25 match inside the body, not just title
+    hits = store.search_documents("consumer prices")
+    assert [h.document_id for h in hits] == ["doc-1"]
+
+
+def test_fts_upsert_replaces_existing_row(store: SQLiteEngineStore) -> None:
+    store.upsert_document(_doc())
+    store.upsert_document_fts(document_id="doc-1", title="first", body="alpha")
+    store.upsert_document_fts(document_id="doc-1", title="second", body="beta")
+    # Old terms gone, new terms hit
+    assert store.search_documents("alpha") == []
+    hits = store.search_documents("beta")
+    assert [h.document_id for h in hits] == ["doc-1"]
+
+
+def test_fts_delete_removes_row(store: SQLiteEngineStore) -> None:
+    store.upsert_document(_doc())
+    store.upsert_document_fts(document_id="doc-1", title="x", body="unobtainium")
+    assert len(store.search_documents("unobtainium")) == 1
+    store.delete_document_fts("doc-1")
+    assert store.search_documents("unobtainium") == []
+
+
+def test_search_documents_empty_query_returns_empty(store: SQLiteEngineStore) -> None:
+    store.upsert_document(_doc())
+    store.upsert_document_fts(document_id="doc-1", title="CPI", body="")
+    assert store.search_documents("") == []
+    assert store.search_documents("   ") == []
+
+
+@pytest.mark.parametrize(
+    "unsafe_query",
+    [
+        "0.5%",           # percent sign
+        "CPI - March",    # hyphen (FTS5 NOT operator)
+        "CPI:",           # colon (FTS5 column filter)
+        'Fed "hawkish',   # unmatched double quote
+        "AA/BBB",         # slash
+        "*asterisk*",     # leading/trailing asterisk
+        "(parens)",       # grouping chars
+        "OR AND NOT",     # reserved keywords
+    ],
+)
+def test_search_documents_tolerates_punctuation(
+    store: SQLiteEngineStore, unsafe_query: str
+) -> None:
+    """FTS5 raises on raw user input containing its syntax characters.
+    search_documents() must either return results or an empty list — it
+    must never raise sqlite3.OperationalError to the caller.
+    """
+    store.upsert_document(_doc())
+    store.upsert_document_fts(
+        document_id="doc-1",
+        title="CPI rose 0.5% in March",
+        body="",
+    )
+    # Either returns hits or [] — but must not raise.
+    result = store.search_documents(unsafe_query)
+    assert isinstance(result, list)
+
+
+def test_search_documents_ranks_by_bm25(store: SQLiteEngineStore) -> None:
+    store.upsert_document(_doc(document_id="doc-1"))
+    store.upsert_document(_doc(
+        document_id="doc-2", canonical_url="https://bls.gov/cpi/2026-03.htm"
+    ))
+    # doc-2 has the target term multiple times → ranks above doc-1
+    store.upsert_document_fts(
+        document_id="doc-1", title="Markets react", body="CPI mentioned once",
+    )
+    store.upsert_document_fts(
+        document_id="doc-2", title="CPI report",
+        body="CPI rose 0.5% CPI headline CPI core",
+    )
+    ranked = store.search_documents("CPI")
+    assert [d.document_id for d in ranked[:2]] == ["doc-2", "doc-1"]

--- a/tests/test_document_extraction.py
+++ b/tests/test_document_extraction.py
@@ -1,0 +1,352 @@
+"""Tests for the LLM 17-field extractor + gov_report ingestion wiring."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Match the standalone-runnable layout used by other tests in this suite.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from ingestion.documents._extraction import (
+    EXTRACTION_FIELDS,
+    ExtractionFields,
+    LLMDocumentExtractor,
+    NullDocumentExtractor,
+    _coerce_fields,
+    _parse_json_response,
+    make_extractor_from_env,
+)
+
+
+# ── Coercion / JSON parsing ──────────────────────────────────────────────
+
+
+def test_parse_json_response_strips_markdown_fence() -> None:
+    assert _parse_json_response('```json\n{"a": 1}\n```') == {"a": 1}
+    assert _parse_json_response("{\"a\": 1}") == {"a": 1}
+    assert _parse_json_response("") == {}
+
+
+def test_coerce_fields_empty() -> None:
+    f = _coerce_fields({})
+    assert f == ExtractionFields()
+
+
+def test_coerce_fields_tolerates_types() -> None:
+    f = _coerce_fields({
+        "institution": "US BLS",
+        "impact_level": "HIGH",           # case-insensitive
+        "confidence": "0.85",              # string number
+        "contains_commentary": "yes",      # string truthy
+        "subject": "CPI",                  # -> subject_freetext
+    })
+    assert f.institution == "US BLS"
+    assert f.impact_level == "high"
+    assert f.confidence == 0.85
+    assert f.contains_commentary is True
+    assert f.subject_freetext == "CPI"
+
+
+def test_coerce_fields_clamps_confidence_and_rejects_bad_impact() -> None:
+    f = _coerce_fields({"confidence": 2.5, "impact_level": "bogus"})
+    assert f.confidence == 1.0
+    assert f.impact_level == ""  # rejected, not preserved
+
+
+def test_coerce_fields_null_safe() -> None:
+    # LLM sometimes returns null/None for unknown fields.
+    f = _coerce_fields({"institution": None, "confidence": None,
+                        "contains_commentary": None})
+    assert f.institution == ""
+    assert f.confidence == 0.0
+    assert f.contains_commentary is False
+
+
+# ── Factory ──────────────────────────────────────────────────────────────
+
+
+def test_make_extractor_returns_null_without_key() -> None:
+    ex = make_extractor_from_env(env={})
+    assert isinstance(ex, NullDocumentExtractor)
+    assert ex.extract(title="x", markdown="y") == ExtractionFields()
+
+
+def test_make_extractor_empty_env_is_isolated_from_os_environ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing an explicit empty dict must NOT fall through to os.environ —
+    otherwise tests on machines that happen to export OPENAI_API_KEY build
+    an LLM extractor and hit the network."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-host-env")
+    ex = make_extractor_from_env(env={})
+    assert isinstance(ex, NullDocumentExtractor)
+
+
+def test_make_extractor_returns_llm_with_key() -> None:
+    # Avoid OpenAI SDK constructor side-effects by stubbing it.
+    with patch("openai.OpenAI") as mock_openai:
+        ex = make_extractor_from_env(env={
+            "DOCUMENT_EXTRACT_API_KEY": "sk-test",
+            "DOCUMENT_EXTRACT_MODEL": "my-model",
+        })
+        assert isinstance(ex, LLMDocumentExtractor)
+        assert mock_openai.called
+        kwargs = mock_openai.call_args.kwargs
+        assert kwargs["api_key"] == "sk-test"
+
+
+# ── LLMDocumentExtractor.extract ─────────────────────────────────────────
+
+
+class _FakeMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeCompletions:
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self.call_kwargs = None
+
+    def create(self, **kwargs):
+        self.call_kwargs = kwargs
+        return _FakeResponse(self._content)
+
+
+class _FakeOpenAIClient:
+    def __init__(self, content: str) -> None:
+        self.chat = type("Chat", (), {})()
+        self.chat.completions = _FakeCompletions(content)
+
+
+def _build_extractor(reply: str) -> tuple[LLMDocumentExtractor, _FakeOpenAIClient]:
+    fake = _FakeOpenAIClient(reply)
+    with patch("openai.OpenAI", return_value=fake):
+        ex = LLMDocumentExtractor(api_key="sk-x", model="m")
+    return ex, fake
+
+
+def test_extractor_empty_markdown_short_circuits() -> None:
+    ex, fake = _build_extractor("{}")
+    fields = ex.extract(title="t", markdown="   ")
+    assert fields == ExtractionFields()
+    assert fake.chat.completions.call_kwargs is None  # not called
+
+
+def test_extractor_happy_path_maps_all_fields() -> None:
+    reply = """{
+      "title": "CPI rose 0.5% in March",
+      "institution": "US Bureau of Labor Statistics",
+      "authors": "BLS Commissioner",
+      "publish_date": "2026-04-10",
+      "data_period": "2026-03",
+      "country": "US",
+      "market": "US Treasuries",
+      "asset_class": "Macro",
+      "sector": "Inflation",
+      "document_type": "Economic Release",
+      "event_type": "Economic Release",
+      "subject": "CPI",
+      "language": "en",
+      "contains_commentary": true,
+      "impact_level": "high",
+      "confidence": 0.85
+    }"""
+    ex, fake = _build_extractor(reply)
+    f = ex.extract(title="CPI rose 0.5%", markdown="Consumer prices rose ...")
+    assert f.institution == "US Bureau of Labor Statistics"
+    assert f.impact_level == "high"
+    assert f.confidence == 0.85
+    assert f.contains_commentary is True
+    assert f.asset_class == "Macro"
+    assert f.sector == "Inflation"
+    assert f.subject_freetext == "CPI"
+    # prompt was built with today's date + all 17 field descriptors
+    sent = fake.chat.completions.call_kwargs
+    assert sent["model"] == "m"
+    assert any(m["role"] == "system" for m in sent["messages"])
+
+
+def test_extractor_api_error_returns_empty_fields() -> None:
+    """Extraction is best-effort — any failure must never bubble out."""
+    class Broken:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**_):
+                    raise RuntimeError("upstream 500")
+
+    with patch("openai.OpenAI", return_value=Broken):
+        ex = LLMDocumentExtractor(api_key="sk", model="m")
+    fields = ex.extract(title="t", markdown="body text")
+    assert fields == ExtractionFields()
+
+
+def test_extractor_bad_json_returns_empty_fields() -> None:
+    ex, _ = _build_extractor("not json at all")
+    assert ex.extract(title="t", markdown="body text") == ExtractionFields()
+
+
+@pytest.mark.parametrize("reply", ["[]", "null", '"just a string"', "42"])
+def test_extractor_non_object_json_returns_empty_fields(reply: str) -> None:
+    """The LLM occasionally returns valid JSON of the wrong shape
+    (top-level list, null, scalar). That must not raise through the
+    ingestion loop — return empty fields instead."""
+    ex, _ = _build_extractor(reply)
+    assert ex.extract(title="t", markdown="body text") == ExtractionFields()
+
+
+# ── EXTRACTION_FIELDS schema guarantee ───────────────────────────────────
+
+
+def test_extraction_field_set_matches_structured_columns() -> None:
+    """Drift guard — the extractor's prompt must still cover every
+    structured column that ingestion promises to populate."""
+    keys = {f["key"] for f in EXTRACTION_FIELDS}
+    expected_structured = {
+        "institution", "authors", "data_period", "market", "asset_class",
+        "sector", "event_type", "impact_level", "contains_commentary",
+        "confidence", "subject",
+    }
+    missing = expected_structured - keys
+    assert not missing, f"extractor prompt missing columns: {missing}"
+
+
+# ── gov_report ingestion wiring ──────────────────────────────────────────
+
+
+def _gov_item(**overrides):
+    from ingestion.scrapers.gov_report import GovReportItem
+    # content_markdown must clear the 100-char threshold in _gov_report.py
+    # (below which the client falls back to item.description); tests should
+    # always exercise the full "content present" path.
+    base = dict(
+        source="gov_bls",
+        source_id="us_bls_cpi",
+        title="CPI rose 0.5% in March",
+        url="https://bls.gov/cpi/2026-04.htm",
+        published_at="2026-04-10T08:30:00Z",
+        published_precision="exact",
+        data_category="inflation",
+        institution="US Bureau of Labor Statistics",
+        description="",
+        importance="high",
+        country="US",
+        language="en",
+        content_markdown=(
+            "Consumer prices rose 0.5 percent in March after a flat February. "
+            "The all items index was up 3.1 percent over the last twelve "
+            "months before seasonal adjustment. Core inflation ex-food and "
+            "energy advanced 0.3 percent month over month."
+        ),
+        raw_json={},
+    )
+    base.update(overrides)
+    return GovReportItem(**base)
+
+
+@pytest.fixture()
+def store(tmp_path: Path):
+    from storage.sqlite import SQLiteEngineStore
+    return SQLiteEngineStore(db_path=tmp_path / "engine.db")
+
+
+def test_gov_report_writes_structured_columns_from_scraper_metadata(store) -> None:
+    """Without any LLM configured, scraper-supplied institution +
+    importance must still land in the new structured columns."""
+    from ingestion.documents.clients._gov_report import (
+        GovReportIngestionClient,
+    )
+    client = GovReportIngestionClient(extractor=NullDocumentExtractor())
+    client.store_items(store, [_gov_item()])
+
+    docs = store.list_documents(document_type="release", limit=5)
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc.institution == "US Bureau of Labor Statistics"
+    assert doc.impact_level == "high"
+    # Fields the LLM would have populated stay empty in the null path
+    assert doc.asset_class == ""
+    assert doc.sector == ""
+
+
+def test_gov_report_merges_llm_extraction_on_blank_fields(store) -> None:
+    from ingestion.documents.clients._gov_report import (
+        GovReportIngestionClient,
+    )
+
+    class FakeExtractor:
+        def extract(self, *, title, markdown):
+            return ExtractionFields(
+                institution="LLM-said-inst",  # scraper value wins
+                authors="BLS Commissioner",
+                data_period="2026-03",
+                market="US Treasuries",
+                asset_class="Macro",
+                sector="Inflation",
+                event_type="Economic Release",
+                impact_level="critical",       # scraper "high" wins
+                contains_commentary=True,
+                confidence=0.9,
+                subject_freetext="CPI",
+            )
+
+    client = GovReportIngestionClient(extractor=FakeExtractor())
+    client.store_items(store, [_gov_item()])
+
+    doc = store.list_documents(document_type="release", limit=5)[0]
+    # Scraper metadata is authoritative for the fields it covers
+    assert doc.institution == "US Bureau of Labor Statistics"
+    assert doc.impact_level == "high"
+    # LLM fills the rest
+    assert doc.authors == "BLS Commissioner"
+    assert doc.data_period == "2026-03"
+    assert doc.asset_class == "Macro"
+    assert doc.sector == "Inflation"
+    assert doc.event_type == "Economic Release"
+    assert doc.contains_commentary is True
+    assert doc.confidence == 0.9
+    assert doc.subject_freetext == "CPI"
+
+
+def test_gov_report_indexes_into_documents_fts(store) -> None:
+    from ingestion.documents.clients._gov_report import (
+        GovReportIngestionClient,
+    )
+    client = GovReportIngestionClient(extractor=NullDocumentExtractor())
+    client.store_items(store, [_gov_item()])
+
+    hits = store.search_documents("CPI")
+    assert len(hits) == 1
+    assert hits[0].title.startswith("CPI rose 0.5%")
+    hits = store.search_documents("consumer prices")
+    assert len(hits) == 1
+
+
+def test_gov_report_tags_subjects_via_title_regex(store) -> None:
+    from ingestion.documents.clients._gov_report import (
+        GovReportIngestionClient,
+    )
+    client = GovReportIngestionClient(extractor=NullDocumentExtractor())
+    client.store_items(store, [_gov_item()])
+
+    doc = store.list_documents(document_type="release", limit=5)[0]
+    tags = dict(store.list_document_subjects(doc.document_id))
+    # Title "CPI rose 0.5% in March" matches econ.cpi via \bCPI\b regex
+    assert "econ.cpi" in tags
+    assert tags["econ.cpi"] == 0.8

--- a/tests/test_fedwatch_ingestion.py
+++ b/tests/test_fedwatch_ingestion.py
@@ -1,0 +1,207 @@
+"""Tests for the FedWatch / rate_probability ingestion path (issue #3 item 3)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from ingestion.scrapers.rateprobability import (
+    FedMeetingProbability,
+    FedRateProbability,
+)
+from ingestion.sources import IngestionOrchestrator
+from storage.sqlite import SQLiteEngineStore
+
+
+def _fake_probability() -> FedRateProbability:
+    return FedRateProbability(
+        as_of="2026-04-19T12:00:00Z",
+        current_band="4.25-4.50",
+        midpoint=4.375,
+        effr=4.33,
+        meetings=[
+            FedMeetingProbability(
+                meeting_date="2026-05-07",
+                implied_rate=4.25,
+                prob_move_pct=85.0,
+                is_cut=True,
+                num_moves=1,
+                change_bps=-12.5,
+            ),
+            FedMeetingProbability(
+                meeting_date="2026-06-18",
+                implied_rate=4.00,
+                prob_move_pct=95.0,
+                is_cut=True,
+                num_moves=2,
+                change_bps=-37.5,
+            ),
+        ],
+    )
+
+
+# ── Observation fetch ────────────────────────────────────────────────────
+
+
+def _orchestrator_with_prob(
+    prob: FedRateProbability, store: SQLiteEngineStore | None = None,
+) -> IngestionOrchestrator:
+    client = Mock()
+    client.fetch_probabilities.return_value = prob
+    if store is None:
+        # In-memory-style sink for pure-fetch tests; real store is injected
+        # in the end-to-end persistence test.
+        store = Mock()
+    return IngestionOrchestrator(store=store, rate_probability=client)
+
+
+def test_rate_probability_fetch_emits_midpoint_and_meetings() -> None:
+    orch = _orchestrator_with_prob(_fake_probability())
+    observations = orch._fetch_rate_probability_observations()
+    series_ids = [o.series_id for o in observations]
+
+    assert "FEDWATCH_MIDPOINT" in series_ids
+    assert "FEDPROB_2026-05-07" in series_ids
+    assert "FEDPROB_2026-06-18" in series_ids
+
+    midpoint = next(o for o in observations if o.series_id == "FEDWATCH_MIDPOINT")
+    assert midpoint.value == 4.375
+    assert midpoint.date == "2026-04-19"
+    assert midpoint.source == "rateprobability"
+    assert midpoint.metadata["current_band"] == "4.25-4.50"
+
+
+def test_rate_probability_fetch_skips_midpoint_when_missing() -> None:
+    prob = FedRateProbability(
+        as_of="2026-04-19T12:00:00Z",
+        current_band="4.25-4.50",
+        midpoint=None,  # upstream returned no value
+        effr=4.33,
+        meetings=_fake_probability().meetings,
+    )
+    orch = _orchestrator_with_prob(prob)
+    series_ids = [o.series_id for o in orch._fetch_rate_probability_observations()]
+    assert "FEDWATCH_MIDPOINT" not in series_ids
+    # Per-meeting data still flows so the forward curve remains available.
+    assert "FEDPROB_2026-05-07" in series_ids
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Missing key entirely
+        {"today": {"as_of": "2026-04-19T12:00:00Z", "current band": "4.25-4.50",
+                   "most_recent_effr": 4.33, "rows": []}},
+        # Explicit null
+        {"today": {"as_of": "2026-04-19T12:00:00Z", "current band": "4.25-4.50",
+                   "midpoint": None, "most_recent_effr": 4.33, "rows": []}},
+        # Non-numeric garbage
+        {"today": {"as_of": "2026-04-19T12:00:00Z", "current band": "4.25-4.50",
+                   "midpoint": "n/a", "most_recent_effr": 4.33, "rows": []}},
+    ],
+)
+def test_rate_probability_parser_preserves_missing_midpoint_as_none(
+    payload: dict,
+) -> None:
+    """Regression for codex P2: the parser must NOT coerce missing /
+    null / non-numeric midpoint values to 0.0, or downstream ingestion
+    publishes a synthetic 0% FEDWATCH_US rate for that snapshot."""
+    from ingestion.scrapers.rateprobability import RateProbabilityClient
+    client = RateProbabilityClient()
+    parsed = client._parse(payload)
+    assert parsed.midpoint is None
+
+
+def test_end_to_end_missing_midpoint_does_not_publish_zero(
+    store: SQLiteEngineStore,
+) -> None:
+    """Full ingest with a missing midpoint: no FEDWATCH_MIDPOINT row
+    should land, so resolve_indicator returns None instead of 0.0."""
+    prob = FedRateProbability(
+        as_of="2026-04-19T12:00:00Z",
+        current_band="4.25-4.50",
+        midpoint=None,
+        effr=4.33,
+        meetings=_fake_probability().meetings,
+    )
+    client = Mock()
+    client.fetch_probabilities.return_value = prob
+    orch = IngestionOrchestrator(store=store, rate_probability=client)
+    store.seed_obs_sources_and_families()
+    store.seed_concept_map()
+
+    orch.run_source("rate_probability")
+    assert store.resolve_indicator("FEDWATCH_US") is None
+
+
+# ── Concept + subject bridge ─────────────────────────────────────────────
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteEngineStore:
+    return SQLiteEngineStore(db_path=tmp_path / "engine.db")
+
+
+def test_seed_registers_fedwatch_obs_family(store: SQLiteEngineStore) -> None:
+    store.seed_obs_sources_and_families()
+    fam = store.get_obs_family("us.rates.fedwatch_midpoint")
+    assert fam is not None
+    assert fam.source_id == "rateprobability"
+    assert fam.provider_series_id == "FEDWATCH_MIDPOINT"
+    assert fam.unit == "percent"
+    assert fam.frequency == "daily"
+
+
+def test_concept_map_has_fedwatch_us(store: SQLiteEngineStore) -> None:
+    store.seed_concept_map()
+    rows = store.get_concept_series("FEDWATCH_US")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.source_id == "rateprobability"
+    assert row.provider_series_id == "FEDWATCH_MIDPOINT"
+    assert row.obs_family_id == "us.rates.fedwatch_midpoint"
+    assert row.role == "primary"
+
+
+def test_fedwatch_us_bridges_to_rate_us_fedwatch_subject(
+    store: SQLiteEngineStore,
+) -> None:
+    """FEDWATCH_US concept → FEDWATCH_MIDPOINT series → rate.us.fedwatch
+    subject through the subject_aliases join, so downstream /items can
+    resolve either vocabulary."""
+    from storage.subjects import sync_from_yaml
+    store.seed_concept_map()
+    sync_from_yaml(store)
+    subs = store.resolve_subjects_for_concept("FEDWATCH_US")
+    assert "rate.us.fedwatch" in subs
+
+
+# ── End-to-end run_source ────────────────────────────────────────────────
+
+
+def test_run_rate_probability_source_persists_midpoint(
+    store: SQLiteEngineStore, tmp_path: Path,
+) -> None:
+    """Full ingest path: observations are written to the indicators
+    table and the concept resolver returns the midpoint value."""
+    prob = _fake_probability()
+    client = Mock()
+    client.fetch_probabilities.return_value = prob
+    orch = IngestionOrchestrator(store=store, rate_probability=client)
+    store.seed_obs_sources_and_families()
+    store.seed_concept_map()
+
+    result = orch.run_source("rate_probability")
+    assert result is not None
+
+    resolved = store.resolve_indicator("FEDWATCH_US")
+    assert resolved is not None
+    assert resolved.value == 4.375
+    assert resolved.source_id == "rateprobability"
+    assert resolved.provider_series_id == "FEDWATCH_MIDPOINT"

--- a/tests/test_news_document_mirror.py
+++ b/tests/test_news_document_mirror.py
@@ -1,0 +1,347 @@
+"""Tests for Step 4: news ingestion mirrors articles into the unified
+document surface (document + document_blob + documents_fts + item_subjects)
+and for the ported discovery helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from ingestion._shared.discovery import (
+    FetchResult,
+    SearchResult,
+    extract_urls,
+    fetch_url,
+    search,
+)
+from ingestion.news.client import NewsIngestionClient
+from ingestion.news._extract import NewsExtraction
+from ingestion.news._types import PreparedNewsRecord
+from storage.sqlite import SQLiteEngineStore
+
+
+# ── Discovery helpers ────────────────────────────────────────────────────
+
+
+def test_extract_urls_dedups_and_preserves_order() -> None:
+    md = (
+        "First https://a.com/p1 then "
+        "https://b.com/path?x=1. "
+        "Duplicate https://a.com/p1 should collapse."
+    )
+    assert extract_urls(md) == [
+        "https://a.com/p1",
+        "https://b.com/path?x=1",
+    ]
+
+
+def test_extract_urls_limit() -> None:
+    md = "one https://a.com two https://b.com three https://c.com"
+    assert extract_urls(md, limit=2) == ["https://a.com", "https://b.com"]
+
+
+def test_extract_urls_empty() -> None:
+    assert extract_urls("") == []
+    assert extract_urls(None) == []  # type: ignore[arg-type]
+
+
+def test_search_returns_empty_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    # Neutralize any .env file resolution too — otherwise a local .env
+    # with BRAVE_API_KEY defined would make this test hit the network.
+    import env
+    monkeypatch.setattr(env, "DEFAULT_ENV_FILES", ())
+    env.clear_env_cache()
+    assert search("federal reserve") == []
+
+
+def test_search_reads_key_from_env_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Regression for the codex P2: search must honor repo .env files the
+    same way FRED_API_KEY / LLM_API_KEY do."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("BRAVE_API_KEY=from-env-file\n")
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    import env
+    monkeypatch.setattr(env, "DEFAULT_ENV_FILES", (env_file,))
+    env.clear_env_cache()
+
+    captured: dict[str, object] = {}
+
+    class FakeResp:
+        status_code = 200
+        def raise_for_status(self) -> None: return None
+        def json(self):
+            return {"web": {"results": [
+                {"title": "t", "url": "https://x.com/", "description": "s"},
+            ]}}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["headers"] = headers
+        return FakeResp()
+
+    monkeypatch.setattr("httpx.get", fake_get)
+    results = search("x")
+    assert len(results) == 1
+    assert captured["headers"]["X-Subscription-Token"] == "from-env-file"
+
+
+def test_search_empty_query_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BRAVE_API_KEY", "sk-fake")  # would be used if queried
+    assert search("") == []
+    assert search("   ") == []
+
+
+def test_fetch_url_without_paywall_returns_error_on_4xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResp:
+        status_code = 403
+        text = ""
+
+    def fake_get(*a, **k):
+        return FakeResp()
+
+    monkeypatch.setattr("httpx.get", fake_get)
+    result = fetch_url("https://example.com/paywalled")
+    assert isinstance(result, FetchResult)
+    assert result.status == 403
+    assert result.text == ""
+    assert "HTTP 403" in (result.error or "")
+
+
+def test_fetch_url_returns_text_on_2xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResp:
+        status_code = 200
+        text = "<html>hello world</html>"
+
+    monkeypatch.setattr("httpx.get", lambda *a, **k: FakeResp())
+    result = fetch_url("https://example.com/")
+    assert result.status == 200
+    assert "hello world" in result.text
+
+
+# ── News → document mirroring ────────────────────────────────────────────
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteEngineStore:
+    return SQLiteEngineStore(db_path=tmp_path / "engine.db")
+
+
+def _prepared(**overrides) -> PreparedNewsRecord:
+    base = dict(
+        source_feed="Reuters Business",
+        feed_category="business",
+        description="Fed chair comments on inflation outlook.",
+        timestamp=1_712_764_200,  # 2024-04-10 ~14:30Z
+        canonical_url="https://reuters.com/x/fed-chair-inflation",
+        raw_url="https://reuters.com/x/fed-chair-inflation?src=rss",
+        raw_title="Fed chair warns CPI trajectory unstable",
+        url_hash="a" * 64,
+        title_hash="b" * 64,
+    )
+    base.update(overrides)
+    return PreparedNewsRecord(**base)
+
+
+def _extraction(**overrides) -> NewsExtraction:
+    base = dict(
+        title="Fed chair warns CPI trajectory unstable",
+        institution="Reuters",
+        authors="Jane Reporter",
+        publish_date="2024-04-10",
+        data_period="2024-04",
+        country="US",
+        market="US Treasuries",
+        asset_class="Macro",
+        sector="Inflation",
+        document_type="News Article",
+        event_type="Market Commentary",
+        subject="CPI",
+        subject_id="",
+        language="en",
+        contains_commentary=True,
+        impact_level="high",
+        finance_category="inflation",
+        confidence=0.8,
+        extraction_provider="keyword",
+    )
+    base.update(overrides)
+    return NewsExtraction(**base)
+
+
+def test_mirror_creates_document_with_structured_columns(store) -> None:
+    client = NewsIngestionClient()
+    # Build the subject tagger the same way store_articles does.
+    client._ensure_news_doc_source(store)
+    from storage.subjects import SubjectTagger, sync_from_yaml
+    sync_from_yaml(store)
+    with store._connection(commit=False) as c:
+        tagger = SubjectTagger(c)
+    client._mirror_as_document(
+        store=store,
+        tagger=tagger,
+        entry=_prepared(),
+        extraction=_extraction(),
+        article_content=(
+            "The chair emphasized that headline CPI readings have been "
+            "running hotter than expected for three consecutive months, "
+            "and markets now price higher terminal rates as a result."
+        ),
+    )
+    docs = store.list_documents(source_id="news", limit=5)
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc.source_id == "news"
+    assert doc.document_type == "report"  # news maps to 'report'
+    assert doc.title.startswith("Fed chair warns")
+    assert doc.subtitle == "Reuters Business"  # feed name carried here
+    assert doc.institution == "Reuters"
+    assert doc.asset_class == "Macro"
+    assert doc.impact_level == "high"
+    assert doc.contains_commentary is True
+    assert doc.confidence == 0.8
+    assert doc.subject_freetext == "CPI"
+    assert doc.event_type == "Market Commentary"
+
+
+def test_mirror_indexes_into_documents_fts(store) -> None:
+    client = NewsIngestionClient()
+    client._ensure_news_doc_source(store)
+    from storage.subjects import SubjectTagger, sync_from_yaml
+    sync_from_yaml(store)
+    with store._connection(commit=False) as c:
+        tagger = SubjectTagger(c)
+    client._mirror_as_document(
+        store=store,
+        tagger=tagger,
+        entry=_prepared(),
+        extraction=_extraction(),
+        article_content="The chair emphasized headline CPI trajectory.",
+    )
+    hits = store.search_documents("CPI")
+    assert [h.source_id for h in hits] == ["news"]
+    hits = store.search_documents("trajectory")
+    assert len(hits) == 1
+
+
+def test_mirror_tags_subjects_via_title_regex(store) -> None:
+    client = NewsIngestionClient()
+    client._ensure_news_doc_source(store)
+    from storage.subjects import SubjectTagger, sync_from_yaml
+    sync_from_yaml(store)
+    with store._connection(commit=False) as c:
+        tagger = SubjectTagger(c)
+    client._mirror_as_document(
+        store=store,
+        tagger=tagger,
+        entry=_prepared(),
+        extraction=_extraction(),
+        article_content="body",
+    )
+    doc = store.list_documents(source_id="news", limit=1)[0]
+    tags = dict(store.list_document_subjects(doc.document_id))
+    # "Fed chair warns CPI trajectory unstable" — matches econ.cpi (\bCPI\b)
+    # and rate.us.fed_funds (\bfed(eral reserve)?\s+rate\b? -- no, just \bFOMC\b
+    # / \bfed funds\b). Let's just assert CPI and check the tagger didn't
+    # over-match.
+    assert "econ.cpi" in tags
+    assert tags["econ.cpi"] == 0.8
+
+
+@pytest.mark.parametrize(
+    "extractor_country, expected",
+    [
+        ("", "XX"),
+        ("global", "XX"),
+        ("Global", "XX"),
+        ("World", "XX"),
+        ("US", "US"),
+        ("us", "US"),
+        ("USA", "US"),
+        ("united states", "US"),
+        ("China", "CN"),
+        ("JAPAN", "JP"),
+        ("Euro Area", "EU"),
+        ("UK", "GB"),
+        ("Unknown land", "XX"),
+    ],
+)
+def test_mirror_normalizes_country_code(
+    store, extractor_country: str, expected: str,
+) -> None:
+    """Regression for codex P2: blank / free-text country values must not
+    silently default to 'US' — that poisons downstream country filters
+    with global and non-US news."""
+    client = NewsIngestionClient()
+    client._ensure_news_doc_source(store)
+    from storage.subjects import SubjectTagger, sync_from_yaml
+    sync_from_yaml(store)
+    with store._connection(commit=False) as c:
+        tagger = SubjectTagger(c)
+    # Unique URL per parametrization so each case creates a distinct doc.
+    prepared = _prepared(
+        canonical_url=f"https://example.com/{expected}/{extractor_country}",
+        url_hash=f"{hash((extractor_country, expected)) & 0xFFFFFFFFFFFFFFFF:016x}" * 4,
+    )
+    client._mirror_as_document(
+        store=store, tagger=tagger, entry=prepared,
+        extraction=_extraction(country=extractor_country),
+        article_content="body",
+    )
+    doc = store.get_document(prepared.url_hash[:16])
+    assert doc is not None
+    assert doc.country_code == expected
+
+
+def test_mirror_skips_if_document_already_exists(store) -> None:
+    """When a gov-report ingest wrote this URL first, news ingestion
+    should leave it alone so it isn't overwritten with news metadata."""
+    client = NewsIngestionClient()
+    client._ensure_news_doc_source(store)
+    from storage.subjects import SubjectTagger, sync_from_yaml
+    sync_from_yaml(store)
+    with store._connection(commit=False) as c:
+        tagger = SubjectTagger(c)
+
+    prepared = _prepared()
+    # First write — as a news document.
+    client._mirror_as_document(
+        store=store, tagger=tagger, entry=prepared,
+        extraction=_extraction(impact_level="high"),
+        article_content="original body",
+    )
+    # Second write with different extraction — should be a no-op.
+    client._mirror_as_document(
+        store=store, tagger=tagger, entry=prepared,
+        extraction=_extraction(impact_level="critical",
+                               institution="SomethingElse"),
+        article_content="updated body that should not land",
+    )
+    doc = store.list_documents(source_id="news", limit=5)[0]
+    assert doc.impact_level == "high"
+    assert doc.institution == "Reuters"
+
+
+def test_ensure_news_doc_source_is_idempotent(store) -> None:
+    client = NewsIngestionClient()
+    client._ensure_news_doc_source(store)
+    client._ensure_news_doc_source(store)
+    with store._connection(commit=False) as c:
+        cnt = c.execute(
+            "SELECT COUNT(*) FROM doc_source WHERE source_id = 'news'"
+        ).fetchone()[0]
+    assert cnt == 1

--- a/tests/test_notes_ingest.py
+++ b/tests/test_notes_ingest.py
@@ -1,0 +1,217 @@
+"""Tests for the research-notes ingestion module (issue #3 item 6)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from ingestion.notes.ingest import (
+    NoteFrontmatter,
+    _ensure_notes_doc_source,
+    ingest_notes,
+    parse_note,
+)
+from storage.sqlite import SQLiteEngineStore
+
+
+_SAMPLE = """---
+title: "Thoughts on Q3 CPI"
+date: "2026-04-19"
+subject_id: econ.cpi
+author: ewan
+---
+
+# Body
+
+Inflation looks sticky in services.
+"""
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ── parse_note ──────────────────────────────────────────────────────────
+
+
+def test_parse_note_happy_path(tmp_path: Path) -> None:
+    p = _write(tmp_path / "n.md", _SAMPLE)
+    fm, body = parse_note(p)
+    assert isinstance(fm, NoteFrontmatter)
+    assert fm.title == "Thoughts on Q3 CPI"
+    assert fm.publish_date == "2026-04-19"
+    assert fm.subject_id == "econ.cpi"
+    assert fm.author == "ewan"
+    assert "Inflation looks sticky" in body
+
+
+def test_parse_note_missing_frontmatter(tmp_path: Path) -> None:
+    p = _write(tmp_path / "n.md", "no frontmatter here")
+    with pytest.raises(ValueError, match="missing YAML frontmatter"):
+        parse_note(p)
+
+
+def test_parse_note_unterminated_frontmatter(tmp_path: Path) -> None:
+    p = _write(tmp_path / "n.md", "---\ntitle: x\n")
+    with pytest.raises(ValueError, match="unterminated frontmatter"):
+        parse_note(p)
+
+
+def test_parse_note_missing_required_field(tmp_path: Path) -> None:
+    text = "---\ntitle: foo\ndate: 2026-01-01\n---\nbody"
+    p = _write(tmp_path / "n.md", text)
+    with pytest.raises(ValueError, match="subject_id"):
+        parse_note(p)
+
+
+def test_parse_note_defaults_country_and_language(tmp_path: Path) -> None:
+    text = '---\ntitle: t\ndate: "2026-04-10"\nsubject_id: econ.cpi\n---\nb'
+    p = _write(tmp_path / "n.md", text)
+    fm, _ = parse_note(p)
+    assert fm.country == "XX"
+    assert fm.language == "en"
+
+
+# ── ingest_notes ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteEngineStore:
+    return SQLiteEngineStore(db_path=tmp_path / "engine.db")
+
+
+def test_ingest_notes_writes_document_and_fts(
+    tmp_path: Path, store: SQLiteEngineStore,
+) -> None:
+    notes_dir = tmp_path / "notes_input"
+    notes_dir.mkdir()
+    _write(notes_dir / "q3_cpi.md", _SAMPLE)
+
+    stats = ingest_notes(notes_dir, store=store)
+    assert stats == {"ingested": 1, "skipped": 0, "failed": 0}
+
+    docs = store.list_documents(source_id="notes", limit=5)
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc.title == "Thoughts on Q3 CPI"
+    assert doc.document_type == "report"
+    assert doc.event_type == "Research Note"
+    assert doc.subject_freetext == "econ.cpi"
+    assert doc.confidence == 1.0
+    assert doc.authors == "ewan"
+    assert doc.institution == "ewan"
+
+    # FTS indexed
+    hits = store.search_documents("sticky")
+    assert [h.document_id for h in hits] == [doc.document_id]
+
+
+def test_ingest_notes_tags_subject_at_full_confidence(
+    tmp_path: Path, store: SQLiteEngineStore,
+) -> None:
+    notes_dir = tmp_path / "in"
+    notes_dir.mkdir()
+    _write(notes_dir / "a.md", _SAMPLE)
+    ingest_notes(notes_dir, store=store)
+
+    doc = store.list_documents(source_id="notes", limit=1)[0]
+    tags = dict(store.list_document_subjects(doc.document_id))
+    assert tags == {"econ.cpi": 1.0}
+
+
+def test_ingest_notes_is_idempotent_by_sha(
+    tmp_path: Path, store: SQLiteEngineStore,
+) -> None:
+    notes_dir = tmp_path / "in"
+    notes_dir.mkdir()
+    _write(notes_dir / "a.md", _SAMPLE)
+
+    first = ingest_notes(notes_dir, store=store)
+    second = ingest_notes(notes_dir, store=store)
+    assert first == {"ingested": 1, "skipped": 0, "failed": 0}
+    assert second == {"ingested": 0, "skipped": 1, "failed": 0}
+
+
+def test_ingest_notes_reingests_on_body_change(
+    tmp_path: Path, store: SQLiteEngineStore,
+) -> None:
+    notes_dir = tmp_path / "in"
+    notes_dir.mkdir()
+    path = _write(notes_dir / "a.md", _SAMPLE)
+    ingest_notes(notes_dir, store=store)
+
+    # Edit body → sha256 over the file changes → new row gets ingested.
+    path.write_text(_SAMPLE + "\n\nAdditional observation.\n", encoding="utf-8")
+    stats = ingest_notes(notes_dir, store=store)
+    assert stats["ingested"] == 1
+
+    docs = store.list_documents(source_id="notes", limit=5)
+    assert len(docs) == 2  # original + updated both stored
+
+
+def test_ingest_notes_counts_malformed_as_failed(
+    tmp_path: Path, store: SQLiteEngineStore,
+) -> None:
+    notes_dir = tmp_path / "in"
+    notes_dir.mkdir()
+    _write(notes_dir / "good.md", _SAMPLE)
+    _write(notes_dir / "bad.md", "no frontmatter at all")
+    _write(notes_dir / "missing_subject.md",
+           "---\ntitle: t\ndate: 2026-01-01\n---\nbody")
+
+    stats = ingest_notes(notes_dir, store=store)
+    assert stats == {"ingested": 1, "skipped": 0, "failed": 2}
+
+
+def test_ingest_notes_seeds_notes_doc_source(
+    tmp_path: Path, store: SQLiteEngineStore,
+) -> None:
+    _ensure_notes_doc_source(store)
+    _ensure_notes_doc_source(store)  # idempotent
+
+    with store._connection(commit=False) as c:
+        row = c.execute(
+            "SELECT source_id, source_type, country_code "
+            "FROM doc_source WHERE source_id = 'notes'"
+        ).fetchone()
+    assert row is not None
+    assert row["source_type"] == "news_agency"
+    assert row["country_code"] == "XX"
+
+
+def test_ingest_notes_empty_dir_is_noop(
+    tmp_path: Path, store: SQLiteEngineStore,
+) -> None:
+    notes_dir = tmp_path / "empty"
+    notes_dir.mkdir()
+    stats = ingest_notes(notes_dir, store=store)
+    assert stats == {"ingested": 0, "skipped": 0, "failed": 0}
+
+
+def test_ingest_notes_dedupes_duplicate_bytes_under_different_names(
+    tmp_path: Path, store: SQLiteEngineStore,
+) -> None:
+    """Regression for codex P2: when two files contain identical bytes
+    under different filenames they share the same sha256 and therefore
+    the same doc_id. Previously the second file slipped past
+    document_exists() (which used filename-qualified canonical_url) and
+    INSERT OR REPLACE overwrote the first row. canonical_url must be
+    sha-only so both files dedupe to one document."""
+    notes_dir = tmp_path / "in"
+    notes_dir.mkdir()
+    _write(notes_dir / "a.md", _SAMPLE)
+    _write(notes_dir / "b.md", _SAMPLE)  # identical bytes
+
+    stats = ingest_notes(notes_dir, store=store)
+    assert stats == {"ingested": 1, "skipped": 1, "failed": 0}
+
+    docs = store.list_documents(source_id="notes", limit=5)
+    assert len(docs) == 1
+    # And the persisted row still points at the original first-seen file.
+    assert docs[0].subtitle == "a.md"

--- a/tests/test_production_regressions.py
+++ b/tests/test_production_regressions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -95,7 +95,10 @@ def test_gov_report_store_items_raises_when_every_item_fails(monkeypatch) -> Non
     client = GovReportIngestionClient()
     monkeypatch.setattr(client, "_ensure_seed", lambda store: None)
 
-    store = Mock()
+    # MagicMock (not Mock) supports the context-manager protocol used by
+    # store._connection(...), which the gov_report client opens to build
+    # the SubjectTagger at the top of store_items.
+    store = MagicMock()
     item = GovReportItem(
         source="gov_bls",
         source_id="us_bls_cpi",
@@ -120,7 +123,7 @@ def test_gov_report_store_items_stores_short_content_with_metadata(monkeypatch) 
     """Items with short content are stored as metadata-only (content_fetched=False)."""
     client = GovReportIngestionClient()
     monkeypatch.setattr(client, "_ensure_seed", lambda store: None)
-    store = Mock()
+    store = MagicMock()
     store.document_exists.return_value = False
     store.news_article_exists.return_value = False
     item = GovReportItem(

--- a/tests/test_subjects.py
+++ b/tests/test_subjects.py
@@ -116,19 +116,45 @@ def test_tagger_structured_dedups_across_alias_types(
     assert hits == [("econ.cpi", STRUCTURED_CONFIDENCE)]
 
 
+@pytest.mark.parametrize(
+    "concept_id, expected_subject",
+    [
+        # FRED-sourced bridges
+        ("CPI_US", "econ.cpi"),
+        ("CORE_PCE_US", "econ.us.core_pce"),
+        ("UNEMP_US", "econ.unemployment"),
+        ("GDP_REAL_US", "econ.gdp"),
+        ("RETAIL_SALES_US", "econ.retail_sales"),
+        ("TREASURY_2Y_US", "rate.us.2y"),
+        ("TREASURY_10Y_US", "rate.us.10y"),
+        ("DOLLAR_INDEX_US", "fx.dxy"),
+        # BLS-sourced bridges (would break without bls_series aliases)
+        ("NFP_US", "econ.us.nfp"),
+        ("PPI_US", "econ.ppi"),
+        # EIA-sourced bridges (would break without eia_series aliases)
+        ("WTI_CRUDE", "commodity.wti"),
+        ("BRENT_CRUDE", "commodity.brent"),
+        # NY Fed bridges (the dual-form alias fix)
+        ("SOFR_US", "rate.us.sofr"),
+        ("OBFR_US", "rate.us.obfr"),
+    ],
+)
 def test_resolve_subjects_for_concept_bridges_vocabularies(
     store: SQLiteEngineStore,
+    concept_id: str,
+    expected_subject: str,
 ) -> None:
-    """concept_map (e.g. CPI_US → CPIAUCSL on fred) should resolve through
-    subject_aliases to the canonical subject econ.cpi — no bridge table,
-    just a join on provider_series_id ↔ alias_value.
+    """concept_map provider_series_id ↔ subject_aliases.alias_value is the
+    only bridge between the timeseries vocabulary and the subject vocabulary.
+    Every concept shipped in _CONCEPT_MAP_DEFS whose subject exists in the
+    yaml must resolve through this join.
     """
     store.seed_concept_map()
     sync_from_yaml(store)
-    subs = store.resolve_subjects_for_concept("CPI_US")
-    assert "econ.cpi" in subs
-    subs_sofr = store.resolve_subjects_for_concept("SOFR_US")
-    assert "rate.us.sofr" in subs_sofr
+    subs = store.resolve_subjects_for_concept(concept_id)
+    assert expected_subject in subs, (
+        f"{concept_id} did not bridge to {expected_subject}; got {subs}"
+    )
 
 
 def test_load_subjects_yaml_shape() -> None:

--- a/tests/test_subjects.py
+++ b/tests/test_subjects.py
@@ -1,0 +1,137 @@
+"""Tests for the unified subject vocabulary (issue #2)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from storage.sqlite import SQLiteEngineStore
+from storage.subjects import (
+    STRUCTURED_CONFIDENCE,
+    TITLE_CONFIDENCE,
+    SubjectTagger,
+    load_subjects_yaml,
+    sync_from_yaml,
+)
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteEngineStore:
+    return SQLiteEngineStore(db_path=tmp_path / "engine.db")
+
+
+def _count(store: SQLiteEngineStore, table: str) -> int:
+    with store._connection(commit=False) as c:
+        return c.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
+def test_schema_creates_subject_tables(store: SQLiteEngineStore) -> None:
+    with store._connection(commit=False) as c:
+        names = {
+            r[0]
+            for r in c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    assert {"subjects", "subject_aliases", "item_subjects"} <= names
+
+
+def test_sync_from_yaml_loads_default_vocab(store: SQLiteEngineStore) -> None:
+    n = sync_from_yaml(store)
+    assert n >= 20
+    assert _count(store, "subjects") == n
+    assert _count(store, "subject_aliases") > n  # each subject has several aliases
+
+
+def test_sync_is_idempotent(store: SQLiteEngineStore) -> None:
+    a = sync_from_yaml(store)
+    before_aliases = _count(store, "subject_aliases")
+    b = sync_from_yaml(store)
+    after_aliases = _count(store, "subject_aliases")
+    assert a == b
+    assert before_aliases == after_aliases
+
+
+def test_list_subjects_sorted(store: SQLiteEngineStore) -> None:
+    sync_from_yaml(store)
+    rows = store.list_subjects()
+    ids = [r["subject_id"] for r in rows]
+    assert ids == sorted(ids)
+    assert "econ.cpi" in ids
+    assert "rate.us.sofr" in ids
+
+
+def test_get_subject_aliases_filtered(store: SQLiteEngineStore) -> None:
+    sync_from_yaml(store)
+    fred = store.get_subject_aliases("econ.cpi", alias_type="fred_series")
+    assert set(fred) == {"CPIAUCSL", "CPILFESL", "CUUR0000SA0"}
+    cal = store.get_subject_aliases("econ.cpi", alias_type="calendar_indicator")
+    assert "CPI" in cal
+
+
+def test_tagger_title_regex(store: SQLiteEngineStore) -> None:
+    sync_from_yaml(store)
+    with store._connection(commit=False) as c:
+        tagger = SubjectTagger(c)
+    hits = tagger.tag_text("Hot CPI print shakes markets")
+    assert hits == [("econ.cpi", TITLE_CONFIDENCE)]
+    hits = tagger.tag_text("Nonfarm payrolls beat forecasts")
+    assert ("econ.us.nfp", TITLE_CONFIDENCE) in hits
+
+
+def test_tagger_structured_alias(store: SQLiteEngineStore) -> None:
+    sync_from_yaml(store)
+    with store._connection(commit=False) as c:
+        tagger = SubjectTagger(c)
+
+    # FRED series (macro-data-service native)
+    assert tagger.tag_alias("fred_series", "CPIAUCSL") == [
+        ("econ.cpi", STRUCTURED_CONFIDENCE)
+    ]
+    # NY Fed series (information-layer addition)
+    assert tagger.tag_alias("ny_fed_series", "SOFR") == [
+        ("rate.us.sofr", STRUCTURED_CONFIDENCE)
+    ]
+    # Calendar indicator (case-insensitive)
+    assert tagger.tag_alias("calendar_indicator", "core cpi") == [
+        ("econ.cpi", STRUCTURED_CONFIDENCE)
+    ]
+    # Unknown alias → empty
+    assert tagger.tag_alias("fred_series", "DOES_NOT_EXIST") == []
+
+
+def test_tagger_structured_dedups_across_alias_types(
+    store: SQLiteEngineStore,
+) -> None:
+    sync_from_yaml(store)
+    with store._connection(commit=False) as c:
+        tagger = SubjectTagger(c)
+    # FRED + calendar both point to econ.cpi → one tuple back
+    hits = tagger.tag_structured(
+        fred_series="CPIAUCSL",
+        calendar_indicator="CPI",
+    )
+    assert hits == [("econ.cpi", STRUCTURED_CONFIDENCE)]
+
+
+def test_resolve_subjects_for_concept_bridges_vocabularies(
+    store: SQLiteEngineStore,
+) -> None:
+    """concept_map (e.g. CPI_US → CPIAUCSL on fred) should resolve through
+    subject_aliases to the canonical subject econ.cpi — no bridge table,
+    just a join on provider_series_id ↔ alias_value.
+    """
+    store.seed_concept_map()
+    sync_from_yaml(store)
+    subs = store.resolve_subjects_for_concept("CPI_US")
+    assert "econ.cpi" in subs
+    subs_sofr = store.resolve_subjects_for_concept("SOFR_US")
+    assert "rate.us.sofr" in subs_sofr
+
+
+def test_load_subjects_yaml_shape() -> None:
+    rows = load_subjects_yaml()
+    assert isinstance(rows, list)
+    assert all("id" in r and "display" in r for r in rows)

--- a/tests/test_unified_api_ops.py
+++ b/tests/test_unified_api_ops.py
@@ -1,0 +1,262 @@
+"""Tests for the unified document query ops: list_items / get_document /
+list_subjects (Step 8 of the information-layer merge)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from ingestion.notes.ingest import ingest_notes
+from macro_data.service import LocalMacroDataService
+from storage.sqlite import DocumentRecord, SQLiteEngineStore
+
+
+_NOTE_CPI = """---
+title: "Sticky services inflation"
+date: "2026-04-15"
+subject_id: econ.cpi
+author: ewan
+---
+
+# Body
+
+March CPI rose 0.5% MoM. Core services remain elevated.
+"""
+
+_NOTE_VIX = """---
+title: "VIX regime thoughts"
+date: "2026-04-16"
+subject_id: vol.vix
+author: ewan
+---
+
+Volatility is picking up as the VIX prints at 22, still firmly in the
+elevated regime but approaching the stressed threshold.
+"""
+
+
+@pytest.fixture()
+def service(tmp_path: Path) -> LocalMacroDataService:
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "cpi.md").write_text(_NOTE_CPI, encoding="utf-8")
+    (notes_dir / "vix.md").write_text(_NOTE_VIX, encoding="utf-8")
+    ingest_notes(notes_dir, store=store)
+    return LocalMacroDataService(store=store)
+
+
+# ── invoke dispatch ─────────────────────────────────────────────────────
+
+
+def test_unknown_operation_raises_key_error(service: LocalMacroDataService) -> None:
+    with pytest.raises(KeyError):
+        service.invoke("does_not_exist", {})
+
+
+# ── list_subjects ───────────────────────────────────────────────────────
+
+
+def test_list_subjects_returns_seeded_vocabulary(
+    service: LocalMacroDataService,
+) -> None:
+    resp = service.invoke("list_subjects", {})
+    subjects = {s["subject_id"] for s in resp["subjects"]}
+    # A handful from the yaml seed — enough to prove sync ran.
+    assert {"econ.cpi", "rate.us.sofr", "vol.vix"} <= subjects
+    for row in resp["subjects"]:
+        assert row["display_name"]  # non-empty
+
+
+# ── list_items ──────────────────────────────────────────────────────────
+
+
+def test_list_items_by_subject(service: LocalMacroDataService) -> None:
+    resp = service.invoke("list_items", {"subject": "econ.cpi"})
+    assert resp["total"] == 1
+    item = resp["items"][0]
+    assert item["title"] == "Sticky services inflation"
+    assert item["source_id"] == "notes"
+
+
+def test_list_items_by_query(service: LocalMacroDataService) -> None:
+    resp = service.invoke("list_items", {"q": "VIX"})
+    # FTS5 finds the VIX note body; note subject 'vol.vix' also tagged.
+    titles = [i["title"] for i in resp["items"]]
+    assert "VIX regime thoughts" in titles
+
+
+def test_list_items_intersects_subject_and_query(
+    service: LocalMacroDataService,
+) -> None:
+    # Subject matches both notes if both had the subject — only CPI has
+    # econ.cpi; the query "services" matches only CPI body. Intersection:
+    # CPI.
+    resp = service.invoke(
+        "list_items", {"subject": "econ.cpi", "q": "services"},
+    )
+    assert resp["total"] == 1
+    assert resp["items"][0]["subject_freetext"] == "econ.cpi"
+
+
+def test_list_items_empty_args_returns_recent(
+    service: LocalMacroDataService,
+) -> None:
+    resp = service.invoke("list_items", {"limit": 10})
+    # Both notes come back, most-recent first.
+    assert resp["total"] == 2
+    assert resp["items"][0]["published_date"] >= resp["items"][1]["published_date"]
+
+
+def test_list_items_clamps_limit_to_cap(service: LocalMacroDataService) -> None:
+    # limit=99999 should clamp to 500 (cap). Nothing to assert on counts
+    # since the fixture has 2 items, but the call should not error.
+    resp = service.invoke("list_items", {"limit": 99999})
+    assert resp["total"] <= 500
+
+
+def test_list_items_invalid_limit_falls_back_to_default(
+    service: LocalMacroDataService,
+) -> None:
+    resp = service.invoke("list_items", {"limit": "abc"})
+    # Doesn't raise; falls back to the 50 default
+    assert resp["total"] >= 1
+
+
+def test_list_items_respects_document_type_filter(
+    service: LocalMacroDataService,
+) -> None:
+    resp = service.invoke(
+        "list_items", {"document_type": "report"},
+    )
+    assert resp["total"] == 2  # both notes are document_type='report'
+
+    resp = service.invoke(
+        "list_items", {"document_type": "minutes"},
+    )
+    assert resp["total"] == 0
+
+
+def test_list_items_respects_country_code_filter(
+    service: LocalMacroDataService,
+) -> None:
+    # Notes default to country_code='XX' unless frontmatter overrides.
+    resp = service.invoke("list_items", {"country_code": "XX"})
+    assert resp["total"] == 2
+    resp = service.invoke("list_items", {"country_code": "US"})
+    assert resp["total"] == 0
+
+
+def test_list_items_min_confidence_excludes_low_confidence(
+    service: LocalMacroDataService,
+) -> None:
+    # Note tags land at confidence 1.0, so min_confidence=1.0 still keeps
+    # them; 1.1 excludes everything.
+    resp = service.invoke(
+        "list_items", {"subject": "econ.cpi", "min_confidence": 1.0},
+    )
+    assert resp["total"] == 1
+    resp = service.invoke(
+        "list_items", {"subject": "econ.cpi", "min_confidence": 1.1},
+    )
+    assert resp["total"] == 0
+
+
+@pytest.mark.parametrize("bad_conf", ["abc", "", [], {"k": "v"}, object()])
+def test_list_items_malformed_min_confidence_uses_default(
+    service: LocalMacroDataService, bad_conf,
+) -> None:
+    """Regression for codex P2: malformed min_confidence must fall back
+    to 0.0 instead of raising ValueError into the HTTP handler as a 500."""
+    resp = service.invoke(
+        "list_items", {"subject": "econ.cpi", "min_confidence": bad_conf},
+    )
+    assert "error" not in resp
+    assert resp["total"] == 1
+
+
+def test_list_items_combined_applies_filters_in_sql(
+    tmp_path: Path,
+) -> None:
+    """Regression for codex P2: when both subject and q are given, the
+    limit must bound the FINAL result set — not two separate candidate
+    windows that could hide matches beyond their caps. Seed many econ.cpi
+    notes, then a single one whose body hits a rare term, and confirm the
+    combined query finds it even if recent subject-tagged notes exceed a
+    window-based cap."""
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    notes_dir = tmp_path / "in"
+    notes_dir.mkdir()
+    # Generate many CPI notes — more than any internal limit*4 window
+    # would ever hold by accident.
+    for i in range(60):
+        (notes_dir / f"cpi_{i:03d}.md").write_text(
+            "---\n"
+            f'title: "CPI note {i}"\n'
+            f"date: 2026-01-{(i % 28) + 1:02d}\n"
+            "subject_id: econ.cpi\n"
+            "---\n\n"
+            "Routine monthly CPI commentary without the target term.\n",
+            encoding="utf-8",
+        )
+    # One note carries the rare term in the body.
+    (notes_dir / "needle.md").write_text(
+        "---\n"
+        'title: "Special CPI reading"\n'
+        "date: 2025-06-15\n"  # older so it's deep in the subject-order window
+        "subject_id: econ.cpi\n"
+        "---\n\n"
+        "This note mentions unobtainium explicitly.\n",
+        encoding="utf-8",
+    )
+    ingest_notes(notes_dir, store=store)
+    svc = LocalMacroDataService(store=store)
+
+    resp = svc.invoke(
+        "list_items",
+        {"subject": "econ.cpi", "q": "unobtainium", "limit": 5},
+    )
+    assert resp["total"] == 1
+    assert resp["items"][0]["title"] == "Special CPI reading"
+
+
+# ── get_document ────────────────────────────────────────────────────────
+
+
+def test_get_document_by_id_returns_body_and_subjects(
+    service: LocalMacroDataService,
+) -> None:
+    ids = [i["document_id"] for i in
+           service.invoke("list_items", {"subject": "econ.cpi"})["items"]]
+    assert ids
+    resp = service.invoke("get_document", {"document_id": ids[0]})
+    assert resp["document"]["title"] == "Sticky services inflation"
+    assert "March CPI" in resp["body"]
+    assert {"subject_id": "econ.cpi", "confidence": 1.0} in resp["subjects"]
+
+
+def test_get_document_by_hash_sha256(service: LocalMacroDataService) -> None:
+    items = service.invoke("list_items", {"subject": "vol.vix"})["items"]
+    sha = items[0]["hash_sha256"]
+    resp = service.invoke("get_document", {"hash_sha256": sha})
+    assert resp["document"]["title"] == "VIX regime thoughts"
+    assert "elevated" in resp["body"]
+
+
+def test_get_document_missing_id_returns_error(
+    service: LocalMacroDataService,
+) -> None:
+    resp = service.invoke("get_document", {})
+    assert "error" in resp
+
+
+def test_get_document_not_found_returns_null(
+    service: LocalMacroDataService,
+) -> None:
+    resp = service.invoke("get_document", {"document_id": "nonexistent_id"})
+    assert resp["document"] is None

--- a/tests/test_vix_regime.py
+++ b/tests/test_vix_regime.py
@@ -1,0 +1,219 @@
+"""Tests for the VIX regime classifier + obs_enrichment sidecar
+(issue #3 item 5)."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from ingestion.timeseries.regimes import (
+    VIX_LOW_THRESHOLD,
+    VIX_STRESSED_THRESHOLD,
+    classify_vix_regime,
+)
+from ingestion.types import RawObservation, RawSeries
+from storage.sqlite import IndicatorObservationRecord, SQLiteEngineStore
+
+
+# ── classify_vix_regime ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0.0, "low"),
+        (10.0, "low"),
+        (VIX_LOW_THRESHOLD - 0.001, "low"),
+        (VIX_LOW_THRESHOLD, "elevated"),
+        (20.0, "elevated"),
+        (VIX_STRESSED_THRESHOLD - 0.001, "elevated"),
+        (VIX_STRESSED_THRESHOLD, "stressed"),
+        (40.0, "stressed"),
+        (80.0, "stressed"),
+    ],
+)
+def test_vix_regime_thresholds(value: float, expected: str) -> None:
+    assert classify_vix_regime(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, float("nan"), float("inf"), -float("inf"), "not a number", "15"[:0]],
+)
+def test_vix_regime_invalid_inputs_return_none(value) -> None:
+    assert classify_vix_regime(value) is None
+
+
+def test_vix_regime_accepts_string_number() -> None:
+    # Some stores coerce float → str on read; classifier should still work.
+    assert classify_vix_regime("18.5") == "elevated"
+
+
+# ── obs_enrichment CRUD ─────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteEngineStore:
+    return SQLiteEngineStore(db_path=tmp_path / "engine.db")
+
+
+def test_obs_enrichment_schema_created(store: SQLiteEngineStore) -> None:
+    with store._connection(commit=False) as c:
+        row = c.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='obs_enrichment'"
+        ).fetchone()
+    assert row is not None
+
+
+def test_set_and_get_obs_enrichment_round_trip(store: SQLiteEngineStore) -> None:
+    store.set_obs_enrichment(
+        obs_family_id="us.markets.vix", date="2026-04-19",
+        key="regime", value="elevated",
+    )
+    got = store.get_obs_enrichment(
+        obs_family_id="us.markets.vix", date="2026-04-19", key="regime",
+    )
+    assert got == "elevated"
+    # Missing row returns None
+    assert store.get_obs_enrichment(
+        obs_family_id="us.markets.vix", date="2026-04-20", key="regime",
+    ) is None
+
+
+def test_set_obs_enrichment_is_upsert(store: SQLiteEngineStore) -> None:
+    store.set_obs_enrichment(
+        obs_family_id="us.markets.vix", date="2026-04-19",
+        key="regime", value="low",
+    )
+    store.set_obs_enrichment(
+        obs_family_id="us.markets.vix", date="2026-04-19",
+        key="regime", value="elevated",
+    )
+    assert store.get_obs_enrichment(
+        obs_family_id="us.markets.vix", date="2026-04-19", key="regime",
+    ) == "elevated"
+
+
+def test_list_obs_enrichment_orders_by_date_desc(store: SQLiteEngineStore) -> None:
+    for date, label in [
+        ("2026-04-17", "low"),
+        ("2026-04-18", "elevated"),
+        ("2026-04-19", "stressed"),
+    ]:
+        store.set_obs_enrichment(
+            obs_family_id="us.markets.vix", date=date,
+            key="regime", value=label,
+        )
+    rows = store.list_obs_enrichment_for_family("us.markets.vix")
+    assert [r[0] for r in rows] == ["2026-04-19", "2026-04-18", "2026-04-17"]
+    assert [r[2] for r in rows] == ["stressed", "elevated", "low"]
+
+
+def test_list_obs_enrichment_filter_by_key(store: SQLiteEngineStore) -> None:
+    store.set_obs_enrichment(obs_family_id="us.markets.vix",
+                             date="2026-04-19", key="regime", value="elevated")
+    store.set_obs_enrichment(obs_family_id="us.markets.vix",
+                             date="2026-04-19", key="percentile", value="62")
+    regime_only = store.list_obs_enrichment_for_family(
+        "us.markets.vix", key="regime",
+    )
+    assert [r[1] for r in regime_only] == ["regime"]
+
+
+# ── refresh_vix_regime (end-to-end) ─────────────────────────────────────
+
+
+def _seed_vix(store: SQLiteEngineStore, values: list[tuple[str, float]]) -> None:
+    for date, value in values:
+        store.upsert_indicator_observation(
+            IndicatorObservationRecord(
+                series_id="VIXCLS",
+                source="fred",
+                date=date,
+                value=value,
+                metadata={},
+            )
+        )
+
+
+def test_refresh_vix_regime_classifies_every_observation(
+    store: SQLiteEngineStore,
+) -> None:
+    _seed_vix(store, [
+        ("2026-04-15", 10.0),   # low
+        ("2026-04-16", 20.0),   # elevated
+        ("2026-04-17", 45.0),   # stressed
+    ])
+
+    count = store.refresh_vix_regime()
+    assert count == 3
+
+    rows = store.list_obs_enrichment_for_family("us.markets.vix", key="regime")
+    got = {d: v for d, _k, v in rows}
+    assert got == {
+        "2026-04-15": "low",
+        "2026-04-16": "elevated",
+        "2026-04-17": "stressed",
+    }
+
+
+def test_refresh_vix_regime_empty_store_writes_nothing(
+    store: SQLiteEngineStore,
+) -> None:
+    """Guard for the 'no data yet' branch: refresh against an empty
+    indicators table returns 0 and leaves obs_enrichment untouched."""
+    assert store.refresh_vix_regime() == 0
+    assert store.list_obs_enrichment_for_family("us.markets.vix") == []
+
+
+def test_refresh_vix_regime_is_idempotent_on_second_call(
+    store: SQLiteEngineStore,
+) -> None:
+    _seed_vix(store, [("2026-04-15", 12.0), ("2026-04-16", 30.0)])
+    assert store.refresh_vix_regime() == 2
+    # Second invocation overwrites the same (family, date, key) rows; the
+    # write count stays 2 but no duplicates accumulate.
+    assert store.refresh_vix_regime() == 2
+    rows = store.list_obs_enrichment_for_family("us.markets.vix", key="regime")
+    assert len(rows) == 2
+
+
+# ── concept / subject bridge ────────────────────────────────────────────
+
+
+def test_vix_us_bridges_to_vol_vix_subject(store: SQLiteEngineStore) -> None:
+    """Regression glue: VIX_US concept → VIXCLS series → vol.vix subject
+    through subject_aliases.fred_series, so /items?subject=vol.vix will
+    eventually surface VIX observations alongside documents."""
+    from storage.subjects import sync_from_yaml
+    store.seed_concept_map()
+    sync_from_yaml(store)
+    subs = store.resolve_subjects_for_concept("VIX_US")
+    assert "vol.vix" in subs
+
+
+def test_vixcls_registered_in_fred_family_map(store: SQLiteEngineStore) -> None:
+    store.seed_obs_sources_and_families()
+    fam = store.get_obs_family("us.markets.vix")
+    assert fam is not None
+    assert fam.source_id == "fred"
+    assert fam.provider_series_id == "VIXCLS"
+    assert fam.unit == "index"
+
+
+def test_vixcls_listed_in_fred_macro_series() -> None:
+    """Regression for codex P2: FredFetcher.fetch_series reads MACRO_SERIES
+    directly, so a series missing from that dict is silently skipped by
+    fred_daily / fred_full — leaving VIX_US empty and refresh_vix_regime
+    with nothing to classify. Asserting presence keeps the VIX ingestion
+    wiring complete end to end."""
+    from ingestion.timeseries._config import MACRO_SERIES
+    assert "VIXCLS" in MACRO_SERIES
+    assert MACRO_SERIES["VIXCLS"]["freq"] == "daily"


### PR DESCRIPTION
## Summary

- Fold the sibling `information/` repo into macro-data-service as a unified document surface alongside the existing macro timeseries, so downstream consumers get economic data, news, gov reports, notes, rate expectations, and VIX regime from one API
- Land information-layer issues #2 (unified subject tagging) and #3 (FTS news search, reference rates, rate expectations, VIX regime, research notes, discovery helper) without duplicating the macro-data-service's existing ingestion scaffolding
- Drop the information-layer RAG export path (markdown → Milvus) — storage first, retrieval later

11 commits over 9 planned steps; each step went through Codex review and every P2 was fixed with a regression test before the next step started.

## What changed

- **Subject vocabulary** (`src/storage/subjects.yaml`, `src/storage/subjects.py`): 24 seed subjects, 117 aliases, `SubjectTagger`, and a `concept_map ↔ subject_aliases` bridge keyed on `provider_series_id` so TE alignment is just new alias rows later
- **Document surface** (`src/storage/sqlite.py`): 11 LLM-extraction columns on `document`, FTS5 virtual table with injection-safe MATCH (double-quotes each token + LIKE fallback), `item_subjects` keyed by `document_id`, and idempotent backfill helpers for upgraded DBs
- **Ingestion**: news articles mirror into `document`/`documents_fts`/`item_subjects`; gov reports populate the 17-field surface with optional LLM extraction (opt-in via `DOCUMENT_EXTRACT_API_KEY`); notes parser writes `document_type='report'`, `event_type='Research Note'` with canonical `note:///<sha>` URL so duplicate bytes dedupe correctly
- **Timeseries additions**: `FEDWATCH_US` (daily midpoint, skips on missing `midpoint`), `VIX_US` (`VIXCLS` now in `MACRO_SERIES`) + `refresh_vix_regime` writing low/elevated/stressed into the new `obs_enrichment` sidecar
- **Shared helpers**: `src/ingestion/_shared/discovery.py` (httpx fetch + Brave search read via `get_env_value` + markdown URL extraction)
- **API ops**: `list_items`, `get_document`, `list_subjects`, `backfill_document_indexes` on `POST /v1/ops/*`

## Test plan

- [x] `PYTHONPATH=src pytest tests/ -q -m "not integration" --ignore` (network-heavy catalog suites) → **420 passed**
- [x] Every step verified against Codex review before commit; P2 findings tracked in-commit
- [ ] Run full integration suite on a fresh DB (SDMX providers need network)
- [ ] Wheel build sanity: `pip wheel . -w /tmp --no-deps` and confirm `storage/subjects.yaml` is packaged (already verified manually during Step 1)
- [ ] Smoke test a live ingest cycle with `DOCUMENT_EXTRACT_API_KEY` unset → confirm gov_report / news ingestion still writes to `document`, `documents_fts`, `item_subjects`
- [ ] Hit `POST /v1/ops/list_items` and `POST /v1/ops/list_subjects` against a local instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)