### PR TITLE
docs(readme): document market-data layer architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Macro Data Service
 
-Institutional-grade macro-data ingestion, resolution, and observability platform. Ingests 86 economic concepts from 11 core sources, supports a 25-source capability registry, and includes release-calendar-aware scheduling, availability verification, and cross-source fallback.
+Institutional-grade macro-data ingestion, resolution, and observability platform. Ingests 86 economic concepts from 11 core sources, supports a 25-source capability registry, and includes release-calendar-aware scheduling, availability verification, and cross-source fallback. A unified market-data layer covers Tiingo US equities/ETFs, EODHD global equities/ETFs/indices, and rates/FX/commodities projected from FRED, EIA, and ECB, with ISIN/FIGI identity and lazy history repair.
 
 ## Architecture
 
 ```text
-Sources (11)          Ingestion              Storage              Resolution
-─────────────        ──────────             ─────────            ───────────
-BLS, FRED, EIA       Fetchers + SDMX        SQLite               resolve_indicator()
-NYFed, Treasury      Normalization           concept_map (86)     source-priority ranking
-IMF, Eurostat        Date alignment          obs_family           cross-source alternates
-BIS, ECB, OECD       Deduplication           release_schedule
-World Bank                                   release_status
+Sources (11 macro + Tiingo + EODHD + OpenFIGI)    Ingestion              Storage              Resolution
+────────────────────────────────────────────     ──────────             ─────────            ───────────
+BLS, FRED, EIA                                   Fetchers + SDMX        SQLite               resolve_indicator()
+NYFed, Treasury                                  Normalization           concept_map (86)     source-priority ranking
+IMF, Eurostat                                    Date alignment          obs_family           cross-source alternates
+BIS, ECB, OECD                                   Deduplication           release_schedule     get_market_history()
+World Bank                                                               release_status       (equity / ETF / index /
+Tiingo        (US stocks + ETFs, OHLCV)          TiingoClient            market_instruments    rate / fx / commodity)
+EODHD         (global + identity + delisted)     EODHDClient             market_symbol_history
+OpenFIGI      (identity enrichment)              OpenFIGIClient          market_price_bars
+
                      ┌─────────────────────────────────────────┐
                      │  Release Schedule → Availability Check  │
                      │  → Retry (1m/5m/15m/1h/4h) → Fallback  │
@@ -28,6 +32,15 @@ World Bank                                   release_status
                      │  catalog-crawlable / discovery-rich     │
                      │  fixed-scope-complete                   │
                      │  discovery / latest-sync / status       │
+                     └─────────────────────────────────────────┘
+                     ┌─────────────────────────────────────────┐
+                     │ Market-Data Layer (issue #1)            │
+                     │  Tiingo US ETFs  → market_price_bars    │
+                     │  EODHD global    → market_price_bars    │
+                     │  FRED/EIA/ECB    → synthetic bars       │
+                     │  IdentityRepair  → break_detected       │
+                     │       ↳ EODHD ID + OpenFIGI + delisted  │
+                     │       ↳ stitch → refetch → stitched     │
                      └─────────────────────────────────────────┘
 ```
 
@@ -53,9 +66,22 @@ src/
     trends/           Reddit, Weibo social trend tracking
       scrapers/       reddit.py, weibo.py
       clients/        RedditTrendIngestionClient, WeiboTrendIngestionClient
-    market/           Real-time price feeds
-      clients/        MarketPriceClient
-      _config.py      MACRO_WATCHLIST
+    market/           Real-time prices, EOD bars, identity, lazy repair
+      scrapers/       Provider HTTP clients
+        _tiingo.py       TiingoClient — US stocks + ETFs OHLCV
+        _eodhd.py        EODHDClient — global EOD bars
+        _eodhd_identity.py  EODHD search / delisted / symbol-change / exchanges
+        _openfigi.py     OpenFIGIClient — /v3/mapping
+      clients/        High-level providers
+        _market.py       MarketPriceClient (yfinance, real-time watchlist)
+        _tiingo.py       TiingoMarketDataProvider (P0)
+        _eodhd.py        EODHDMarketDataProvider (P1 global)
+        _macro_market.py MacroMarketProvider (FRED/EIA/ECB projection)
+        _identity_repair.py IdentityRepairService (P2 lazy repair)
+      _tiingo_universe.py  11-ETF US macro universe + ISIN/FIGI seeds
+      _eodhd_universe.py   6-instrument global universe
+      _macro_map.py        13-entry rates/FX/commodity mapping
+      _config.py           MACRO_WATCHLIST (real-time watchlist)
     calendar/         Economic event calendars
       scrapers/       ForexFactory, Investing, TradingEconomics
     _shared/          Cross-cutting: http_transport, url_canon, selector versioning
@@ -98,6 +124,12 @@ macro-data-service serve                              # start HTTP server
 macro-data-service refresh                            # refresh all sources
 macro-data-service refresh-source --source fred       # refresh single source
 macro-data-service refresh-indicator CPI_US           # refresh single concept
+
+# Market-data layer sources (issue #1):
+macro-data-service refresh-source --source tiingo_market     # US ETFs (SPY, QQQ, ...)
+macro-data-service refresh-source --source eodhd_market      # global (N225, GDAXI, ...)
+macro-data-service refresh-source --source macro_market      # project FRED/EIA/ECB rows
+macro-data-service refresh-source --source identity_repair   # lazy repair break_detected
 ```
 
 ### Resolution
@@ -264,6 +296,73 @@ and the rest of the 17-field surface is controlled by
 `DOCUMENT_EXTRACT_MODEL` / `DOCUMENT_EXTRACT_BASE_URL`. Unset → ingestion
 falls back to scraper-supplied metadata without LLM calls.
 
+## Market-data layer
+
+Unified surface for equities, ETFs, indices, rates, FX, and commodities.
+All instruments share a stable `instrument_id`, carry ISIN/FIGI/CUSIP
+columns from day one, and expose a `history_status` that lazy repair can
+advance as ticker history is discovered.
+
+### Schema (`src/storage/sqlite.py`)
+
+- `market_instruments` — one row per instrument. Fields include
+  `instrument_id`, `primary_ticker`, `asset_class`, `market`,
+  `exchange_code`, `currency`, `isin`, `openfigi`, `composite_figi`,
+  `share_class_figi`, `cusip`, `lei`, `primary_provider`,
+  `provider_symbols_json`, `history_status`, `description_for_agent`.
+- `market_symbol_history` — ticker segments (listing_start,
+  ticker_rename, exchange_change, delisting, manual_link) with
+  mapping_confidence in `{provider_native, auto_isin, auto_figi,
+  name_match, manual}` and `valid_from`/`valid_to` boundaries.
+- `market_price_bars` — daily OHLCV + adjusted_* + dividend_cash,
+  split_factor, plus four boolean quality flags
+  (`has_break_detected`, `has_pre2018_delisted`,
+  `has_missing_corp_acts`, `has_mapping_review_needed`) and
+  `quality_flags_json` for detailed diagnostics. Unique key
+  `(instrument_id, date, bar_interval, source_name, source_symbol)`.
+
+### Providers
+
+| Source | Universe | Orchestrator source |
+|---|---|---|
+| Tiingo (`/tiingo/daily/<ticker>/prices`) | 11 US macro ETFs (SPY, QQQ, IWM, DIA, TLT, IEF, HYG, LQD, GLD, SLV, USO) | `tiingo_market` |
+| EODHD (`/api/eod/<ticker>`) | 6 global instruments (N225, GDAXI, HSI, VWRL.LSE, SAP.XETRA, 0700.HK) | `eodhd_market` |
+| FRED / EIA / ECB (projection) | 13 rates/FX/commodities (DFF, DGS2/10/30, DFII10, T10Y2Y, ECB deposit, DTWEXBGS, DEXCHUS, ECB EUR/USD daily, WTI, Brent, Henry Hub natgas) | `macro_market` |
+
+Each provider exposes the same minimal interface:
+
+- `seed_universe(store)` — idempotent upsert of instruments + initial segments
+- `refresh_market_history(store, symbol, start, end)` — fetch + normalize + quality flags
+- `get_market_history(store, symbol, start, end, adjusted)` — agent-native rows
+
+### Quality checks
+
+After every `refresh_market_history` the provider runs, in order: OHLC
+sanity, adjusted-close-vs-close adjustment check, corporate-action skip
+(split_factor ≠ 1 or dividend_cash > 0), and adjusted-close break
+detection at a 50% threshold. Detected breaks flip `history_status` to
+`break_detected`; status is only ever upgraded, never downgraded on
+partial-window refreshes.
+
+### Lazy repair (`identity_repair` source)
+
+When `history_status = break_detected`, `IdentityRepairService`:
+
+1. Reads local segments from `market_symbol_history`.
+2. Queries EODHD by ISIN (`/api/search`); falls back to primary ticker
+   for ISIN-less instruments (indices, macro).
+3. Queries OpenFIGI `/v3/mapping` by ISIN, falls back to ticker.
+4. Scans EODHD `/api/exchange-symbol-list?delisted=1` for fuzzy name
+   matches (provider-local codes like `NYSEARCA`/`NASDAQ`/`NYSE`/`AMEX`
+   are translated to EODHD's `US` first).
+5. Parses `/api/symbol-change-history` events filtered by both ticker
+   AND exchange so cross-venue bleed cannot occur.
+6. Persists new segments, triggers the caller-supplied refetch
+   callback, and only then promotes `history_status` from
+   `break_detected` → `stitched`. No callback → status stays
+   `break_detected` with a `segments_discovered_pending_refetch` note.
+   No candidates at all → `manual_review`.
+
 ## Data model
 
 ```text
@@ -271,16 +370,24 @@ falls back to scraper-supplied metadata without LLM calls.
 │  concept_map    │────▶│  indicators  │     │ release_schedule │
 │  86 concepts    │     │  observations│     │  86 rules        │
 │  11 sources     │     │  per source  │     │  8 rule types    │
-│  priority ranks │     └──────────────┘     └────────┬────────┘
-└─────────────────┘                                   │
-                                              ┌───────▼────────┐
-┌─────────────────┐                           │ release_status  │
-│  obs_family     │                           │  PENDING        │
-│  obs_source     │                           │  WAITING        │
-│  calendar_*     │                           │  FETCHED        │
-│  documents      │                           │  CONFIRMED      │
-│  market_prices  │                           │  STALE / FAILED │
-└─────────────────┘                           └────────────────┘
+│  priority ranks │     └──────┬───────┘     └────────┬────────┘
+└─────────────────┘            │                      │
+                               │ (macro projection)   │
+                               ▼                      ▼
+                   ┌───────────────────────┐ ┌───────────────────┐
+                   │  market_instruments   │ │ release_status    │
+                   │  market_symbol_history│ │  PENDING / WAITING│
+                   │  market_price_bars    │ │  FETCHED / CONFIRM│
+                   │  (equity / etf / idx /│ │  STALE / FAILED   │
+                   │   rate / fx / commod) │ └───────────────────┘
+                   └───────────────────────┘
+┌─────────────────┐
+│  obs_family     │
+│  obs_source     │
+│  calendar_*     │
+│  documents      │
+│  market_prices  │ (legacy real-time watchlist)
+└─────────────────┘
 
 ┌─────────────────────┐    ┌──────────────────────┐
 │ source_capability   │───▶│ catalog_entity       │
@@ -316,6 +423,25 @@ macro-data-service serve --host 127.0.0.1 --port 8765
 ```
 
 SQLite path: `.macro-data/engine.db`
+
+### Environment variables
+
+`src/env.py` reads from process env first, then `.env` at the repo root.
+
+| Variable | Used by | Required? |
+|---|---|---|
+| `FRED_API_KEY` | FRED series, FX, and macro-market rate/FX projection | yes for any FRED data |
+| `BLS_API_KEY` | BLS series | yes for BLS |
+| `BEA_API_KEY` | BEA series | yes for BEA |
+| `CENSUS_API_KEY` | Census series | yes for Census |
+| `EIA_API_KEY` | EIA + macro-market commodity projection | yes for EIA |
+| `IMF_API_KEY` | IMF SDMX | yes for IMF |
+| `TIINGO_API_KEY` | `tiingo_market` — US stocks/ETFs OHLCV | yes for P0 |
+| `EODHD_API_KEY` | `eodhd_market` + `identity_repair` (search, delisted, symbol-change, exchanges-list) | yes for P1 global + P2 repair |
+| `OPENFIGI_API_KEY` | `identity_repair` — higher rate limit on `/v3/mapping` | optional (anonymous tier works) |
+| `LLM_API_KEY` / `OPENROUTER_API_KEY` | News LLM extraction (`ingestion.news._extract`, loaded via `get_env_value` → process env **or** `.env`) | optional; unset → keyword-based metadata |
+| `DOCUMENT_EXTRACT_API_KEY` / `OPENAI_API_KEY` | Gov-report + notes 17-field LLM extraction (`make_extractor_from_env`, **reads `os.environ` only — not `.env`**) | optional; unset → scraper metadata only |
+| `DOCUMENT_EXTRACT_MODEL`, `DOCUMENT_EXTRACT_BASE_URL`, `DOCUMENT_EXTRACT_CONTEXT_CHARS` | Model / endpoint / chunk-size overrides for the gov-report extractor (same process-env-only loading) | optional |
 
 ## Agent wiring
 


### PR DESCRIPTION
## Summary

Folds the issue #1 market-data layer into the README so agents and
operators can see the full architecture at a glance:

- Architecture diagram extended with a dedicated Market-Data-Layer block
  covering the three providers (Tiingo US, EODHD global, FRED/EIA/ECB
  projection) plus the IdentityRepairService flow.
- Layout section now maps the new \`market/scrapers/\` + \`market/clients/\`
  files and the three seed configs (\`_tiingo_universe\`,
  \`_eodhd_universe\`, \`_macro_map\`).
- New \"Market-data layer\" section documents the 3-table schema, the
  provider interface (\`seed_universe\` / \`refresh_market_history\` /
  \`get_market_history\`), the quality-check order, and the lazy-repair
  preconditions — including the review-driven invariants that a
  refetch callback is required to promote to \`stitched\`, that
  \`NYSEARCA\`/\`NASDAQ\`/\`NYSE\`/\`AMEX\` map to EODHD's \`US\`, and that
  rename events are filtered by ticker AND exchange.
- Data-model diagram updated to show \`market_instruments\`,
  \`market_symbol_history\`, \`market_price_bars\` downstream of the macro
  indicators table.
- CLI section adds \`refresh-source --source tiingo_market | eodhd_market
  | macro_market | identity_repair\`.
- New Environment-variables table explaining that news LLM extraction
  uses \`LLM_API_KEY\` / \`OPENROUTER_API_KEY\` via \`get_env_value\` (process
  env or \`.env\`), while the gov-report / notes extractor reads
  \`DOCUMENT_EXTRACT_API_KEY\` / \`OPENAI_API_KEY\` from \`os.environ\` only
  (not \`.env\`) — the second key was originally mis-documented; codex
  review caught it.

## Test plan

- [x] Codex review pass on the README diff
- [ ] CI on the PR