### PR TITLE
chore(coderabbit): trim tone_instructions under 250-char limit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,11 +9,7 @@
 language: "en-US"
 early_access: false
 
-tone_instructions: |
-  Expert-level review. Flag correctness bugs and architectural risks first;
-  stylistic nits last, if at all. Skip filler ("Let me explain", "It's
-  important to note"). No emojis. When proposing a change, show the exact
-  diff, not a paragraph of prose. Match the codebase's direct tone.
+tone_instructions: "Expert-level review. Flag correctness and architecture first; style nits last. Skip filler. No emojis. Show exact diffs, not prose. Match the codebase's direct tone."
 
 reviews:
   profile: "assertive"


### PR DESCRIPTION
## Summary

CodeRabbit's schema caps `tone_instructions` at 250 chars. The original text (~320 chars) failed validation, so every review on the repo silently fell back to defaults (profile `CHILL`, poem enabled, no path_instructions applied).

Surfaced on PR #11:

> Validation error: String must contain at most 250 character(s) at \"tone_instructions\"

## Test plan

- [ ] After merge, re-review PR #11 with `@coderabbitai full review` — should show `Configuration used: .coderabbit.yaml` and `Review profile: ASSERTIVE`