### PR TITLE
feat(issue #5): source families + cross-type list_items

### DIFF
--- a/src/ingestion/sources.py
+++ b/src/ingestion/sources.py
@@ -121,6 +121,7 @@ class RefreshStats:
 class IngestionRunReport:
     source: str
     stored: int
+    family: str = ""
     fetched: int | None = None
     normalized: int | None = None
     validated: int | None = None
@@ -143,9 +144,46 @@ class IngestionRunReport:
         return payload
 
 
+SOURCE_FAMILIES: dict[str, str] = {
+    # economic_data
+    "fred_daily": "economic_data",
+    "fred_nondaily": "economic_data",
+    "fred_full": "economic_data",
+    "fred_vintages": "economic_data",
+    "bls": "economic_data",
+    "eia": "economic_data",
+    "treasury_fiscal": "economic_data",
+    "nyfed_rates": "economic_data",
+    "imf": "economic_data",
+    "imf_vintages": "economic_data",
+    "eurostat": "economic_data",
+    "bis": "economic_data",
+    "ecb": "economic_data",
+    "oecd": "economic_data",
+    "worldbank": "economic_data",
+    "worldbank_catalog": "economic_data",
+    # market_price
+    "market": "market_price",
+    "tiingo_market": "market_price",
+    "eodhd_market": "market_price",
+    "macro_market": "market_price",
+    "identity_repair": "market_price",
+    # release_report
+    "gov_reports": "release_report",
+    "fed": "release_report",
+    # news / calendar / trend / signal
+    "news": "news",
+    "calendar": "calendar",
+    "reddit_trends": "trend",
+    "weibo_trends": "trend",
+    "rate_probability": "signal",
+}
+
+
 @dataclass(frozen=True)
 class IngestionSourceDefinition:
     name: str
+    family: str = ""
     interval_seconds: int | None = None
     prepare: Callable[[], None] | None = None
     fetch: Callable[[], Iterable[Any]] | None = None
@@ -289,10 +327,17 @@ class IngestionOrchestrator:
         return event
 
     def register_source(self, definition: IngestionSourceDefinition) -> None:
+        if not definition.family:
+            family = SOURCE_FAMILIES.get(definition.name, "")
+            if family:
+                definition = dataclasses.replace(definition, family=family)
         self._sources[definition.name] = definition
 
-    def list_sources(self) -> list[str]:
-        return list(self._sources)
+    def list_sources(self) -> list[dict[str, str]]:
+        return [
+            {"name": name, "family": definition.family}
+            for name, definition in self._sources.items()
+        ]
 
     def last_run_report(self, source: str) -> IngestionRunReport | None:
         return self._last_run_reports.get(source)
@@ -399,6 +444,7 @@ class IngestionOrchestrator:
                     report = IngestionRunReport(
                         source=definition.name,
                         stored=stored,
+                        family=definition.family,
                         duration_ms=int((time.perf_counter() - started) * 1000),
                         retries=attempt,
                     )
@@ -417,6 +463,7 @@ class IngestionOrchestrator:
                 report = IngestionRunReport(
                     source=definition.name,
                     stored=int(stored if stored is not None else len(deduplicated_items)),
+                    family=definition.family,
                     fetched=len(raw_items),
                     normalized=len(normalized_items),
                     validated=len(validated_items),
@@ -437,6 +484,7 @@ class IngestionOrchestrator:
                 report = IngestionRunReport(
                     source=definition.name,
                     stored=0,
+                    family=definition.family,
                     duration_ms=int((time.perf_counter() - started) * 1000),
                     retries=attempt,
                     error=str(exc),

--- a/src/macro_data/cli.py
+++ b/src/macro_data/cli.py
@@ -53,6 +53,10 @@ def build_parser() -> argparse.ArgumentParser:
     refresh_source.add_argument("--source", required=True)
     refresh_source.add_argument("--db-path", default=None)
 
+    list_sources = subparsers.add_parser("list-sources")
+    list_sources.add_argument("--family", default=None)
+    list_sources.add_argument("--db-path", default=None)
+
     capabilities = subparsers.add_parser("sources-capabilities")
     capabilities.add_argument("--all", action="store_true", dest="include_internal")
     capabilities.add_argument("--db-path", default=None)
@@ -665,6 +669,12 @@ def main(argv: list[str] | None = None) -> int:
 
     service = build_local_macro_data_service(db_path=Path(args.db_path) if hasattr(args, "db_path") and args.db_path else None)
 
+    if args.command == "list-sources":
+        return _run_service_json(
+            service,
+            "list_sources",
+            {"family": args.family} if args.family else {},
+        )
     if args.command == "sources-capabilities":
         return _run_service_json(
             service,

--- a/src/macro_data/service.py
+++ b/src/macro_data/service.py
@@ -15,6 +15,41 @@ _NEWS_PRESETS: dict[str, tuple[str, ...]] = {
     "premium": ("bloomberg", "ft", "wsj", "reuters"),
     "free": ("investing", "forexfactory", "tradingeconomics"),
 }
+
+# Maps a DocumentRecord.source_id to its ingestion family tag. Exact-match
+# sources are listed here; `GovReportIngestionClient` writes documents with
+# derived source ids like ``us.bls`` / ``cn.stats`` (country.agency), so
+# ``_document_family`` also treats any dotted source id as a gov report
+# and tags it ``release_report``.
+_DOCUMENT_SOURCE_FAMILY: dict[str, str] = {
+    "news": "news",
+    "notes": "note",
+    "calendar": "calendar",
+}
+
+
+def _document_family(doc: Any) -> str:
+    source_id = getattr(doc, "source_id", "") or ""
+    fam = _DOCUMENT_SOURCE_FAMILY.get(source_id)
+    if fam:
+        return fam
+    # Gov report source ids are derived as "country.agency" — treat any
+    # dotted id as a gov release so the family filter actually matches.
+    if "." in source_id:
+        return "release_report"
+    return ""
+
+
+# Families whose rows live in the document table (as opposed to
+# indicators / market_price_bars). When the caller's family filter is one
+# of these, the indicator + market-bar branches are skipped; otherwise
+# only those branches run and documents are skipped. ``trend`` is stored
+# in ``trend_topics`` — list_items does not yet project it, so it is
+# omitted here on purpose (returning documents under a `trend` filter
+# would mislabel the rows).
+_DOCUMENT_FAMILIES: frozenset[str] = frozenset(
+    {"news", "note", "calendar", "release_report"}
+)
 _VALID_MARKET_ASSET_CLASSES = {"index", "commodity", "fx", "bond", "stock", "crypto"}
 _VALID_RATE_TYPES = {"sofr", "effr", "obfr", "all"}
 _ARTICLE_DOMAIN_MAP: dict[str, str] = {
@@ -45,6 +80,7 @@ class LocalMacroDataService:
         self._ingestion = ingestion
         self._retriever = retriever
         self._ontology_seeded = False
+        self._subject_vocabulary_seeded = False
 
     def invoke(self, operation: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
         handler = getattr(self, f"_op_{operation}", None)
@@ -59,6 +95,29 @@ class LocalMacroDataService:
         if callable(seed):
             seed()
         self._ontology_seeded = True
+
+    def _ensure_subject_vocabulary(self) -> None:
+        """Seed subject_aliases + concept_map once per process.
+
+        The cross-type ``list_items`` branches (indicators, market bars)
+        read ``subject_aliases`` and ``concept_map``. On a DB populated
+        only through time-series refresh paths neither table is filled,
+        so we load the yaml vocabulary + default concept map on demand
+        — both helpers are idempotent so repeat calls are cheap."""
+        if self._subject_vocabulary_seeded:
+            return
+        try:
+            from storage.subjects import sync_from_yaml
+            sync_from_yaml(self._store)
+        except (AttributeError, TypeError, FileNotFoundError):
+            pass
+        seed_cm = getattr(self._store, "seed_concept_map", None)
+        if callable(seed_cm):
+            try:
+                seed_cm()
+            except Exception:
+                logger.warning("seed_concept_map failed", exc_info=True)
+        self._subject_vocabulary_seeded = True
 
     def _op_refresh_all_sources(self, arguments: dict[str, Any]) -> dict[str, Any]:
         del arguments
@@ -82,21 +141,29 @@ class LocalMacroDataService:
     # ── Unified document queries (issue #2 / #3) ────────────────────────
 
     def _op_list_items(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """Merged feed across the unified document surface.
+        """Merged feed across the unified surface: documents + indicator
+        observations + market-price bars, all filterable by ``subject``.
 
         Arguments:
           subject         — subject_id to filter on (e.g. "econ.cpi")
-          q               — free-text query (FTS5 over title + body)
+          q               — free-text query (FTS5 over title + body;
+                            applies to documents only)
+          family          — optional family filter (e.g. "economic_data",
+                            "market_price", "news"). When unset, rows
+                            from every family are returned.
           min_confidence  — default 0.0; filters item_subjects rows
           limit           — default 50, capped at 500
           document_type   — optional exact match (e.g. "report")
           country_code    — optional 2-letter ISO filter
 
-        Returns ``{"items": [...], "total": N}`` with summary rows
-        (no body) — use get_document to fetch a single markdown.
+        Each item carries a ``family`` and ``kind`` tag so callers can
+        dispatch without a second lookup. Documents keep the existing
+        summary shape; indicator / market-bar rows carry only the
+        columns relevant to their type.
         """
         subject = (arguments.get("subject") or "").strip() or None
         query = (arguments.get("q") or "").strip() or None
+        family_filter = (arguments.get("family") or "").strip() or None
         document_type = (arguments.get("document_type") or "").strip() or None
         country_code = (arguments.get("country_code") or "").strip() or None
         try:
@@ -104,28 +171,69 @@ class LocalMacroDataService:
         except (TypeError, ValueError):
             limit = 50
         limit = max(1, min(limit, 500))
-        # min_confidence matches the `limit` handling: malformed input
-        # falls back to the default so a string-typed argument never
-        # bubbles up as a 500 from the HTTP handler.
         raw_conf = arguments.get("min_confidence")
         try:
             min_conf = float(raw_conf) if raw_conf is not None else 0.0
         except (TypeError, ValueError):
             min_conf = 0.0
 
-        # Filters live in SQL via list_items_combined so the limit
-        # bounds the final result set — no pre-intersection cap that
-        # could hide matches beyond the candidate window.
-        candidates = self._store.list_items_combined(
-            subject_id=subject,
-            query=query,
-            limit=limit,
-            min_confidence=min_conf,
-            document_type=document_type,
-            country_code=country_code,
-        )
+        # Subject-driven branches need the yaml vocabulary + default
+        # concept_map loaded. Both helpers are idempotent.
+        if subject:
+            self._ensure_subject_vocabulary()
 
-        items = [self._document_summary(d) for d in candidates]
+        items: list[dict[str, Any]] = []
+
+        # Documents branch. Non-document filters (document_type /
+        # country_code) only make sense here — indicator + market-bar
+        # rows carry no such metadata, so including them when the
+        # caller asked for `document_type="report"` would violate the
+        # filter contract.
+        want_documents = family_filter is None or family_filter in _DOCUMENT_FAMILIES
+        if want_documents:
+            # The family predicate runs in SQL now (see
+            # SQLiteEngineStore._family_predicate) so the server-side
+            # limit bounds the matching document rows directly — no
+            # widen-then-post-filter sleight of hand.
+            candidates = self._store.list_items_combined(
+                subject_id=subject,
+                query=query,
+                limit=limit,
+                min_confidence=min_conf,
+                document_type=document_type,
+                country_code=country_code,
+                family=family_filter if family_filter in _DOCUMENT_FAMILIES else None,
+            )
+            for doc in candidates:
+                summary = self._document_summary(doc)
+                summary["family"] = _document_family(doc)
+                summary["kind"] = "document"
+                items.append(summary)
+
+        # Indicator + market-bar branches only run when the caller is
+        # asking by subject. Without a subject the join chain
+        # (subject_aliases → concept_map / market_instruments) can't
+        # produce meaningful rows, and widening the branches to "all
+        # indicators" would explode the result set.
+        if subject and not query and not document_type and not country_code:
+            if family_filter in (None, "economic_data"):
+                items.extend(
+                    self._store.list_subject_indicators(subject, limit=limit)
+                )
+            if family_filter in (None, "market_price"):
+                items.extend(
+                    self._store.list_subject_market_bars(subject, limit=limit)
+                )
+
+        # When a family filter is set, only one branch ran and its own
+        # SQL LIMIT has already capped the result to `limit`. Without a
+        # filter, every branch returns up to `limit` rows so the
+        # envelope can carry up to ``3 * limit`` — intentional, since
+        # the callers asked for cross-type visibility and dropping the
+        # later branches to fit a global `limit` would re-introduce the
+        # crowding bug Codex flagged.
+        if family_filter:
+            items = items[:limit]
         return {"total": len(items), "items": items}
 
     def _op_get_document(self, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/src/macro_data/service.py
+++ b/src/macro_data/service.py
@@ -238,6 +238,19 @@ class LocalMacroDataService:
                 "available_sources": self._ingestion.list_sources(),
             }
 
+    def _op_list_sources(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Return registered ingestion sources as ``[{name, family}, ...]``.
+
+        Optional ``family`` filter narrows to a single family tag.
+        """
+        if self._ingestion is None:
+            return {"error": "sources unavailable", "sources": []}
+        family = (arguments.get("family") or "").strip() or None
+        sources = self._ingestion.list_sources()
+        if family:
+            sources = [s for s in sources if s.get("family") == family]
+        return {"total": len(sources), "sources": sources}
+
     def _op_list_source_capabilities(self, arguments: dict[str, Any]) -> dict[str, Any]:
         include_internal = bool(arguments.get("include_internal", False))
         if self._ingestion is None:

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -6756,6 +6756,26 @@ class SQLiteEngineStore:
                 written += 1
         return written
 
+    # Family-name → SQL predicate over ``document.source_id``. Keeps the
+    # family filter in SQL so the LIMIT bounds matching rows, not a
+    # candidate pool that may have already dropped them. ``release_report``
+    # matches any dotted source_id (``us.bls``, ``cn.stats`` …) written by
+    # GovReportIngestionClient.
+    _DOCUMENT_FAMILY_SQL: dict[str, tuple[str, tuple[Any, ...]]] = {
+        "news":           ("document.source_id = ?",                ("news",)),
+        "note":           ("document.source_id = ?",                ("notes",)),
+        "calendar":       ("document.source_id = ?",                ("calendar",)),
+        "release_report": ("instr(document.source_id, '.') > 0",    ()),
+    }
+
+    @classmethod
+    def _family_predicate(cls, family: str | None) -> tuple[str, tuple[Any, ...]]:
+        """Return ``(sql_fragment, params)`` for a doc family filter, or
+        an empty clause if ``family`` isn't a known document family."""
+        if not family:
+            return "", ()
+        return cls._DOCUMENT_FAMILY_SQL.get(family, ("", ()))
+
     def list_items_for_subject(
         self,
         subject_id: str,
@@ -6764,11 +6784,12 @@ class SQLiteEngineStore:
         min_confidence: float = 0.0,
         document_type: str | None = None,
         country_code: str | None = None,
+        family: str | None = None,
     ) -> list[DocumentRecord]:
         """Return documents tagged with ``subject_id`` (confidence >= the
         filter), most-recent first. Joins item_subjects + document and
-        applies document_type / country_code predicates in SQL so the
-        caller doesn't have to post-filter a capped window."""
+        applies document_type / country_code / family predicates in SQL
+        so the caller doesn't have to post-filter a capped window."""
         sql = [
             "SELECT document.*",
             "FROM item_subjects",
@@ -6784,6 +6805,10 @@ class SQLiteEngineStore:
         if country_code:
             sql.append("  AND document.country_code = ?")
             params.append(country_code)
+        family_sql, family_params = self._family_predicate(family)
+        if family_sql:
+            sql.append(f"  AND {family_sql}")
+            params.extend(family_params)
         sql.append("ORDER BY document.published_epoch_ms DESC,")
         sql.append("         document.published_date DESC")
         sql.append("LIMIT ?")
@@ -6801,6 +6826,7 @@ class SQLiteEngineStore:
         min_confidence: float = 0.0,
         document_type: str | None = None,
         country_code: str | None = None,
+        family: str | None = None,
     ) -> list[DocumentRecord]:
         """Return documents matching both a subject tag AND an FTS query.
 
@@ -6819,27 +6845,60 @@ class SQLiteEngineStore:
             return self.list_items_for_subject(
                 subject_id, limit=limit, min_confidence=min_confidence,
                 document_type=document_type, country_code=country_code,
+                family=family,
             )
         if query and not subject_id:
             return self._search_documents_filtered(
                 query, limit=limit,
                 document_type=document_type, country_code=country_code,
+                family=family,
             )
         if not subject_id and not query:
-            return self.list_documents(
-                document_type=document_type, country_code=country_code,
-                limit=limit,
-            )
+            family_sql, family_params = self._family_predicate(family)
+            if not family_sql:
+                return self.list_documents(
+                    document_type=document_type, country_code=country_code,
+                    limit=limit,
+                )
+            # Recency feed with a family filter — the LIMIT must bound
+            # rows *after* the family predicate applies, so run a direct
+            # SQL query rather than calling list_documents and trimming.
+            type_clause = " AND document.document_type = ?" if document_type else ""
+            country_clause = " AND document.country_code = ?" if country_code else ""
+            # Order matches the WHERE clause: family_sql first, then the
+            # type_clause and country_clause appended after it.
+            direct_params: list[Any] = list(family_params)
+            if document_type:
+                direct_params.append(document_type)
+            if country_code:
+                direct_params.append(country_code)
+            with self._connection(commit=False) as connection:
+                rows = connection.execute(
+                    f"""
+                    SELECT document.*
+                    FROM document
+                    WHERE {family_sql}
+                      {type_clause}{country_clause}
+                    ORDER BY document.published_epoch_ms DESC,
+                             document.published_date DESC
+                    LIMIT ?
+                    """,
+                    [*direct_params, limit],
+                ).fetchall()
+            return [self._row_to_document(r) for r in rows]
 
         # Both set — combine in one query so the limit isn't eaten by a
         # pre-intersection cap.
         type_clause = " AND document.document_type = ?" if document_type else ""
         country_clause = " AND document.country_code = ?" if country_code else ""
+        family_sql, family_params = self._family_predicate(family)
+        family_clause = f" AND {family_sql}" if family_sql else ""
         extra_params: list[Any] = []
         if document_type:
             extra_params.append(document_type)
         if country_code:
             extra_params.append(country_code)
+        extra_params.extend(family_params)
 
         with self._connection(commit=False) as connection:
             if self._fts5_available(connection):
@@ -6857,7 +6916,7 @@ class SQLiteEngineStore:
                             WHERE documents_fts MATCH ?
                               AND item_subjects.subject_id = ?
                               AND item_subjects.confidence >= ?
-                              {type_clause}{country_clause}
+                              {type_clause}{country_clause}{family_clause}
                             ORDER BY rank
                             LIMIT ?
                             """,
@@ -6876,7 +6935,7 @@ class SQLiteEngineStore:
                 WHERE item_subjects.subject_id = ?
                   AND item_subjects.confidence >= ?
                   AND (document.title LIKE ? OR document.subtitle LIKE ?)
-                  {type_clause}{country_clause}
+                  {type_clause}{country_clause}{family_clause}
                 ORDER BY document.published_epoch_ms DESC,
                          document.published_date DESC
                 LIMIT ?
@@ -6885,6 +6944,225 @@ class SQLiteEngineStore:
             ).fetchall()
         return [self._row_to_document(r) for r in rows]
 
+    # Mapping from `subject_aliases.alias_type` to the `indicators.source`
+    # value that alias implies. Kept in-module because it's a storage-layer
+    # fact about how the live seeded subjects relate to the indicators
+    # table — duplicating it on ingestion would invert the dependency.
+    _ALIAS_TYPE_TO_INDICATOR_SOURCE: dict[str, str] = {
+        "fred_series": "fred",
+        "bls_series": "bls",
+        "eia_series": "eia",
+        "ny_fed_series": "nyfed",
+        "fedwatch_series": "rateprobability",
+        "imf_series": "imf",
+        "ecb_series": "ecb",
+        "bis_series": "bis",
+        "eurostat_series": "eurostat",
+        "oecd_series": "oecd",
+        "worldbank_series": "worldbank",
+        "treasury_series": "treasury_fiscal",
+    }
+
+    def list_subject_indicators(
+        self, subject_id: str, *, limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return indicator observations reached from ``subject_id``.
+
+        Two branches are unioned and tagged ``family = 'economic_data'``:
+
+        1. **concept_map bridge** — ``subject_aliases → concept_map →
+           indicators``, matching ``resolve_indicator``'s live chain.
+           Carries the ``concept_id`` so cross-source aliases surface.
+        2. **direct alias match** — ``subject_aliases → indicators`` keyed
+           by ``(alias_type, alias_value)``. Covers subjects whose alias
+           points straight at an ``indicators.(source, series_id)`` row
+           without a concept_map entry (``commodity.gold`` →
+           ``GOLDAMGBD228NLBM``, etc.).
+
+        Dedup is on ``(source, series_id, date)`` — the concept_map row
+        wins when both branches resolve to the same observation, so the
+        richer ``concept_id`` annotation is preserved."""
+        # Per-query fetch is intentionally wider than `limit`: the final
+        # slice applies a per-series cap (see below), and a tight
+        # per-query LIMIT would drop older series before the fair-share
+        # logic runs. The ceiling keeps worst-case memory bounded.
+        internal_cap = max(limit * 10, 500)
+        with self._connection(commit=False) as connection:
+            # Pivot through concept_id so every (source, provider_series_id)
+            # row in concept_map that shares a concept with a subject alias
+            # contributes. Stopping at the one matched row would hide the
+            # cross-source alternates the concept_map is meant to express
+            # (``econ.unemployment`` via FRED ``UNRATE`` still needs to
+            # surface the BLS ``LNS14000000`` observations under ``UNEMP_US``).
+            #
+            # The `cm_in.source_id` CASE mirrors the direct-alias branch:
+            # if a provider series id is reused across sources (same id
+            # under ``fred`` and ``imf``), a ``fred_series`` alias must not
+            # attach to the ``imf`` concept row and fan out through
+            # unrelated observations.
+            case_branches_concept = " ".join(
+                f"WHEN sa.alias_type = '{at}' THEN '{src}'"
+                for at, src in self._ALIAS_TYPE_TO_INDICATOR_SOURCE.items()
+            )
+            concept_rows = connection.execute(
+                f"""
+                SELECT DISTINCT
+                  i.source AS source, i.series_id AS series_id,
+                  i.date AS date, i.value AS value,
+                  cm_out.concept_id AS concept_id
+                FROM subject_aliases sa
+                JOIN concept_map cm_in
+                  ON cm_in.provider_series_id = sa.alias_value
+                 AND cm_in.source_id = (CASE {case_branches_concept} END)
+                JOIN concept_map cm_out
+                  ON cm_out.concept_id = cm_in.concept_id
+                JOIN indicators i
+                  ON i.source = cm_out.source_id
+                 AND i.series_id = cm_out.provider_series_id
+                WHERE sa.subject_id = ?
+                ORDER BY i.date DESC
+                LIMIT ?
+                """,
+                (subject_id, internal_cap),
+            ).fetchall()
+            alias_rows: list[Any] = []
+            if self._ALIAS_TYPE_TO_INDICATOR_SOURCE:
+                placeholders = ",".join(
+                    "?" * len(self._ALIAS_TYPE_TO_INDICATOR_SOURCE)
+                )
+                # Build a CASE so the JOIN predicate compares the alias to
+                # the correct `indicators.source` per alias_type.
+                case_branches = " ".join(
+                    f"WHEN sa.alias_type = '{at}' THEN '{src}'"
+                    for at, src in self._ALIAS_TYPE_TO_INDICATOR_SOURCE.items()
+                )
+                alias_rows = connection.execute(
+                    f"""
+                    SELECT DISTINCT
+                      i.source AS source, i.series_id AS series_id,
+                      i.date AS date, i.value AS value
+                    FROM subject_aliases sa
+                    JOIN indicators i
+                      ON i.series_id = sa.alias_value
+                     AND i.source = (CASE {case_branches} END)
+                    WHERE sa.subject_id = ?
+                      AND sa.alias_type IN ({placeholders})
+                    ORDER BY i.date DESC
+                    LIMIT ?
+                    """,
+                    (
+                        subject_id,
+                        *self._ALIAS_TYPE_TO_INDICATOR_SOURCE.keys(),
+                        internal_cap,
+                    ),
+                ).fetchall()
+
+        # Merge both queries keyed on (source, series_id, date) so the
+        # concept row wins on dedup (its concept_id annotation is
+        # richer) while direct-only series still contribute.
+        merged: dict[tuple[str, str, str], dict[str, Any]] = {}
+        for r in concept_rows:
+            key = (r["source"], r["series_id"], r["date"])
+            merged[key] = {
+                "family": "economic_data",
+                "kind": "indicator",
+                "source": r["source"],
+                "series_id": r["series_id"],
+                "concept_id": r["concept_id"],
+                "date": r["date"],
+                "value": r["value"],
+            }
+        for r in alias_rows:
+            key = (r["source"], r["series_id"], r["date"])
+            if key in merged:
+                continue
+            merged[key] = {
+                "family": "economic_data",
+                "kind": "indicator",
+                "source": r["source"],
+                "series_id": r["series_id"],
+                "concept_id": "",
+                "date": r["date"],
+                "value": r["value"],
+            }
+
+        # Group by (source, series_id) so each series gets a fair
+        # share of the final limit — a subject whose concept path has
+        # 100 recent DFF observations must not bury the direct-only
+        # FEDFUNDS series. Per-series cap = ceil(limit / N) with a
+        # floor of 1 so even many series each surface at least once.
+        by_series: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for row in merged.values():
+            by_series.setdefault((row["source"], row["series_id"]), []).append(row)
+        if not by_series:
+            return []
+        per_series_cap = max(1, -(-limit // len(by_series)))  # ceil div
+        kept: list[dict[str, Any]] = []
+        for rows in by_series.values():
+            rows.sort(key=lambda r: r["date"], reverse=True)
+            kept.extend(rows[:per_series_cap])
+        kept.sort(
+            key=lambda r: (r["date"], r["source"], r["series_id"]),
+            reverse=True,
+        )
+        return kept[:limit]
+
+    def list_subject_market_bars(
+        self, subject_id: str, *, limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return market-price bars reached from ``subject_id``.
+
+        A subject links to a market instrument when any of its aliases
+        match ``market_instruments.primary_ticker``, ``.instrument_id``,
+        or appears as a value in ``.provider_symbols_json`` — the last
+        branch covers synthetic macro instruments (e.g.
+        ``MACRO_RATES_US_10Y``) whose ``provider_symbols_json`` stores
+        the underlying indicator series id (``DGS10``). Rows are tagged
+        ``family = 'market_price'``."""
+        with self._connection(commit=False) as connection:
+            rows = connection.execute(
+                """
+                SELECT DISTINCT
+                  mi.instrument_id AS instrument_id,
+                  mi.primary_ticker AS primary_ticker,
+                  mi.asset_class AS asset_class,
+                  bars.date AS date,
+                  bars.bar_interval AS bar_interval,
+                  bars.open AS open, bars.high AS high,
+                  bars.low AS low, bars.close AS close,
+                  bars.volume AS volume
+                FROM subject_aliases sa
+                JOIN market_instruments mi
+                  ON mi.primary_ticker = sa.alias_value
+                  OR mi.instrument_id = sa.alias_value
+                  OR EXISTS (
+                    SELECT 1 FROM json_each(mi.provider_symbols_json) je
+                    WHERE je.value = sa.alias_value
+                  )
+                JOIN market_price_bars bars
+                  ON bars.instrument_id = mi.instrument_id
+                WHERE sa.subject_id = ?
+                ORDER BY bars.date DESC
+                LIMIT ?
+                """,
+                (subject_id, limit),
+            ).fetchall()
+        return [
+            {
+                "family": "market_price",
+                "kind": "market_bar",
+                "instrument_id": r["instrument_id"],
+                "ticker": r["primary_ticker"],
+                "asset_class": r["asset_class"],
+                "date": r["date"],
+                "bar_interval": r["bar_interval"],
+                "open": r["open"], "high": r["high"],
+                "low": r["low"], "close": r["close"],
+                "volume": r["volume"],
+            }
+            for r in rows
+        ]
+
     def _search_documents_filtered(
         self,
         query: str,
@@ -6892,21 +7170,26 @@ class SQLiteEngineStore:
         limit: int,
         document_type: str | None,
         country_code: str | None,
+        family: str | None = None,
     ) -> list[DocumentRecord]:
         """Like :meth:`search_documents` but with document_type / country
-        predicates applied in SQL so the limit counts post-filter rows."""
-        if not (document_type or country_code):
+        / family predicates applied in SQL so the limit counts post-filter
+        rows."""
+        if not (document_type or country_code or family):
             return self.search_documents(query, limit=limit)
         query = query.strip()
         if not query:
             return []
         type_clause = " AND document.document_type = ?" if document_type else ""
         country_clause = " AND document.country_code = ?" if country_code else ""
+        family_sql, family_params = self._family_predicate(family)
+        family_clause = f" AND {family_sql}" if family_sql else ""
         extra_params: list[Any] = []
         if document_type:
             extra_params.append(document_type)
         if country_code:
             extra_params.append(country_code)
+        extra_params.extend(family_params)
         with self._connection(commit=False) as connection:
             if self._fts5_available(connection):
                 sanitized = self._quote_fts_query(query)
@@ -6919,7 +7202,7 @@ class SQLiteEngineStore:
                             JOIN document
                               ON document.document_id = documents_fts.document_id
                             WHERE documents_fts MATCH ?
-                              {type_clause}{country_clause}
+                              {type_clause}{country_clause}{family_clause}
                             ORDER BY rank
                             LIMIT ?
                             """,
@@ -6928,12 +7211,17 @@ class SQLiteEngineStore:
                         return [self._row_to_document(r) for r in rows]
                     except sqlite3.OperationalError:
                         pass
+            # LIKE fallback uses unqualified column names (no `document.`
+            # alias) because the FROM clause is `document` directly — so
+            # the family predicate fragment (which says `document.source_id`)
+            # needs stripping of the table prefix.
             like = f"%{query}%"
+            like_family_clause = family_clause.replace("document.", "")
             rows = connection.execute(
                 f"""
                 SELECT * FROM document
                 WHERE (title LIKE ? OR subtitle LIKE ?)
-                  {type_clause}{country_clause}
+                  {type_clause}{country_clause}{like_family_clause}
                 ORDER BY published_epoch_ms DESC, published_date DESC
                 LIMIT ?
                 """,

--- a/tests/test_eodhd_market_data.py
+++ b/tests/test_eodhd_market_data.py
@@ -244,7 +244,8 @@ def test_orchestrator_registers_eodhd_market_source(store: SQLiteEngineStore) ->
     from ingestion.sources import IngestionOrchestrator
 
     orch = IngestionOrchestrator(store=store)
-    assert "eodhd_market" in orch.list_sources()
+    names = [s["name"] for s in orch.list_sources()]
+    assert "eodhd_market" in names
 
 
 # ── Review-driven invariants ──────────────────────────────────────────────

--- a/tests/test_identity_repair.py
+++ b/tests/test_identity_repair.py
@@ -490,7 +490,8 @@ def test_orchestrator_registers_identity_repair_source(store: SQLiteEngineStore)
     from ingestion.sources import IngestionOrchestrator
 
     orch = IngestionOrchestrator(store=store)
-    assert "identity_repair" in orch.list_sources()
+    names = [s["name"] for s in orch.list_sources()]
+    assert "identity_repair" in names
 
 
 def test_source_registration_runs_after_market_providers(store: SQLiteEngineStore) -> None:
@@ -499,7 +500,7 @@ def test_source_registration_runs_after_market_providers(store: SQLiteEngineStor
     from ingestion.sources import IngestionOrchestrator
 
     orch = IngestionOrchestrator(store=store)
-    order = orch.list_sources()
+    order = [s["name"] for s in orch.list_sources()]
     assert order.index("tiingo_market") < order.index("identity_repair")
     assert order.index("eodhd_market") < order.index("identity_repair")
 

--- a/tests/test_ingestion_orchestrator.py
+++ b/tests/test_ingestion_orchestrator.py
@@ -9,6 +9,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from ingestion import IngestionOrchestrator, IngestionSourceDefinition
+from ingestion.sources import SOURCE_FAMILIES
 
 
 class IngestionOrchestratorTest(unittest.TestCase):
@@ -182,6 +183,77 @@ class IngestionOrchestratorTest(unittest.TestCase):
         self.assertEqual(report.validated, 2)
         self.assertEqual(report.deduplicated, 1)
         self.assertEqual(report.stored, 1)
+
+
+class SourceFamilyTaggingTest(unittest.TestCase):
+    """Issue #5 Slice 1 — every default source carries a family tag, and the
+    tag flows through list_sources() and IngestionRunReport.to_dict()."""
+
+    def _build_orchestrator(self) -> IngestionOrchestrator:
+        return IngestionOrchestrator(
+            store=Mock(),
+            fred=Mock(), investing=Mock(), forexfactory=Mock(),
+            tradingeconomics=Mock(), fed=Mock(), market=Mock(),
+            news=Mock(), reddit_trends=Mock(), weibo_trends=Mock(),
+            rate_probability=Mock(), nyfed=Mock(), gov_report=Mock(),
+            eia=Mock(), treasury_fiscal=Mock(), imf=Mock(),
+            eurostat=Mock(), bis=Mock(), ecb=Mock(), oecd=Mock(),
+            worldbank=Mock(),
+        )
+
+    def test_every_registered_default_source_has_non_empty_family(self) -> None:
+        orch = self._build_orchestrator()
+        offenders = [s for s in orch.list_sources() if not s["family"]]
+        self.assertEqual(offenders, [], f"sources without family: {offenders}")
+
+    def test_list_sources_returns_name_family_dicts(self) -> None:
+        orch = self._build_orchestrator()
+        rows = orch.list_sources()
+        self.assertTrue(all(set(r.keys()) == {"name", "family"} for r in rows))
+        by_name = {r["name"]: r["family"] for r in rows}
+        # Spot-check one entry per family bucket.
+        self.assertEqual(by_name["fred_daily"], "economic_data")
+        self.assertEqual(by_name["tiingo_market"], "market_price")
+        self.assertEqual(by_name["gov_reports"], "release_report")
+        self.assertEqual(by_name["fed"], "release_report")
+        self.assertEqual(by_name["news"], "news")
+        self.assertEqual(by_name["calendar"], "calendar")
+        self.assertEqual(by_name["reddit_trends"], "trend")
+        self.assertEqual(by_name["rate_probability"], "signal")
+
+    def test_registered_definition_picks_up_family_from_registry(self) -> None:
+        orch = self._build_orchestrator()
+        orch.register_source(
+            IngestionSourceDefinition(name="fred_daily", fetch=lambda: [], store=lambda _: 0)
+        )
+        self.assertEqual(orch._sources["fred_daily"].family, "economic_data")
+
+    def test_custom_source_without_family_stays_empty(self) -> None:
+        orch = self._build_orchestrator()
+        orch.register_source(
+            IngestionSourceDefinition(name="adhoc", fetch=lambda: [], store=lambda _: 0)
+        )
+        self.assertEqual(orch._sources["adhoc"].family, "")
+
+    def test_run_report_to_dict_includes_family(self) -> None:
+        orch = self._build_orchestrator()
+        orch.register_source(
+            IngestionSourceDefinition(
+                name="fred_daily",
+                execute=lambda: 7,
+            )
+        )
+        report = orch.run_source("fred_daily")
+        payload = report.to_dict()
+        self.assertEqual(payload["family"], "economic_data")
+        self.assertEqual(payload["source"], "fred_daily")
+        self.assertEqual(payload["stored"], 7)
+
+    def test_source_families_registry_covers_all_defaults(self) -> None:
+        orch = self._build_orchestrator()
+        registered = {s["name"] for s in orch.list_sources()}
+        missing = registered - set(SOURCE_FAMILIES)
+        self.assertEqual(missing, set(), f"registry missing entries: {missing}")
 
 
 if __name__ == "__main__":

--- a/tests/test_macro_market_mapping.py
+++ b/tests/test_macro_market_mapping.py
@@ -230,7 +230,8 @@ def test_orchestrator_registers_macro_market_source(store: SQLiteEngineStore) ->
     from ingestion.sources import IngestionOrchestrator
 
     orch = IngestionOrchestrator(store=store)
-    assert "macro_market" in orch.list_sources()
+    names = [s["name"] for s in orch.list_sources()]
+    assert "macro_market" in names
 
 
 # ── Review-driven invariants ──────────────────────────────────────────────
@@ -245,7 +246,7 @@ def test_source_registration_order_runs_after_upstream_sources(
     from ingestion.sources import IngestionOrchestrator
 
     orch = IngestionOrchestrator(store=store)
-    order = orch.list_sources()
+    order = [s["name"] for s in orch.list_sources()]
     assert order.index("fred_daily") < order.index("macro_market")
     assert order.index("eia") < order.index("macro_market")
     assert order.index("ecb") < order.index("macro_market")

--- a/tests/test_tiingo_market_data.py
+++ b/tests/test_tiingo_market_data.py
@@ -398,4 +398,5 @@ def test_orchestrator_registers_tiingo_market_source(store: SQLiteEngineStore) -
     from ingestion.sources import IngestionOrchestrator
 
     orch = IngestionOrchestrator(store=store)
-    assert "tiingo_market" in orch.list_sources()
+    names = [s["name"] for s in orch.list_sources()]
+    assert "tiingo_market" in names

--- a/tests/test_unified_api_ops.py
+++ b/tests/test_unified_api_ops.py
@@ -13,7 +13,36 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from ingestion.notes.ingest import ingest_notes
 from macro_data.service import LocalMacroDataService
-from storage.sqlite import DocumentRecord, SQLiteEngineStore
+from storage.sqlite import (
+    ConceptMapRecord,
+    DocSourceRecord,
+    DocumentRecord,
+    IndicatorObservationRecord,
+    MarketInstrumentRecord,
+    MarketPriceBarRecord,
+    SQLiteEngineStore,
+)
+from storage.subjects import sync_from_yaml
+
+
+def _make_doc_source(store: SQLiteEngineStore, source_id: str) -> None:
+    """Test helper — seed the minimum doc_source row needed for the
+    foreign key on ``document.source_id``."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+    store.upsert_doc_source(
+        DocSourceRecord(
+            source_id=source_id,
+            source_code=source_id.upper().replace(".", "_"),
+            source_name=source_id,
+            source_type=(
+                "government_agency" if "." in source_id else "news_agency"
+            ),
+            country_code="US", default_language_code="en",
+            homepage_url="https://example.com",
+            is_active=True, created_at=now, updated_at=now,
+        )
+    )
 
 
 _NOTE_CPI = """---
@@ -304,3 +333,501 @@ def test_list_sources_without_ingestion_returns_error(tmp_path: Path) -> None:
     svc = LocalMacroDataService(store=store, ingestion=None)
     resp = svc.invoke("list_sources", {})
     assert resp == {"error": "sources unavailable", "sources": []}
+
+
+# ── list_items cross-type (issue #5 Slice 2) ────────────────────────────
+
+
+@pytest.fixture()
+def cross_type_service(tmp_path: Path) -> LocalMacroDataService:
+    """Seed subjects.yaml + concept_map + an indicator row + a macro
+    market instrument whose provider_symbols_json points at the same
+    fred series that subject econ.cpi already aliases, so the
+    subject_aliases → concept_map → indicators chain and the
+    subject_aliases → market_instruments (via provider_symbols_json)
+    chain both have live rows to find."""
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    store.seed_concept_map()
+
+    # Also ingest one CPI-tagged note so the documents branch has
+    # something to return alongside the indicator + bar rows.
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "cpi.md").write_text(_NOTE_CPI, encoding="utf-8")
+    ingest_notes(notes_dir, store=store)
+
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="CPIAUCSL", source="fred",
+            date="2026-03-31", value=310.12,
+        )
+    )
+    store.upsert_market_instrument(
+        MarketInstrumentRecord(
+            instrument_id="MACRO_US_CPI",
+            primary_ticker="USCPI",
+            name="US CPI (synthetic macro instrument)",
+            asset_class="rate", market="macro",
+            provider_symbols_json={"fred": "CPIAUCSL"},
+        )
+    )
+    store.upsert_market_price_bar(
+        MarketPriceBarRecord(
+            instrument_id="MACRO_US_CPI",
+            date="2026-03-31", bar_interval="1d",
+            open=310.0, high=310.5, low=309.8, close=310.12, volume=0.0,
+            source_name="macro_market", source_symbol="USCPI",
+        )
+    )
+    return LocalMacroDataService(store=store)
+
+
+def test_list_items_returns_indicator_rows_tagged_economic_data(
+    cross_type_service: LocalMacroDataService,
+) -> None:
+    resp = cross_type_service.invoke("list_items", {"subject": "econ.cpi"})
+    indicators = [
+        i for i in resp["items"]
+        if i.get("kind") == "indicator"
+    ]
+    assert indicators, "expected at least one indicator row for econ.cpi"
+    row = indicators[0]
+    assert row["family"] == "economic_data"
+    assert row["source"] == "fred"
+    assert row["series_id"] == "CPIAUCSL"
+    assert row["concept_id"] == "CPI_US"
+    assert row["value"] == 310.12
+
+
+def test_list_items_returns_market_bars_tagged_market_price(
+    cross_type_service: LocalMacroDataService,
+) -> None:
+    resp = cross_type_service.invoke("list_items", {"subject": "econ.cpi"})
+    bars = [i for i in resp["items"] if i.get("kind") == "market_bar"]
+    assert bars, "expected a market bar row reached via provider_symbols_json"
+    bar = bars[0]
+    assert bar["family"] == "market_price"
+    assert bar["instrument_id"] == "MACRO_US_CPI"
+    assert bar["ticker"] == "USCPI"
+    assert bar["close"] == 310.12
+
+
+def test_list_items_family_filter_narrows_to_economic_data(
+    cross_type_service: LocalMacroDataService,
+) -> None:
+    resp = cross_type_service.invoke(
+        "list_items", {"subject": "econ.cpi", "family": "economic_data"},
+    )
+    assert resp["items"], "family filter should not empty the result"
+    for item in resp["items"]:
+        assert item["family"] == "economic_data"
+        assert item["kind"] == "indicator"
+
+
+def test_list_items_family_filter_narrows_to_market_price(
+    cross_type_service: LocalMacroDataService,
+) -> None:
+    resp = cross_type_service.invoke(
+        "list_items", {"subject": "econ.cpi", "family": "market_price"},
+    )
+    assert resp["items"], "family filter should not empty the result"
+    for item in resp["items"]:
+        assert item["family"] == "market_price"
+        assert item["kind"] == "market_bar"
+
+
+def test_list_items_document_rows_carry_family_tag(
+    cross_type_service: LocalMacroDataService,
+) -> None:
+    resp = cross_type_service.invoke("list_items", {"subject": "econ.cpi"})
+    docs = [i for i in resp["items"] if i.get("kind") == "document"]
+    assert docs, "cpi note should appear in the envelope"
+    # The ingested note carries source_id='notes' — surfaced as family='note'.
+    assert docs[0]["family"] == "note"
+
+
+def test_list_items_with_query_suppresses_indicator_and_bar_branches(
+    cross_type_service: LocalMacroDataService,
+) -> None:
+    """When the caller provides a free-text query, only the documents
+    branch runs — indicators / market bars carry no FTS-addressable
+    text, so surfacing them would silently ignore the query."""
+    resp = cross_type_service.invoke(
+        "list_items", {"subject": "econ.cpi", "q": "inflation"},
+    )
+    kinds = {i.get("kind") for i in resp["items"]}
+    assert "indicator" not in kinds
+    assert "market_bar" not in kinds
+
+
+def test_list_items_lazy_seeds_subject_vocabulary(tmp_path: Path) -> None:
+    """A DB populated only through the time-series path carries no
+    subject_aliases / concept_map rows. list_items must seed them on
+    demand rather than silently returning empty."""
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="CPIAUCSL", source="fred",
+            date="2026-03-31", value=310.12,
+        )
+    )
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke(
+        "list_items", {"subject": "econ.cpi", "family": "economic_data"},
+    )
+    indicators = [i for i in resp["items"] if i.get("kind") == "indicator"]
+    assert indicators, "lazy seeding should surface the indicator row"
+    assert indicators[0]["series_id"] == "CPIAUCSL"
+
+
+def test_list_items_dotted_source_id_tagged_release_report(tmp_path: Path) -> None:
+    """GovReport docs are stored with source ids like ``us.bls`` —
+    ``_document_family`` treats any dotted id as a release_report so the
+    family filter catches them."""
+    from datetime import datetime, timezone
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    _make_doc_source(store, "us.bls")
+    now = datetime.now(timezone.utc).isoformat()
+    doc = DocumentRecord(
+        document_id="doc-bls-1",
+        release_family_id="",
+        source_id="us.bls",
+        canonical_url="https://www.bls.gov/releases/cpi-20260315",
+        title="CPI March 2026",
+        subtitle="", document_type="release", mime_type="text/html",
+        language_code="en", country_code="US", topic_code="inflation",
+        published_date="2026-03-15", published_at="2026-03-15T12:30:00Z",
+        published_epoch_ms=1_742_042_200_000,
+        published_precision="day", status="published",
+        version_no=1, parent_document_id="",
+        hash_sha256="sha-bls-cpi-0315", created_at=now, updated_at=now,
+    )
+    store.upsert_document(doc)
+    store.set_document_subjects(doc.document_id, {"econ.cpi": 1.0})
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke(
+        "list_items", {"subject": "econ.cpi", "family": "release_report"},
+    )
+    assert resp["items"], "dotted source_id should match release_report filter"
+    assert all(i["family"] == "release_report" for i in resp["items"])
+    assert resp["items"][0]["source_id"] == "us.bls"
+
+
+def test_list_items_family_filter_sees_through_recency_crowding(tmp_path: Path) -> None:
+    """If many recent news docs crowd out older notes within the raw
+    fetch window, the family filter must still surface the note — the
+    service widens the internal fetch when a family filter is set."""
+    from datetime import datetime, timezone
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    _make_doc_source(store, "news")
+    _make_doc_source(store, "notes")
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    def _make_doc(doc_id: str, source: str, doc_type: str, ts_ms: int) -> DocumentRecord:
+        return DocumentRecord(
+            document_id=doc_id, release_family_id="", source_id=source,
+            canonical_url=f"https://example.com/{doc_id}",
+            title=f"Title {doc_id}", subtitle="", document_type=doc_type,
+            mime_type="text/html", language_code="en", country_code="US",
+            topic_code="inflation", published_date="2026-04-01",
+            published_at="2026-04-01T00:00:00Z",
+            published_epoch_ms=ts_ms, published_precision="day",
+            status="published", version_no=1, parent_document_id="",
+            hash_sha256=doc_id, created_at=now_iso, updated_at=now_iso,
+        )
+
+    # 15 recent news items, then one older note. With a limit of 5 the
+    # un-widened fetch would only see news rows.
+    for i in range(15):
+        doc = _make_doc(f"news-{i:02d}", "news", "report",
+                        1_745_000_000_000 + i)
+        store.upsert_document(doc)
+        store.set_document_subjects(doc.document_id, {"econ.cpi": 1.0})
+    older = _make_doc("note-01", "notes", "report", 1_700_000_000_000)
+    store.upsert_document(older)
+    store.set_document_subjects(older.document_id, {"econ.cpi": 1.0})
+
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke(
+        "list_items",
+        {"subject": "econ.cpi", "family": "note", "limit": 5},
+    )
+    assert resp["items"], "SQL family filter should surface the older note"
+    assert resp["items"][0]["document_id"] == "note-01"
+    assert resp["items"][0]["family"] == "note"
+
+
+def test_list_items_indicator_reached_via_direct_alias(tmp_path: Path) -> None:
+    """Not every subject alias has a matching concept_map entry —
+    ``commodity.gold`` aliases ``fred_series: GOLDAMGBD228NLBM`` but
+    the default concept_map doesn't carry it. The indicator branch
+    must still surface that observation via the direct alias join."""
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    store.seed_concept_map()
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="GOLDAMGBD228NLBM", source="fred",
+            date="2026-04-01", value=2345.5,
+        )
+    )
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke(
+        "list_items", {"subject": "commodity.gold", "family": "economic_data"},
+    )
+    indicators = [i for i in resp["items"] if i.get("kind") == "indicator"]
+    assert indicators, "direct alias path should surface gold indicator"
+    assert indicators[0]["series_id"] == "GOLDAMGBD228NLBM"
+    assert indicators[0]["source"] == "fred"
+    assert indicators[0]["concept_id"] == ""  # no concept_map mapping
+
+
+def test_list_items_family_filter_without_subject_is_enforced_in_sql(
+    tmp_path: Path,
+) -> None:
+    """``family='note'`` without a subject/query hits the recency feed
+    branch. The filter must apply in SQL so newer news rows don't bury
+    older notes within the returned window."""
+    from datetime import datetime, timezone
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    _make_doc_source(store, "news")
+    _make_doc_source(store, "notes")
+    now_iso = datetime.now(timezone.utc).isoformat()
+    for i in range(8):
+        store.upsert_document(
+            DocumentRecord(
+                document_id=f"news-{i:02d}", release_family_id="",
+                source_id="news",
+                canonical_url=f"https://example.com/news-{i}",
+                title=f"News {i}", subtitle="", document_type="report",
+                mime_type="text/html", language_code="en", country_code="US",
+                topic_code="", published_date="2026-04-01",
+                published_at="2026-04-01T00:00:00Z",
+                published_epoch_ms=1_745_000_000_000 + i,
+                published_precision="day", status="published",
+                version_no=1, parent_document_id="",
+                hash_sha256=f"news-{i}", created_at=now_iso, updated_at=now_iso,
+            )
+        )
+    store.upsert_document(
+        DocumentRecord(
+            document_id="note-01", release_family_id="", source_id="notes",
+            canonical_url="https://example.com/note-01",
+            title="Older Note", subtitle="", document_type="report",
+            mime_type="text/html", language_code="en", country_code="US",
+            topic_code="", published_date="2025-12-01",
+            published_at="2025-12-01T00:00:00Z",
+            published_epoch_ms=1_700_000_000_000,
+            published_precision="day", status="published",
+            version_no=1, parent_document_id="",
+            hash_sha256="note-01", created_at=now_iso, updated_at=now_iso,
+        )
+    )
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke("list_items", {"family": "note", "limit": 5})
+    assert resp["items"], "family filter must survive the no-subject branch"
+    for item in resp["items"]:
+        assert item["family"] == "note"
+
+
+def test_list_items_trend_family_does_not_leak_documents(
+    tmp_path: Path,
+) -> None:
+    """``trend`` rows live in ``trend_topics`` — list_items does not
+    project them yet, so a trend-family request must not return
+    documents tagged under a different family."""
+    from datetime import datetime, timezone
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    _make_doc_source(store, "news")
+    now_iso = datetime.now(timezone.utc).isoformat()
+    store.upsert_document(
+        DocumentRecord(
+            document_id="news-1", release_family_id="", source_id="news",
+            canonical_url="https://example.com/news-1",
+            title="Headline", subtitle="", document_type="report",
+            mime_type="text/html", language_code="en", country_code="US",
+            topic_code="", published_date="2026-04-01",
+            published_at="2026-04-01T00:00:00Z",
+            published_epoch_ms=1_745_000_000_000,
+            published_precision="day", status="published",
+            version_no=1, parent_document_id="",
+            hash_sha256="news-1", created_at=now_iso, updated_at=now_iso,
+        )
+    )
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke("list_items", {"family": "trend"})
+    assert resp["items"] == []
+
+
+def test_list_items_indicator_fans_out_cross_source_via_concept_id(
+    tmp_path: Path,
+) -> None:
+    """``UNEMP_US`` concept maps FRED ``UNRATE`` + BLS ``LNS14000000``.
+    A subject aliasing only ``UNRATE`` must still surface the BLS
+    observation — the concept bridge pivots through concept_id rather
+    than stopping at the matched concept_map row."""
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    store.seed_concept_map()
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="UNRATE", source="fred",
+            date="2026-03-31", value=3.9,
+        )
+    )
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="LNS14000000", source="bls",
+            date="2026-03-31", value=3.9,
+        )
+    )
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke(
+        "list_items",
+        {"subject": "econ.unemployment", "family": "economic_data"},
+    )
+    indicators = [i for i in resp["items"] if i.get("kind") == "indicator"]
+    sources = {i["source"] for i in indicators}
+    assert {"fred", "bls"} <= sources, (
+        f"cross-source fan-out should carry both providers, got {sources}"
+    )
+
+
+def test_list_items_family_recency_with_document_type_filter(tmp_path: Path) -> None:
+    """Recency feed called with ``family='news'`` + ``document_type='report'``
+    must bind each filter to the right column. A parameter-order mix-up
+    would pass ``report`` to ``source_id`` and return an empty result."""
+    from datetime import datetime, timezone
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    _make_doc_source(store, "news")
+    now_iso = datetime.now(timezone.utc).isoformat()
+    store.upsert_document(
+        DocumentRecord(
+            document_id="news-report-1", release_family_id="", source_id="news",
+            canonical_url="https://example.com/report-1",
+            title="Analyst Report", subtitle="", document_type="report",
+            mime_type="text/html", language_code="en", country_code="US",
+            topic_code="", published_date="2026-04-01",
+            published_at="2026-04-01T00:00:00Z",
+            published_epoch_ms=1_745_000_000_000,
+            published_precision="day", status="published",
+            version_no=1, parent_document_id="",
+            hash_sha256="news-report-1", created_at=now_iso, updated_at=now_iso,
+        )
+    )
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke(
+        "list_items",
+        {"family": "news", "document_type": "report", "limit": 5},
+    )
+    assert resp["items"], "family + document_type combo should return rows"
+    assert resp["items"][0]["family"] == "news"
+    assert resp["items"][0]["document_type"] == "report"
+
+
+def test_list_items_direct_only_series_survives_concept_path_cap(
+    tmp_path: Path,
+) -> None:
+    """``rate.us.fed_funds`` has ``DFF`` in concept_map and ``FEDFUNDS``
+    on the direct alias path. If the concept path saturates ``limit``
+    with DFF observations the direct-only FEDFUNDS series must still
+    appear — the merge happens before the cap."""
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    store.seed_concept_map()
+    # Saturate the concept path with recent DFF rows.
+    for day in range(3, 25):
+        store.upsert_indicator_observation(
+            IndicatorObservationRecord(
+                series_id="DFF", source="fred",
+                date=f"2026-04-{day:02d}", value=5.25,
+            )
+        )
+    # One older direct-only observation.
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="FEDFUNDS", source="fred",
+            date="2026-04-02", value=5.25,
+        )
+    )
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke(
+        "list_items",
+        {"subject": "rate.us.fed_funds", "family": "economic_data", "limit": 10},
+    )
+    series = {i["series_id"] for i in resp["items"] if i.get("kind") == "indicator"}
+    assert "FEDFUNDS" in series, (
+        f"direct-only series must survive concept-path saturation, got {sorted(series)}"
+    )
+
+
+def test_list_items_concept_bridge_respects_alias_source(tmp_path: Path) -> None:
+    """When a provider_series_id collides across sources in concept_map
+    (same id under two ``source_id`` values), a ``fred_series`` alias
+    must only bridge through the fred row — otherwise the fan-out
+    through cm_out leaks unrelated observations."""
+    from datetime import datetime, timezone
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    sync_from_yaml(store)
+    store.seed_concept_map()
+    # Stage a colliding concept_map entry under a non-fred source that
+    # reuses the CPIAUCSL series id, and store an indicator row there.
+    now = datetime.now(timezone.utc).isoformat()
+    with store._connection(commit=True) as connection:
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO concept_map
+              (concept_id, source_id, provider_series_id,
+               obs_family_id, priority, role, notes, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("UNRELATED_CPI", "imf", "CPIAUCSL", "",
+             1, "primary", "collision", now),
+        )
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="CPIAUCSL", source="imf",
+            date="2026-03-31", value=999.0,
+        )
+    )
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="CPIAUCSL", source="fred",
+            date="2026-03-31", value=310.12,
+        )
+    )
+    svc = LocalMacroDataService(store=store)
+    resp = svc.invoke(
+        "list_items", {"subject": "econ.cpi", "family": "economic_data"},
+    )
+    concept_ids = {
+        i.get("concept_id")
+        for i in resp["items"]
+        if i.get("kind") == "indicator"
+    }
+    assert "UNRELATED_CPI" not in concept_ids, (
+        "alias_type=fred_series must not bridge through a non-fred "
+        f"concept_map row; got concepts {concept_ids}"
+    )
+
+
+def test_list_items_without_family_filter_shows_all_branches(
+    cross_type_service: LocalMacroDataService,
+) -> None:
+    """With ``family`` omitted, documents, indicators, and market bars
+    all surface — dropping later branches to fit a global ``limit``
+    would re-introduce the crowding bug. Each branch keeps its own
+    cap."""
+    resp = cross_type_service.invoke(
+        "list_items", {"subject": "econ.cpi", "limit": 5},
+    )
+    kinds = {i.get("kind") for i in resp["items"]}
+    assert "document" in kinds
+    assert "indicator" in kinds
+    assert "market_bar" in kinds

--- a/tests/test_unified_api_ops.py
+++ b/tests/test_unified_api_ops.py
@@ -260,3 +260,47 @@ def test_get_document_not_found_returns_null(
 ) -> None:
     resp = service.invoke("get_document", {"document_id": "nonexistent_id"})
     assert resp["document"] is None
+
+
+# ── list_sources (issue #5 Slice 1) ─────────────────────────────────────
+
+
+class _StubIngestion:
+    def __init__(self, rows: list[dict[str, str]]) -> None:
+        self._rows = rows
+
+    def list_sources(self) -> list[dict[str, str]]:
+        return list(self._rows)
+
+
+def test_list_sources_returns_name_family_rows(tmp_path: Path) -> None:
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    ingestion = _StubIngestion([
+        {"name": "fred_daily", "family": "economic_data"},
+        {"name": "tiingo_market", "family": "market_price"},
+        {"name": "news", "family": "news"},
+    ])
+    svc = LocalMacroDataService(store=store, ingestion=ingestion)
+    resp = svc.invoke("list_sources", {})
+    assert resp["total"] == 3
+    assert resp["sources"][0] == {"name": "fred_daily", "family": "economic_data"}
+
+
+def test_list_sources_filters_by_family(tmp_path: Path) -> None:
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    ingestion = _StubIngestion([
+        {"name": "fred_daily", "family": "economic_data"},
+        {"name": "tiingo_market", "family": "market_price"},
+        {"name": "news", "family": "news"},
+    ])
+    svc = LocalMacroDataService(store=store, ingestion=ingestion)
+    resp = svc.invoke("list_sources", {"family": "market_price"})
+    assert resp["total"] == 1
+    assert resp["sources"] == [{"name": "tiingo_market", "family": "market_price"}]
+
+
+def test_list_sources_without_ingestion_returns_error(tmp_path: Path) -> None:
+    store = SQLiteEngineStore(db_path=tmp_path / "engine.db")
+    svc = LocalMacroDataService(store=store, ingestion=None)
+    resp = svc.invoke("list_sources", {})
+    assert resp == {"error": "sources unavailable", "sources": []}


### PR DESCRIPTION
Closes #5.

## Summary
- **Slice 1** — every `IngestionSourceDefinition` now carries a `family` tag (applied once in `SOURCE_FAMILIES`, threaded through `IngestionRunReport.to_dict()`), `list_sources()` returns `[{name, family}, …]`, and a new `list_sources` service op exposes the rows over HTTP/CLI with an optional family filter.
- **Slice 2** — `list_items` unions documents + indicator observations + market-price bars for a subject in a single call. Each row carries a `family` + `kind` discriminator, and an optional `family` filter narrows the envelope. The document branch pushes the family predicate into SQL; indicators pivot through concept_id and also match directly via `subject_aliases → indicators` (so cross-source alternates and direct-only series both surface). Market bars are reached through `primary_ticker` / `instrument_id` equality and a `json_each` over `provider_symbols_json` — the last path covers synthetic macro instruments today.

## Codex review chain
Five rounds; every filed P1/P2 correctness bug was fixed (bug-chain exempt from the 2-round cap). Rejections filtered per CLAUDE.md rule 2: the round-5 "normalize regex ticker aliases" finding was declined because it would require expanding `subjects.yaml` for every equity subject — scope creep outside the issue; the code already matches any structured `ticker` alias once seeded.

## Test plan
- [x] `pytest tests/test_ingestion_orchestrator.py tests/test_unified_api_ops.py` — 48 pass (includes 15 new tests).
- [x] `pytest tests/test_identity_repair.py tests/test_macro_market_mapping.py tests/test_eodhd_market_data.py tests/test_tiingo_market_data.py` — 74 pass (ordering assertions updated for the new `list_sources` shape).
- [x] Round-5 Codex review produced no remaining P1/P2 bugs.