### PR TITLE
chore: add skeleton-first GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/skeleton.md
+++ b/.github/ISSUE_TEMPLATE/skeleton.md
@@ -1,0 +1,71 @@
+---
+name: Skeleton
+about: Skeleton-first issue — file before digging in. Grows as investigation progresses.
+title: "short imperative summary"
+labels: []
+assignees: []
+---
+
+<!--
+File BEFORE coding. Skip only for typos / single-file obvious fixes / refactors
+the user explicitly requested in chat. See CLAUDE.md §"Issue-fix workflow" step 0.
+
+Keep the initial skeleton small. Fill TBDs in place as you learn (`gh issue edit`).
+Before opening the PR, every TBD must be resolved or deleted.
+-->
+
+## Summary
+
+<!-- One sentence: what the symptom or request is, plus the triggering observation
+(the commit, log line, ticket, user report, or file path that surfaced it). -->
+
+## Proposed minimum slice
+
+<!-- The smallest change that satisfies the ask. One or two bullets. -->
+
+## Out of scope
+
+<!-- Adjacent improvements we're explicitly NOT doing in this issue. Link follow-ups
+as separate issue numbers when known. -->
+
+## Investigation checkpoints
+
+- **Root cause:** TBD
+- **Repro:** TBD
+- **Fix:** TBD
+
+<!--
+Each TBD is a checkpoint — the moment it has an answer, edit this body in place.
+No re-approval needed for fills within the approved scope.
+-->
+
+---
+
+<!-- Sections below grow as work proceeds. Delete any you don't need. -->
+
+## Phased plan
+
+<!-- Only for multi-slice work. Each phase = one commit on the issue's branch.
+Format (from #8 / #9):
+
+### P0 — <short name>
+**Depends on:** <other phase or "nothing">
+- Concrete deliverable 1
+- Concrete deliverable 2
+**Done when:** <one-line exit criterion>
+-->
+
+## Decision record
+
+<!-- Non-obvious choices made during implementation. Two columns: decision / why.
+Appended as decisions land, never rewritten. -->
+
+## Acceptance criteria
+
+<!-- Checkbox list. Ticked as each phase closes. The issue closes when every box ticks. -->
+
+- [ ] TBD
+
+## References
+
+<!-- Parent issue, related PRs, docs pages, external API references. -->


### PR DESCRIPTION
## Summary

Adds a skeleton-first GitHub issue template at `.github/ISSUE_TEMPLATE/skeleton.md`, aligned with CLAUDE.md §"Issue-fix workflow" step 0.

- **skeleton.md** — required starting sections (Summary / Proposed minimum slice / Out of scope / Investigation checkpoints with `Root cause / Repro / Fix: TBD` placeholders). Growable sections (Phased plan / Decision record / Acceptance criteria / References) are commented examples matching the structure of issues #8 and #9 so the template keeps working as an issue evolves through its phases.
- **config.yml** — `blank_issues_enabled: false` so every new ticket routes through the skeleton, enforcing the skeleton-first rule at the GitHub UI level rather than on the honor system.

## Test plan

- [ ] Visit the Issues → New Issue page on the repo — blank issues should be disabled; the skeleton template should be the only option
- [ ] CodeRabbit auto-review fires on this PR (first validation of the expert-level config merged in #10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated issue submission configuration to disable blank issues and streamline available creation flows.
  * Added a "skeleton-first" investigation issue template with guided sections for summary, scope, investigation checkpoints, phased plan, decision record, acceptance criteria, and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->