### PR TITLE
Issue #8 - retire legacy calendar_events path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ Two physical lanes behind one downstream contract (see `src/storage/STORAGE.md` 
 - **Corporate lane** — `cal_corp_raw` / `cal_corp_event`. EODHD earnings / IPOs / splits / dividends / earnings_trends.
 - **Unified view:** `v_calendar_item` `UNION ALL`s both lanes into the `CalendarItem` DTO shape. Downstream sees one target.
 - **Revision model:** content-hash over mutable fields; append-only raw; PIT projection as the queryable layer. Mirrors `obs_family` / `indicator_vintages`.
-- **Legacy `calendar_events`** (HTML-scraped) untouched until slice-2 API fetcher proves parity.
+- **Legacy `calendar_events`** compatibility table remains in schema for old DBs, but the HTML-scraped refresh path is retired. Legacy read helpers now read `cal_econ_event`, and public clients use `GET /v1/calendar` over `v_calendar_item`.
 
 Slice progress:
 
@@ -238,7 +238,7 @@ src/
 
 | Issue | Branch | Slice |
 |---|---|---|
-| #8 | `feat/issue-8-calendar-two-lane-schema` | P0 shipped (two-lane schema + DTO + view). P1 shipped (TE API scaffold + dry-run HTTP ops). P2 shipped (EODHD corporate scaffold + `calendar_corp_fetch` op, dry-run default). Slices P3–P5 pending (TE backfill execution, official sources, legacy retirement). |
+| #8 | `fix/issue-8-retire-legacy-calendar` | Final retirement slice: legacy HTML calendar source is inert, old read helpers point at `cal_econ_event`, and `/v1/calendar` is the downstream contract. |
 
 Closed recently (context only — the code is the source of truth):
 

--- a/src/ingestion/source_capabilities.py
+++ b/src/ingestion/source_capabilities.py
@@ -534,7 +534,7 @@ class SourceCapabilityManager:
         from ingestion.news_feeds import get_feeds
         from ingestion.scrapers.eia import EIAClient
         from ingestion.scrapers.treasury_fiscal import TreasuryFiscalClient
-        from ingestion.clients._trends import _REDDIT_TREND_SOURCES
+        from ingestion.trends.clients._trends import _REDDIT_TREND_SOURCES
 
         adapters: dict[str, SourceCapabilityAdapter] = {}
 
@@ -635,9 +635,18 @@ class SourceCapabilityManager:
 
         def _calendar_entities(query: str | None, limit: int | None) -> list[dict[str, Any]]:
             entities = [
-                _entity("calendar", "investing", "provider", "Investing.com"),
-                _entity("calendar", "forexfactory", "provider", "ForexFactory"),
-                _entity("calendar", "tradingeconomics", "provider", "TradingEconomics"),
+                _entity("calendar", "tradingeconomics", "provider", "TradingEconomics", description="historical economic calendar"),
+                _entity("calendar", "eodhd", "provider", "EODHD", description="corporate calendar"),
+                _entity("calendar", "bls", "provider", "BLS"),
+                _entity("calendar", "bea", "provider", "BEA"),
+                _entity("calendar", "census", "provider", "Census"),
+                _entity("calendar", "ism", "provider", "ISM"),
+                _entity("calendar", "umich", "provider", "U Michigan"),
+                _entity("calendar", "conference-board", "provider", "Conference Board"),
+                _entity("calendar", "nar", "provider", "NAR"),
+                _entity("calendar", "federal-reserve", "provider", "Federal Reserve"),
+                _entity("calendar", "ecb", "provider", "ECB"),
+                _entity("calendar", "nbs", "provider", "NBS"),
             ]
             return _limit_items(entities, query, limit)
 
@@ -1054,10 +1063,10 @@ class SourceCapabilityManager:
             display_name="Economic Calendar",
             source_type="fixed-scope-complete",
             entity_type="provider",
-            description="Calendar providers with normalized event ingestion",
-            is_default_scheduled=True,
+            description="Unified calendar providers; legacy HTML refresh is retired",
+            supports_latest_sync=False,
+            is_default_scheduled=False,
             discover=_calendar_entities,
-            sync_latest=lambda entity_ids, limit: _run_job("calendar"),
         )
         adapters["fed"] = SourceCapabilityAdapter(
             source_id="fed",

--- a/src/ingestion/sources.py
+++ b/src/ingestion/sources.py
@@ -384,7 +384,6 @@ class IngestionOrchestrator:
         for definition in definitions:
             self.register_source(definition)
         self._default_refresh_order = [
-            "calendar",
             "fed",
             "market",
             "tiingo_market",
@@ -572,13 +571,7 @@ class IngestionOrchestrator:
     def _build_calendar_source(self) -> IngestionSourceDefinition:
         return IngestionSourceDefinition(
             name="calendar",
-            interval_seconds=3600,
-            prepare=self._ensure_calendar_indicator_seed,
-            fetch=self._fetch_calendar_events,
-            normalize=self._normalize_calendar_events,
-            validate=self._validate_calendar_events,
-            deduplicate=self._deduplicate_calendar_events,
-            store=self._store_calendar_events,
+            execute=lambda: 0,
         )
 
     def _fetch_calendar_events(self) -> list[StoredEventRecord]:

--- a/src/macro_data/service.py
+++ b/src/macro_data/service.py
@@ -2986,47 +2986,18 @@ class LocalMacroDataService:
         }
 
     def _op_fetch_live_calendar(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        from ingestion.scrapers import (
-            ForexFactoryCalendarClient,
-            InvestingCalendarClient,
-            TradingEconomicsCalendarClient,
-        )
-
-        source = (arguments.get("source") or "all").lower()
-        importance_filter = arguments.get("importance")
-        country_filter = arguments.get("country")
-        sources = ("investing", "forexfactory", "tradingeconomics") if source == "all" else (source,)
-        all_events: list[Any] = []
-        errors: list[str] = []
-        for item in sources:
-            try:
-                if item == "investing":
-                    all_events.extend(InvestingCalendarClient().fetch())
-                elif item == "forexfactory":
-                    all_events.extend(ForexFactoryCalendarClient().fetch())
-                elif item == "tradingeconomics":
-                    all_events.extend(TradingEconomicsCalendarClient().fetch())
-            except Exception as exc:
-                logger.warning("Live fetch from %s failed: %s", item, exc)
-                errors.append(f"{item}: {exc}")
-        for event in all_events:
-            try:
-                self._store.upsert_calendar_event(event)
-            except Exception:
-                logger.warning("Failed to persist live calendar event %s", getattr(event, "event_id", ""), exc_info=True)
-        filtered = all_events
-        if importance_filter:
-            filtered = [event for event in filtered if event.importance == importance_filter]
-        if country_filter:
-            filtered = [event for event in filtered if event.country == str(country_filter).upper()]
-        result: dict[str, Any] = {
-            "total_fetched": len(all_events),
-            "returned": len(filtered),
-            "events": [self._event_to_dict(event) for event in filtered],
+        del arguments
+        return {
+            "retired": True,
+            "total_fetched": 0,
+            "returned": 0,
+            "events": [],
+            "replacement": {
+                "read": "GET /v1/calendar or service op list_calendar_items",
+                "schedule_refresh": "calendar_econ_refresh_schedules",
+                "value_sweep": "calendar_econ_sweep_values",
+            },
         }
-        if errors:
-            result["errors"] = errors
-        return result
 
     def _op_fetch_live_news(self, arguments: dict[str, Any]) -> dict[str, Any]:
         raw_sources = (arguments.get("sources") or "all").lower().strip()

--- a/src/macro_data/service.py
+++ b/src/macro_data/service.py
@@ -3407,6 +3407,14 @@ class LocalMacroDataService:
         indicator_id = getattr(event, "indicator_id", "")
         if indicator_id:
             payload["indicator_id"] = indicator_id
+        event_time_utc = getattr(event, "event_time_utc", "")
+        if event_time_utc:
+            payload["event_time_utc"] = event_time_utc
+            payload["event_time_precision"] = getattr(
+                event,
+                "event_time_precision",
+                "datetime",
+            )
         return payload
 
     def _price_to_dict(self, price: Any) -> dict[str, Any]:

--- a/src/macro_data/service.py
+++ b/src/macro_data/service.py
@@ -3392,7 +3392,12 @@ class LocalMacroDataService:
     def _event_to_dict(self, event: Any) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "source": event.source,
-            "event_id": event.event_id,
+            "event_id": (
+                f"{event.source}:{event.event_id}"
+                if ":" not in str(event.event_id)
+                else event.event_id
+            ),
+            "provider_event_id": event.event_id,
             "timestamp": event.timestamp,
             "datetime_utc": format_epoch_iso(event.timestamp),
             "country": event.country,

--- a/src/storage/STORAGE.md
+++ b/src/storage/STORAGE.md
@@ -426,7 +426,7 @@ capability/catalog state describes what a source *can* expose, while
 
 | Table | Purpose |
 |-------|---------|
-| `calendar_events` | Economic calendar (Investing, ForexFactory, TradingEconomics) |
+| `calendar_events` | Legacy economic calendar compatibility table; HTML refresh retired |
 | `market_prices` | Asset price snapshots (yfinance) |
 | `central_bank_comms` | Fed speeches, statements, testimony (RSS feeds) |
 | `obs_source` | Observation data providers (FRED, EIA, Treasury Fiscal, NY Fed, rateprobability) |
@@ -567,14 +567,15 @@ phases for the current month) — no separate `cal_budget` table.
 `previous`, `forecast`, `consensus_forecast`, `source_url`,
 `last_update_epoch_ms`, `observed_at_epoch_ms`.
 
-Future HTTP surface: `GET /calendar?domain=economic&country=US&from=…` or
+HTTP surface: `GET /v1/calendar?domain=economic&country=US` or
 `?domain=corporate&ticker=AAPL&subtype=earnings` reads this view.
 
 ### Relationship to legacy `calendar_events`
 
-`calendar_events` (HTML-scraped via `scrapers/tradingeconomics.py`) is
-untouched in this slice. Retirement happens in slice 2 after the TE API
-fetcher writes through `cal_econ_*` with parity.
+`calendar_events` is retained as a compatibility table for old local DBs.
+The HTML-scraped live refresh path is retired; legacy read helpers use
+`cal_econ_event`, and new consumers read `v_calendar_item` through
+`GET /v1/calendar`.
 
 ## Running Tests
 

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -41,12 +41,35 @@ _CALENDAR_KEYWORD_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 
-def _calendar_keyword_patterns(keyword: str) -> list[str]:
+def _calendar_keyword_patterns(
+    keyword: str,
+    *,
+    connection: sqlite3.Connection | None = None,
+) -> list[str]:
     base = keyword.strip().lower()
     if not base:
         return []
     patterns = {base}
     patterns.update(_CALENDAR_KEYWORD_ALIASES.get(base, ()))
+    if connection is not None:
+        like = f"%{base}%"
+        rows = connection.execute(
+            """
+            SELECT alias_normalized AS pattern FROM calendar_indicator_alias
+            WHERE alias_normalized LIKE ?
+            UNION
+            SELECT LOWER(canonical_name) AS pattern FROM calendar_indicator
+            WHERE LOWER(canonical_name) LIKE ?
+            UNION
+            SELECT indicator_id AS pattern FROM calendar_indicator
+            WHERE LOWER(indicator_id) LIKE ?
+            """,
+            (like, like, like),
+        ).fetchall()
+        for row in rows:
+            pattern = str(row["pattern"] or "").strip().lower()
+            if pattern:
+                patterns.add(pattern)
     return sorted(patterns)
 
 
@@ -54,8 +77,10 @@ def _add_calendar_keyword_filter(
     conditions: list[str],
     params: list[Any],
     keyword: str | None,
+    *,
+    connection: sqlite3.Connection | None = None,
 ) -> None:
-    patterns = _calendar_keyword_patterns(keyword or "")
+    patterns = _calendar_keyword_patterns(keyword or "", connection=connection)
     if not patterns:
         return
     clauses: list[str] = []
@@ -102,6 +127,38 @@ def _calendar_surprise(
     if actual_value is None or forecast_value is None:
         return None
     return round(actual_value - forecast_value, 4)
+
+
+def _event_time_lower_bound_clause() -> str:
+    return (
+        "((event_time_precision = 'date' AND date(event_time_utc) >= date(?)) "
+        "OR (event_time_precision != 'date' AND datetime(event_time_utc) >= datetime(?)))"
+    )
+
+
+def _event_time_upper_bound_clause() -> str:
+    return (
+        "((event_time_precision = 'date' AND date(event_time_utc) <= date(?)) "
+        "OR (event_time_precision != 'date' AND datetime(event_time_utc) <= datetime(?)))"
+    )
+
+
+def _add_event_time_lower_bound(
+    conditions: list[str],
+    params: list[Any],
+    value: str,
+) -> None:
+    conditions.append(_event_time_lower_bound_clause())
+    params.extend((value, value))
+
+
+def _add_event_time_upper_bound(
+    conditions: list[str],
+    params: list[Any],
+    value: str,
+) -> None:
+    conditions.append(_event_time_upper_bound_clause())
+    params.extend((value, value))
 
 
 @dataclass(frozen=True)
@@ -3933,8 +3990,9 @@ class SQLiteEngineStore:
         category: str | None = None,
     ) -> list[StoredEventRecord]:
         cutoff = (utc_now() - timedelta(days=days)).isoformat()
-        conditions = ["datetime(event_time_utc) >= datetime(?)"]
-        params: list[Any] = [cutoff]
+        conditions: list[str] = []
+        params: list[Any] = []
+        _add_event_time_lower_bound(conditions, params, cutoff)
         if released_only:
             conditions.append("actual IS NOT NULL")
         if importance:
@@ -3968,8 +4026,9 @@ class SQLiteEngineStore:
         category: str | None = None,
     ) -> list[StoredEventRecord]:
         now_iso = utc_now().isoformat()
-        conditions = ["datetime(event_time_utc) >= datetime(?)"]
-        params: list[Any] = [now_iso]
+        conditions: list[str] = []
+        params: list[Any] = []
+        _add_event_time_lower_bound(conditions, params, now_iso)
         if importance:
             conditions.append("importance = ?")
             params.append(importance)
@@ -4005,11 +4064,10 @@ class SQLiteEngineStore:
     ) -> list[StoredEventRecord]:
         from_iso = datetime.fromtimestamp(date_from, tz=timezone.utc).isoformat()
         to_iso = datetime.fromtimestamp(date_to, tz=timezone.utc).isoformat()
-        conditions = [
-            "datetime(event_time_utc) >= datetime(?)",
-            "datetime(event_time_utc) <= datetime(?)",
-        ]
-        params: list[Any] = [from_iso, to_iso]
+        conditions: list[str] = []
+        params: list[Any] = []
+        _add_event_time_lower_bound(conditions, params, from_iso)
+        _add_event_time_upper_bound(conditions, params, to_iso)
         if released_only:
             conditions.append("actual IS NOT NULL")
         if importance:
@@ -4060,11 +4118,13 @@ class SQLiteEngineStore:
         indicator_keyword: str,
         limit: int = 12,
     ) -> list[StoredEventRecord]:
-        conditions = ["actual IS NOT NULL"]
-        params: list[Any] = []
-        _add_calendar_keyword_filter(conditions, params, indicator_keyword)
-        params.append(limit)
         with self._connection(commit=False) as connection:
+            conditions = ["actual IS NOT NULL"]
+            params: list[Any] = []
+            _add_calendar_keyword_filter(
+                conditions, params, indicator_keyword, connection=connection
+            )
+            params.append(limit)
             rows = connection.execute(
                 f"""
                 SELECT * FROM cal_econ_event
@@ -4154,10 +4214,12 @@ class SQLiteEngineStore:
         )
 
     def latest_released_event(self, *, indicator_keyword: str | None = None) -> StoredEventRecord | None:
-        params: list[Any] = []
-        conditions = ["actual IS NOT NULL"]
-        _add_calendar_keyword_filter(conditions, params, indicator_keyword)
         with self._connection(commit=False) as connection:
+            params: list[Any] = []
+            conditions = ["actual IS NOT NULL"]
+            _add_calendar_keyword_filter(
+                conditions, params, indicator_keyword, connection=connection
+            )
             row = connection.execute(
                 f"""
                 SELECT * FROM cal_econ_event

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -2593,6 +2593,22 @@ class SQLiteEngineStore:
                 "ON cal_econ_event(indicator_id, datetime(event_time_utc))"
             )
             connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cal_econ_event_date "
+                "ON cal_econ_event(date(event_time_utc))"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cal_econ_event_date_provider "
+                "ON cal_econ_event(date(event_time_utc), provider_event_id)"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cal_econ_event_date_country "
+                "ON cal_econ_event(country_code, date(event_time_utc))"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cal_econ_event_date_indicator "
+                "ON cal_econ_event(indicator_id, date(event_time_utc))"
+            )
+            connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS cal_econ_drops (
                     provider           TEXT NOT NULL,

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -2520,6 +2520,22 @@ class SQLiteEngineStore:
                 "ON cal_econ_event(event_time_utc)"
             )
             connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cal_econ_event_datetime "
+                "ON cal_econ_event(datetime(event_time_utc))"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cal_econ_event_datetime_provider "
+                "ON cal_econ_event(datetime(event_time_utc), provider_event_id)"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cal_econ_event_datetime_country "
+                "ON cal_econ_event(country_code, datetime(event_time_utc))"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cal_econ_event_datetime_indicator "
+                "ON cal_econ_event(indicator_id, datetime(event_time_utc))"
+            )
+            connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS cal_econ_drops (
                     provider           TEXT NOT NULL,
@@ -4147,13 +4163,13 @@ class SQLiteEngineStore:
                 SELECT * FROM cal_econ_event
                 WHERE {' AND '.join(conditions)}
                 ORDER BY
+                    datetime(event_time_utc) DESC,
                     CASE importance
                         WHEN 'high' THEN 3
                         WHEN 'medium' THEN 2
                         WHEN 'low' THEN 1
                         ELSE 0
                     END DESC,
-                    datetime(event_time_utc) DESC,
                     provider_event_id DESC
                 LIMIT 1
                 """,

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -46,33 +46,64 @@ def _calendar_keyword_patterns(
     *,
     connection: sqlite3.Connection | None = None,
 ) -> list[str]:
+    patterns, _ = _calendar_keyword_pattern_sets(keyword, connection=connection)
+    return sorted(patterns)
+
+
+def _calendar_keyword_pattern_sets(
+    keyword: str,
+    *,
+    connection: sqlite3.Connection | None = None,
+) -> tuple[set[str], set[str]]:
     from ingestion.scrapers._common import normalize_indicator_name
 
     base = normalize_indicator_name(keyword)
     if not base:
-        return []
+        return set(), set()
+    raw_keyword = keyword.strip()
     patterns = {base}
-    patterns.update(_CALENDAR_KEYWORD_ALIASES.get(base, ()))
+    raw_patterns = {raw_keyword, base}
+    aliases = _CALENDAR_KEYWORD_ALIASES.get(base, ())
+    patterns.update(aliases)
+    raw_patterns.update(aliases)
     if connection is not None:
-        like = f"%{base}%"
-        rows = connection.execute(
-            """
-            SELECT alias_normalized AS pattern FROM calendar_indicator_alias
-            WHERE alias_normalized LIKE ?
-            UNION
-            SELECT LOWER(canonical_name) AS pattern FROM calendar_indicator
-            WHERE LOWER(canonical_name) LIKE ?
-            UNION
-            SELECT indicator_id AS pattern FROM calendar_indicator
-            WHERE LOWER(indicator_id) LIKE ?
-            """,
-            (like, like, like),
-        ).fetchall()
-        for row in rows:
-            pattern = normalize_indicator_name(str(row["pattern"] or ""))
-            if pattern:
-                patterns.add(pattern)
-    return sorted(patterns)
+        for lookup_term in sorted({raw_keyword, base}):
+            like = f"%{lookup_term}%"
+            rows = connection.execute(
+                """
+                SELECT
+                    alias_original AS alias_raw,
+                    NULL AS canonical_raw,
+                    NULL AS indicator_raw
+                FROM calendar_indicator_alias
+                WHERE alias_original LIKE ?
+                UNION
+                SELECT
+                    NULL AS alias_raw,
+                    canonical_name AS canonical_raw,
+                    NULL AS indicator_raw
+                FROM calendar_indicator
+                WHERE canonical_name LIKE ?
+                UNION
+                SELECT
+                    NULL AS alias_raw,
+                    NULL AS canonical_raw,
+                    indicator_id AS indicator_raw
+                FROM calendar_indicator
+                WHERE indicator_id LIKE ?
+                """,
+                (like, like, like),
+            ).fetchall()
+            for row in rows:
+                for column in ("alias_raw", "canonical_raw", "indicator_raw"):
+                    raw_pattern = str(row[column] or "").strip()
+                    if not raw_pattern:
+                        continue
+                    raw_patterns.add(raw_pattern)
+                    pattern = normalize_indicator_name(raw_pattern)
+                    if pattern:
+                        patterns.add(pattern)
+    return patterns, raw_patterns
 
 
 def _add_calendar_keyword_filter(
@@ -82,16 +113,18 @@ def _add_calendar_keyword_filter(
     *,
     connection: sqlite3.Connection | None = None,
 ) -> None:
-    patterns = _calendar_keyword_patterns(keyword or "", connection=connection)
-    if not patterns:
+    _, raw_patterns = _calendar_keyword_pattern_sets(
+        keyword or "", connection=connection
+    )
+    if not raw_patterns:
         return
     clauses: list[str] = []
-    for pattern in patterns:
+    for pattern in sorted(raw_patterns):
         like = f"%{pattern}%"
         clauses.extend((
-            "LOWER(title) LIKE ?",
-            "LOWER(COALESCE(indicator_id, '')) LIKE ?",
-            "LOWER(category) LIKE ?",
+            "title LIKE ?",
+            "COALESCE(indicator_id, '') LIKE ?",
+            "category LIKE ?",
         ))
         params.extend((like, like, like))
     conditions.append(f"({' OR '.join(clauses)})")

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -31,6 +31,79 @@ def _matches_scope_tags(text: str, tags: list[str]) -> bool:
     return any(re.search(rf"\b{re.escape(tag.lower())}\b", lowered) for tag in tags)
 
 
+_CALENDAR_KEYWORD_ALIASES: dict[str, tuple[str, ...]] = {
+    "cpi": ("consumer price index", "inflation rate"),
+    "core cpi": ("consumer price index all items less food and energy",),
+    "ppi": ("producer price index",),
+    "nfp": ("nonfarm payroll", "employment situation"),
+    "pmi": ("purchasing managers", "manufacturing pmi", "services pmi"),
+    "gdp": ("gross domestic product",),
+}
+
+
+def _calendar_keyword_patterns(keyword: str) -> list[str]:
+    base = keyword.strip().lower()
+    if not base:
+        return []
+    patterns = {base}
+    patterns.update(_CALENDAR_KEYWORD_ALIASES.get(base, ()))
+    return sorted(patterns)
+
+
+def _add_calendar_keyword_filter(
+    conditions: list[str],
+    params: list[Any],
+    keyword: str | None,
+) -> None:
+    patterns = _calendar_keyword_patterns(keyword or "")
+    if not patterns:
+        return
+    clauses: list[str] = []
+    for pattern in patterns:
+        like = f"%{pattern}%"
+        clauses.extend((
+            "LOWER(title) LIKE ?",
+            "LOWER(COALESCE(indicator_id, '')) LIKE ?",
+            "LOWER(category) LIKE ?",
+        ))
+        params.extend((like, like, like))
+    conditions.append(f"({' OR '.join(clauses)})")
+
+
+def _calendar_numeric_value(value: str | None) -> float | None:
+    if value is None:
+        return None
+    cleaned = value.strip().replace(",", "")
+    if not cleaned:
+        return None
+    multiplier = 1.0
+    suffix_map = {
+        "K": 1_000.0,
+        "M": 1_000_000.0,
+        "B": 1_000_000_000.0,
+    }
+    suffix = cleaned[-1].upper()
+    if suffix in suffix_map:
+        multiplier = suffix_map[suffix]
+        cleaned = cleaned[:-1]
+    cleaned = cleaned.replace("%", "").strip()
+    try:
+        return float(cleaned) * multiplier
+    except ValueError:
+        return None
+
+
+def _calendar_surprise(
+    actual: str | None,
+    forecast: str | None,
+) -> float | None:
+    actual_value = _calendar_numeric_value(actual)
+    forecast_value = _calendar_numeric_value(forecast)
+    if actual_value is None or forecast_value is None:
+        return None
+    return round(actual_value - forecast_value, 4)
+
+
 @dataclass(frozen=True)
 class StoredEventRecord:
     source: str
@@ -3843,8 +3916,8 @@ class SQLiteEngineStore:
         country: str | None = None,
         category: str | None = None,
     ) -> list[StoredEventRecord]:
-        cutoff = int((utc_now() - timedelta(days=days)).timestamp())
-        conditions = ["timestamp >= ?"]
+        cutoff = (utc_now() - timedelta(days=days)).isoformat()
+        conditions = ["datetime(event_time_utc) >= datetime(?)"]
         params: list[Any] = [cutoff]
         if released_only:
             conditions.append("actual IS NOT NULL")
@@ -3852,24 +3925,23 @@ class SQLiteEngineStore:
             conditions.append("importance = ?")
             params.append(importance)
         if country:
-            conditions.append("country = ?")
+            conditions.append("country_code = ?")
             params.append(country)
         if category:
             conditions.append("category = ?")
             params.append(category)
         params.append(limit)
-        # Only fixed SQL fragments are appended here; user input stays parameterized.
         with self._connection(commit=False) as connection:
             rows = connection.execute(
                 f"""
-                SELECT * FROM calendar_events
+                SELECT * FROM cal_econ_event
                 WHERE {' AND '.join(conditions)}
-                ORDER BY timestamp DESC, id DESC
+                ORDER BY datetime(event_time_utc) DESC, provider_event_id DESC
                 LIMIT ?
                 """,
                 params,
             ).fetchall()
-        return [self._row_to_event(row) for row in rows]
+        return [self._row_to_econ_event(row) for row in rows]
 
     def list_upcoming_events(
         self,
@@ -3879,14 +3951,14 @@ class SQLiteEngineStore:
         country: str | None = None,
         category: str | None = None,
     ) -> list[StoredEventRecord]:
-        now_epoch = int(utc_now().timestamp())
-        conditions = ["timestamp >= ?"]
-        params: list[Any] = [now_epoch]
+        now_iso = utc_now().isoformat()
+        conditions = ["datetime(event_time_utc) >= datetime(?)"]
+        params: list[Any] = [now_iso]
         if importance:
             conditions.append("importance = ?")
             params.append(importance)
         if country:
-            conditions.append("country = ?")
+            conditions.append("country_code = ?")
             params.append(country)
         if category:
             conditions.append("category = ?")
@@ -3895,14 +3967,14 @@ class SQLiteEngineStore:
         with self._connection(commit=False) as connection:
             rows = connection.execute(
                 f"""
-                SELECT * FROM calendar_events
+                SELECT * FROM cal_econ_event
                 WHERE {' AND '.join(conditions)}
-                ORDER BY timestamp ASC, id ASC
+                ORDER BY datetime(event_time_utc) ASC, provider_event_id ASC
                 LIMIT ?
                 """,
                 params,
             ).fetchall()
-        return [self._row_to_event(row) for row in rows]
+        return [self._row_to_econ_event(row) for row in rows]
 
     def list_events_in_range(
         self,
@@ -3915,15 +3987,20 @@ class SQLiteEngineStore:
         category: str | None = None,
         released_only: bool = False,
     ) -> list[StoredEventRecord]:
-        conditions = ["timestamp >= ?", "timestamp <= ?"]
-        params: list[Any] = [date_from, date_to]
+        from_iso = datetime.fromtimestamp(date_from, tz=timezone.utc).isoformat()
+        to_iso = datetime.fromtimestamp(date_to, tz=timezone.utc).isoformat()
+        conditions = [
+            "datetime(event_time_utc) >= datetime(?)",
+            "datetime(event_time_utc) <= datetime(?)",
+        ]
+        params: list[Any] = [from_iso, to_iso]
         if released_only:
             conditions.append("actual IS NOT NULL")
         if importance:
             conditions.append("importance = ?")
             params.append(importance)
         if country:
-            conditions.append("country = ?")
+            conditions.append("country_code = ?")
             params.append(country)
         if category:
             conditions.append("category = ?")
@@ -3932,14 +4009,14 @@ class SQLiteEngineStore:
         with self._connection(commit=False) as connection:
             rows = connection.execute(
                 f"""
-                SELECT * FROM calendar_events
+                SELECT * FROM cal_econ_event
                 WHERE {' AND '.join(conditions)}
-                ORDER BY timestamp ASC, id ASC
+                ORDER BY datetime(event_time_utc) ASC, provider_event_id ASC
                 LIMIT ?
                 """,
                 params,
             ).fetchall()
-        return [self._row_to_event(row) for row in rows]
+        return [self._row_to_econ_event(row) for row in rows]
 
     def list_today_events(
         self,
@@ -3967,17 +4044,21 @@ class SQLiteEngineStore:
         indicator_keyword: str,
         limit: int = 12,
     ) -> list[StoredEventRecord]:
+        conditions = ["actual IS NOT NULL"]
+        params: list[Any] = []
+        _add_calendar_keyword_filter(conditions, params, indicator_keyword)
+        params.append(limit)
         with self._connection(commit=False) as connection:
             rows = connection.execute(
-                """
-                SELECT * FROM calendar_events
-                WHERE LOWER(indicator) LIKE ? AND actual IS NOT NULL
-                ORDER BY timestamp DESC, id DESC
+                f"""
+                SELECT * FROM cal_econ_event
+                WHERE {' AND '.join(conditions)}
+                ORDER BY datetime(event_time_utc) DESC, provider_event_id DESC
                 LIMIT ?
                 """,
-                (f"%{indicator_keyword.lower()}%", limit),
+                params,
             ).fetchall()
-        return [self._row_to_event(row) for row in rows]
+        return [self._row_to_econ_event(row) for row in rows]
 
     def latest_market_prices(self) -> list[MarketPriceRecord]:
         with self._connection(commit=False) as connection:
@@ -4059,21 +4140,61 @@ class SQLiteEngineStore:
     def latest_released_event(self, *, indicator_keyword: str | None = None) -> StoredEventRecord | None:
         params: list[Any] = []
         conditions = ["actual IS NOT NULL"]
-        if indicator_keyword:
-            conditions.append("LOWER(indicator) LIKE ?")
-            params.append(f"%{indicator_keyword.lower()}%")
-        # Only fixed SQL fragments are appended here; user input stays parameterized.
+        _add_calendar_keyword_filter(conditions, params, indicator_keyword)
         with self._connection(commit=False) as connection:
             row = connection.execute(
                 f"""
-                SELECT * FROM calendar_events
+                SELECT * FROM cal_econ_event
                 WHERE {' AND '.join(conditions)}
-                ORDER BY importance DESC, timestamp DESC, id DESC
+                ORDER BY
+                    CASE importance
+                        WHEN 'high' THEN 3
+                        WHEN 'medium' THEN 2
+                        WHEN 'low' THEN 1
+                        ELSE 0
+                    END DESC,
+                    datetime(event_time_utc) DESC,
+                    provider_event_id DESC
                 LIMIT 1
                 """,
                 params,
             ).fetchone()
-        return self._row_to_event(row) if row is not None else None
+        return self._row_to_econ_event(row) if row is not None else None
+
+    def _row_to_econ_event(self, row: sqlite3.Row) -> StoredEventRecord:
+        parsed_event_time = datetime.fromisoformat(
+            str(row["event_time_utc"]).replace("Z", "+00:00")
+        )
+        if parsed_event_time.tzinfo is None:
+            parsed_event_time = parsed_event_time.replace(tzinfo=timezone.utc)
+        timestamp = int(parsed_event_time.timestamp())
+        return StoredEventRecord(
+            source=row["provider"],
+            event_id=f"{row['provider']}:{row['provider_event_id']}",
+            timestamp=timestamp,
+            country=row["country_code"],
+            indicator=row["title"],
+            category=row["category"],
+            importance=row["importance"] or "medium",
+            actual=row["actual"],
+            forecast=row["forecast"] or row["consensus_forecast"],
+            previous=row["previous"],
+            revised_previous=row["revised"],
+            surprise=_calendar_surprise(
+                row["actual"],
+                row["forecast"] or row["consensus_forecast"],
+            ),
+            currency=row["currency"],
+            unit=row["unit"],
+            raw_json={
+                "provider_event_id": row["provider_event_id"],
+                "reference_date": row["reference_date"],
+                "reference_label": row["reference_label"],
+                "source_url": row["source_url"],
+                "content_hash": row["content_hash"],
+            },
+            indicator_id=row["indicator_id"],
+        )
 
     def _row_to_event(self, row: sqlite3.Row) -> StoredEventRecord:
         return StoredEventRecord(
@@ -7684,7 +7805,10 @@ class SQLiteEngineStore:
             "imf_vintages": ("indicator_vintages", "source = ?", ("imf",), "scraped_at"),
             "market": ("market_prices", "1 = 1", tuple(), "scraped_at"),
             "fed": ("central_bank_comms", "source = ?", ("fed",), "scraped_at"),
-            "calendar": ("calendar_events", "1 = 1", tuple(), "scraped_at"),
+            "calendar": (
+                "v_calendar_item", "1 = 1", tuple(),
+                "datetime(observed_at_epoch_ms / 1000, 'unixepoch')",
+            ),
             "news": ("news_articles", "source_feed NOT LIKE 'gov_%'", tuple(), "scraped_at"),
             "gov_reports": ("document", "1 = 1", tuple(), "updated_at"),
             "reddit_trends": ("trend_topics", "provider = ?", ("reddit",), "scraped_at"),
@@ -8172,14 +8296,14 @@ class SQLiteEngineStore:
         with self._connection(commit=False) as connection:
             rows = connection.execute(
                 """
-                SELECT * FROM calendar_events
+                SELECT * FROM cal_econ_event
                 WHERE indicator_id = ? AND actual IS NOT NULL
-                ORDER BY timestamp DESC, id DESC
+                ORDER BY datetime(event_time_utc) DESC, provider_event_id DESC
                 LIMIT ?
                 """,
                 (indicator_id, limit),
             ).fetchall()
-        return [self._row_to_event(row) for row in rows]
+        return [self._row_to_econ_event(row) for row in rows]
 
     def _row_to_calendar_indicator(self, row: sqlite3.Row) -> CalendarIndicatorRecord:
         return CalendarIndicatorRecord(

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -35,7 +35,12 @@ _CALENDAR_KEYWORD_ALIASES: dict[str, tuple[str, ...]] = {
     "cpi": ("consumer price index", "inflation rate"),
     "core cpi": ("consumer price index all items less food and energy",),
     "ppi": ("producer price index",),
-    "nfp": ("nonfarm payroll", "employment situation"),
+    "nfp": (
+        "nonfarm payroll",
+        "non farm payroll",
+        "non-farm payroll",
+        "employment situation",
+    ),
     "pmi": ("purchasing managers", "manufacturing pmi", "services pmi"),
     "gdp": ("gross domestic product",),
 }
@@ -67,7 +72,8 @@ def _calendar_keyword_pattern_sets(
     patterns.update(aliases)
     raw_patterns.update(aliases)
     if connection is not None:
-        for lookup_term in sorted({raw_keyword, base}):
+        lookup_terms = {raw_keyword, base, *aliases}
+        for lookup_term in sorted(term for term in lookup_terms if term):
             like = f"%{lookup_term}%"
             rows = connection.execute(
                 """

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -46,7 +46,9 @@ def _calendar_keyword_patterns(
     *,
     connection: sqlite3.Connection | None = None,
 ) -> list[str]:
-    base = keyword.strip().lower()
+    from ingestion.scrapers._common import normalize_indicator_name
+
+    base = normalize_indicator_name(keyword)
     if not base:
         return []
     patterns = {base}
@@ -67,7 +69,7 @@ def _calendar_keyword_patterns(
             (like, like, like),
         ).fetchall()
         for row in rows:
-            pattern = str(row["pattern"] or "").strip().lower()
+            pattern = normalize_indicator_name(str(row["pattern"] or ""))
             if pattern:
                 patterns.add(pattern)
     return sorted(patterns)

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -52,13 +52,13 @@ def _add_calendar_keyword_filter(
     keyword: str | None,
     *,
     connection: sqlite3.Connection | None = None,
-) -> None:
+) -> bool:
     from ingestion.scrapers._common import normalize_indicator_name
 
     raw_keyword = (keyword or "").strip()
     base = normalize_indicator_name(raw_keyword)
-    if not base:
-        return
+    if not base or not re.search(r"[0-9A-Za-z]", base):
+        return False
     aliases = _CALENDAR_KEYWORD_ALIASES.get(base, ())
     raw_patterns = {raw_keyword, base, *aliases}
     if connection is not None:
@@ -96,7 +96,7 @@ def _add_calendar_keyword_filter(
                     if raw_pattern:
                         raw_patterns.add(raw_pattern)
     if not raw_patterns:
-        return
+        return False
     clauses: list[str] = []
     for pattern in sorted(raw_patterns):
         like = f"%{pattern}%"
@@ -107,6 +107,7 @@ def _add_calendar_keyword_filter(
         ))
         params.extend((like, like, like))
     conditions.append(f"({' OR '.join(clauses)})")
+    return True
 
 
 def _calendar_numeric_value(value: str | None) -> float | None:
@@ -4014,9 +4015,11 @@ class SQLiteEngineStore:
         category: str | None = None,
     ) -> list[StoredEventRecord]:
         cutoff = (utc_now() - timedelta(days=days)).isoformat()
+        now_iso = utc_now().isoformat()
         conditions: list[str] = []
         params: list[Any] = []
         _add_event_time_lower_bound(conditions, params, cutoff)
+        _add_event_time_upper_bound(conditions, params, now_iso)
         if released_only:
             conditions.append("actual IS NOT NULL")
         if importance:
@@ -4145,9 +4148,11 @@ class SQLiteEngineStore:
         with self._connection(commit=False) as connection:
             conditions = ["actual IS NOT NULL"]
             params: list[Any] = []
-            _add_calendar_keyword_filter(
+            matched_keyword = _add_calendar_keyword_filter(
                 conditions, params, indicator_keyword, connection=connection
             )
+            if not matched_keyword:
+                return []
             params.append(limit)
             rows = connection.execute(
                 f"""
@@ -4241,9 +4246,11 @@ class SQLiteEngineStore:
         with self._connection(commit=False) as connection:
             params: list[Any] = []
             conditions = ["actual IS NOT NULL"]
-            _add_calendar_keyword_filter(
+            matched_keyword = _add_calendar_keyword_filter(
                 conditions, params, indicator_keyword, connection=connection
             )
+            if indicator_keyword is not None and not matched_keyword:
+                return None
             row = connection.execute(
                 f"""
                 SELECT * FROM cal_econ_event

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -46,16 +46,7 @@ _CALENDAR_KEYWORD_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 
-def _calendar_keyword_patterns(
-    keyword: str,
-    *,
-    connection: sqlite3.Connection | None = None,
-) -> list[str]:
-    patterns, _ = _calendar_keyword_pattern_sets(keyword, connection=connection)
-    return sorted(patterns)
-
-
-def _calendar_keyword_pattern_sets(
+def _calendar_keyword_patterns_and_raw(
     keyword: str,
     *,
     connection: sqlite3.Connection | None = None,
@@ -119,7 +110,7 @@ def _add_calendar_keyword_filter(
     *,
     connection: sqlite3.Connection | None = None,
 ) -> None:
-    _, raw_patterns = _calendar_keyword_pattern_sets(
+    _, raw_patterns = _calendar_keyword_patterns_and_raw(
         keyword or "", connection=connection
     )
     if not raw_patterns:
@@ -170,26 +161,15 @@ def _calendar_surprise(
     return round(actual_value - forecast_value, 4)
 
 
-def _event_time_lower_bound_clause() -> str:
-    return (
-        "((event_time_precision = 'date' AND date(event_time_utc) >= date(?)) "
-        "OR (event_time_precision != 'date' AND datetime(event_time_utc) >= datetime(?)))"
-    )
-
-
-def _event_time_upper_bound_clause() -> str:
-    return (
-        "((event_time_precision = 'date' AND date(event_time_utc) <= date(?)) "
-        "OR (event_time_precision != 'date' AND datetime(event_time_utc) <= datetime(?)))"
-    )
-
-
 def _add_event_time_lower_bound(
     conditions: list[str],
     params: list[Any],
     value: str,
 ) -> None:
-    conditions.append(_event_time_lower_bound_clause())
+    conditions.append(
+        "((event_time_precision = 'date' AND date(event_time_utc) >= date(?)) "
+        "OR (event_time_precision != 'date' AND datetime(event_time_utc) >= datetime(?)))"
+    )
     params.extend((value, value))
 
 
@@ -198,7 +178,10 @@ def _add_event_time_upper_bound(
     params: list[Any],
     value: str,
 ) -> None:
-    conditions.append(_event_time_upper_bound_clause())
+    conditions.append(
+        "((event_time_precision = 'date' AND date(event_time_utc) <= date(?)) "
+        "OR (event_time_precision != 'date' AND datetime(event_time_utc) <= datetime(?)))"
+    )
     params.extend((value, value))
 
 

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -46,6 +46,49 @@ _CALENDAR_KEYWORD_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 
+_CALENDAR_COUNTRY_ALIASES: dict[str, str] = {
+    "US": "US",
+    "USA": "US",
+    "UNITED STATES": "US",
+    "UNITED STATES OF AMERICA": "US",
+    "CN": "CN",
+    "CHINA": "CN",
+    "JP": "JP",
+    "JAPAN": "JP",
+    "UK": "UK",
+    "GB": "UK",
+    "UNITED KINGDOM": "UK",
+    "EU": "EU",
+    "EURO AREA": "EU",
+    "EUROZONE": "EU",
+    "EUROPEAN UNION": "EU",
+}
+
+_CALENDAR_COUNTRY_DISPLAY: dict[str, str] = {
+    "US": "United States",
+    "CN": "China",
+    "JP": "Japan",
+    "UK": "United Kingdom",
+    "EU": "Euro Area",
+}
+
+
+def _calendar_country_code(value: str) -> str | None:
+    normalized = re.sub(r"[\s_-]+", " ", value.strip().upper())
+    if not normalized:
+        return None
+    if normalized in _CALENDAR_COUNTRY_ALIASES:
+        return _CALENDAR_COUNTRY_ALIASES[normalized]
+    if re.fullmatch(r"[A-Z]{2}", normalized):
+        return normalized
+    return None
+
+
+def _calendar_country_display(country_code: str) -> str:
+    code = (country_code or "").strip().upper()
+    return _CALENDAR_COUNTRY_DISPLAY.get(code, code)
+
+
 def _add_calendar_keyword_filter(
     conditions: list[str],
     params: list[Any],
@@ -166,6 +209,19 @@ def _add_event_time_upper_bound(
         "OR (event_time_precision != 'date' AND datetime(event_time_utc) <= datetime(?)))"
     )
     params.extend((value, value))
+
+
+def _add_calendar_country_filter(
+    conditions: list[str],
+    params: list[Any],
+    country: str,
+) -> None:
+    country_code = _calendar_country_code(country)
+    if country_code is None:
+        conditions.append("1 = 0")
+        return
+    conditions.append("country_code = ?")
+    params.append(country_code)
 
 
 @dataclass(frozen=True)
@@ -4026,8 +4082,7 @@ class SQLiteEngineStore:
             conditions.append("importance = ?")
             params.append(importance)
         if country:
-            conditions.append("country_code = ?")
-            params.append(country)
+            _add_calendar_country_filter(conditions, params, country)
         if category:
             conditions.append("category = ?")
             params.append(category)
@@ -4060,8 +4115,7 @@ class SQLiteEngineStore:
             conditions.append("importance = ?")
             params.append(importance)
         if country:
-            conditions.append("country_code = ?")
-            params.append(country)
+            _add_calendar_country_filter(conditions, params, country)
         if category:
             conditions.append("category = ?")
             params.append(category)
@@ -4101,8 +4155,7 @@ class SQLiteEngineStore:
             conditions.append("importance = ?")
             params.append(importance)
         if country:
-            conditions.append("country_code = ?")
-            params.append(country)
+            _add_calendar_country_filter(conditions, params, country)
         if category:
             conditions.append("category = ?")
             params.append(category)
@@ -4279,9 +4332,9 @@ class SQLiteEngineStore:
         timestamp = int(parsed_event_time.timestamp())
         return StoredEventRecord(
             source=row["provider"],
-            event_id=f"{row['provider']}:{row['provider_event_id']}",
+            event_id=row["provider_event_id"],
             timestamp=timestamp,
-            country=row["country_code"],
+            country=_calendar_country_display(row["country_code"]),
             indicator=row["title"],
             category=row["category"],
             importance=row["importance"] or "medium",
@@ -4299,6 +4352,8 @@ class SQLiteEngineStore:
                 "event_time_utc": row["event_time_utc"],
                 "event_time_precision": row["event_time_precision"],
                 "provider_event_id": row["provider_event_id"],
+                "provider": row["provider"],
+                "country_code": row["country_code"],
                 "reference_date": row["reference_date"],
                 "reference_label": row["reference_label"],
                 "source_url": row["source_url"],
@@ -7919,8 +7974,8 @@ class SQLiteEngineStore:
             "market": ("market_prices", "1 = 1", tuple(), "scraped_at"),
             "fed": ("central_bank_comms", "source = ?", ("fed",), "scraped_at"),
             "calendar": (
-                "v_calendar_item", "1 = 1", tuple(),
-                "datetime(observed_at_epoch_ms / 1000, 'unixepoch')",
+                "v_calendar_item", "1 = 1", (),
+                "strftime('%Y-%m-%dT%H:%M:%f+00:00', observed_at_epoch_ms / 1000.0, 'unixepoch')",
             ),
             "news": ("news_articles", "source_feed NOT LIKE 'gov_%'", tuple(), "scraped_at"),
             "gov_reports": ("document", "1 = 1", tuple(), "updated_at"),

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -46,22 +46,21 @@ _CALENDAR_KEYWORD_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 
-def _calendar_keyword_patterns_and_raw(
-    keyword: str,
+def _add_calendar_keyword_filter(
+    conditions: list[str],
+    params: list[Any],
+    keyword: str | None,
     *,
     connection: sqlite3.Connection | None = None,
-) -> tuple[set[str], set[str]]:
+) -> None:
     from ingestion.scrapers._common import normalize_indicator_name
 
-    base = normalize_indicator_name(keyword)
+    raw_keyword = (keyword or "").strip()
+    base = normalize_indicator_name(raw_keyword)
     if not base:
-        return set(), set()
-    raw_keyword = keyword.strip()
-    patterns = {base}
-    raw_patterns = {raw_keyword, base}
+        return
     aliases = _CALENDAR_KEYWORD_ALIASES.get(base, ())
-    patterns.update(aliases)
-    raw_patterns.update(aliases)
+    raw_patterns = {raw_keyword, base, *aliases}
     if connection is not None:
         lookup_terms = {raw_keyword, base, *aliases}
         for lookup_term in sorted(term for term in lookup_terms if term):
@@ -94,25 +93,8 @@ def _calendar_keyword_patterns_and_raw(
             for row in rows:
                 for column in ("alias_raw", "canonical_raw", "indicator_raw"):
                     raw_pattern = str(row[column] or "").strip()
-                    if not raw_pattern:
-                        continue
-                    raw_patterns.add(raw_pattern)
-                    pattern = normalize_indicator_name(raw_pattern)
-                    if pattern:
-                        patterns.add(pattern)
-    return patterns, raw_patterns
-
-
-def _add_calendar_keyword_filter(
-    conditions: list[str],
-    params: list[Any],
-    keyword: str | None,
-    *,
-    connection: sqlite3.Connection | None = None,
-) -> None:
-    _, raw_patterns = _calendar_keyword_patterns_and_raw(
-        keyword or "", connection=connection
-    )
+                    if raw_pattern:
+                        raw_patterns.add(raw_pattern)
     if not raw_patterns:
         return
     clauses: list[str] = []
@@ -203,6 +185,8 @@ class StoredEventRecord:
     unit: str = ""
     raw_json: dict[str, Any] = field(default_factory=dict)
     indicator_id: str | None = None
+    event_time_utc: str = ""
+    event_time_precision: str = "datetime"
 
 
 @dataclass(frozen=True)
@@ -4305,6 +4289,8 @@ class SQLiteEngineStore:
             currency=row["currency"],
             unit=row["unit"],
             raw_json={
+                "event_time_utc": row["event_time_utc"],
+                "event_time_precision": row["event_time_precision"],
                 "provider_event_id": row["provider_event_id"],
                 "reference_date": row["reference_date"],
                 "reference_label": row["reference_label"],
@@ -4312,6 +4298,8 @@ class SQLiteEngineStore:
                 "content_hash": row["content_hash"],
             },
             indicator_id=row["indicator_id"],
+            event_time_utc=row["event_time_utc"],
+            event_time_precision=row["event_time_precision"] or "datetime",
         )
 
     def _row_to_event(self, row: sqlite3.Row) -> StoredEventRecord:

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -324,6 +324,34 @@ def test_calendar_keyword_filter_matches_acronym_aliases(
     assert [event.event_id for event in events] == ["bls:cpi-official"]
 
 
+def test_calendar_keyword_filter_invalid_keyword_fails_closed(
+    store: SQLiteEngineStore,
+) -> None:
+    with store._connection(commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'bls', 'cpi-invalid-keyword-guard',
+                '2026-04-10T12:30:00+00:00', 'datetime',
+                'US', 'Inflation', 'Consumer Price Index', 'high', '1.0',
+                'invalid-keyword-guard', 1700000000000,
+                '2026-04-23', '2026-04-23'
+            )
+            """
+        )
+
+    assert store.list_indicator_releases(indicator_keyword="!!!", limit=10) == []
+    assert store.latest_released_event(indicator_keyword="!!!") is None
+    assert store.list_indicator_releases(indicator_keyword="%", limit=10) == []
+    assert store.latest_released_event(indicator_keyword="%") is None
+    assert store.list_indicator_releases(indicator_keyword="_", limit=10) == []
+    assert store.latest_released_event(indicator_keyword="_") is None
+
+
 def test_calendar_keyword_filter_uses_raw_title_spellings(
     store: SQLiteEngineStore,
 ) -> None:
@@ -387,6 +415,35 @@ def test_calendar_keyword_filter_preserves_normalized_alias_lookup(
 
     assert latest is not None
     assert latest.event_id == "tradingeconomics:inflation-yoy"
+
+
+def test_recent_events_excludes_future_scheduled_rows(
+    store: SQLiteEngineStore,
+) -> None:
+    past = datetime.now(UTC) - timedelta(hours=1)
+    future = datetime.now(UTC) + timedelta(hours=1)
+    with store._connection(commit=True) as c:
+        c.executemany(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'bls', ?, ?, 'datetime',
+                'US', 'Inflation', ?, 'high', ?,
+                1700000000000, '2026-04-23', '2026-04-23'
+            )
+            """,
+            [
+                ("past-release", past.isoformat(), "Past CPI", "past-release"),
+                ("future-release", future.isoformat(), "Future CPI", "future-release"),
+            ],
+        )
+
+    events = store.list_recent_events(released_only=False, country="US")
+
+    assert [event.event_id for event in events] == ["bls:past-release"]
 
 
 def test_calendar_keyword_filter_keeps_normalized_base_title_match(

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -278,8 +278,9 @@ def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
 def test_latest_released_event_prefers_newest_before_importance(
     store: SQLiteEngineStore,
 ) -> None:
-    older = datetime(2026, 4, 22, 12, tzinfo=timezone.utc)
-    newer = datetime(2026, 4, 23, 12, tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    older = now - timedelta(days=2)
+    newer = now - timedelta(days=1)
     with store._connection(commit=True) as c:
         c.executemany(
             """

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -250,7 +250,7 @@ def test_legacy_calendar_read_helpers_use_economic_lane(
     assert [event.event_id for event in trend] == ["bls:cpi-2026-03"]
 
 
-def test_calendar_keyword_patterns_normalize_keyword_before_alias_lookup(
+def test_calendar_keyword_patterns_match_raw_db_spellings_before_normalizing(
     store: SQLiteEngineStore,
 ) -> None:
     store.seed_calendar_indicators()
@@ -266,6 +266,96 @@ def test_calendar_keyword_patterns_normalize_keyword_before_alias_lookup(
 
     assert "inflation rate mom" in seeded_aliases
     assert "inflation rate yoy" in seeded_aliases
+
+
+def test_calendar_keyword_filter_uses_raw_title_spellings(
+    store: SQLiteEngineStore,
+) -> None:
+    with store._connection(commit=True) as c:
+        c.executemany(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                ?, ?, ?, 'datetime', 'US', 'Inflation', ?, 'high', '1.0', ?,
+                1700000000000, '2026-04-23', '2026-04-23'
+            )
+            """,
+            [
+                (
+                    "bls",
+                    "cpi-mar",
+                    "2026-04-10T12:30:00+00:00",
+                    "CPI (Mar)",
+                    "raw-title",
+                ),
+                (
+                    "bls",
+                    "retail-sales",
+                    "2026-04-11T12:30:00+00:00",
+                    "Retail Sales",
+                    "other-title",
+                ),
+            ],
+        )
+
+    latest = store.latest_released_event(indicator_keyword="CPI (Mar)")
+
+    assert latest is not None
+    assert latest.event_id == "bls:cpi-mar"
+
+
+def test_calendar_keyword_filter_preserves_normalized_alias_lookup(
+    store: SQLiteEngineStore,
+) -> None:
+    store.seed_calendar_indicators()
+    with store._connection(commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'tradingeconomics', 'inflation-yoy',
+                '2026-04-11T12:30:00+00:00', 'datetime',
+                'US', 'Inflation', 'Inflation Rate YoY', 'high', '1.0',
+                'inflation-yoy', 1700000000000, '2026-04-23', '2026-04-23'
+            )
+            """
+        )
+
+    latest = store.latest_released_event(indicator_keyword="Inflation   Rate (Mar)")
+
+    assert latest is not None
+    assert latest.event_id == "tradingeconomics:inflation-yoy"
+
+
+def test_calendar_keyword_filter_keeps_normalized_base_title_match(
+    store: SQLiteEngineStore,
+) -> None:
+    with store._connection(commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'census', 'retail-sales',
+                '2026-04-11T12:30:00+00:00', 'datetime',
+                'US', 'Growth', 'Retail Sales', 'high', '1.0',
+                'retail-sales', 1700000000000, '2026-04-23', '2026-04-23'
+            )
+            """
+        )
+
+    latest = store.latest_released_event(indicator_keyword="Retail Sales (Mar)")
+
+    assert latest is not None
+    assert latest.event_id == "census:retail-sales"
 
 
 def test_legacy_calendar_upcoming_helper_uses_economic_lane(

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -46,6 +46,21 @@ def _indexes(store: SQLiteEngineStore, table: str) -> set[str]:
         }
 
 
+def _index_sql(store: SQLiteEngineStore, table: str) -> dict[str, str]:
+    with store._connection(commit=False) as c:
+        return {
+            row["name"]: row["sql"] or ""
+            for row in c.execute(
+                """
+                SELECT name, sql
+                FROM sqlite_master
+                WHERE type = 'index' AND tbl_name = ?
+                """,
+                (table,),
+            ).fetchall()
+        }
+
+
 def test_schema_creates_six_calendar_tables(store: SQLiteEngineStore) -> None:
     expected = {
         "cal_provider",
@@ -79,6 +94,9 @@ def test_schema_creates_calendar_time_expression_indexes(
         "idx_cal_econ_event_date_indicator",
     }
     assert expected <= _indexes(store, "cal_econ_event")
+    sql_by_name = _index_sql(store, "cal_econ_event")
+    assert "datetime(event_time_utc)" in sql_by_name["idx_cal_econ_event_datetime"]
+    assert "date(event_time_utc)" in sql_by_name["idx_cal_econ_event_date"]
 
 
 def test_view_unions_both_lanes(store: SQLiteEngineStore) -> None:
@@ -119,6 +137,9 @@ def test_view_unions_both_lanes(store: SQLiteEngineStore) -> None:
         ("corporate", "earnings",  None, "AAPL.US", "AAPL Q2 Earnings"),
         ("economic",  "release",   "US", None,       "CPI YoY"),
     ]
+    stats = store.get_source_storage_stats("calendar")
+    assert stats["latest_ts"].startswith("1970-01-01T00:00:00.")
+    assert stats["latest_ts"].endswith("+00:00")
 
 
 def test_cal_provider_seeded(store: SQLiteEngineStore) -> None:
@@ -238,16 +259,17 @@ def test_legacy_calendar_read_helpers_use_economic_lane(
         )
     )
 
-    recent = store.list_recent_events(released_only=True, country="US")
+    recent = store.list_recent_events(released_only=True, country="United States")
     latest = store.latest_released_event(indicator_keyword="cpi")
     trend = store.list_indicator_releases(indicator_keyword="cpi")
 
     assert [event.source for event in recent] == ["bls"]
+    assert recent[0].country == "United States"
     assert latest is not None
     assert latest.source == "bls"
     assert latest.actual == "3.1"
     assert latest.surprise == pytest.approx(-0.1)
-    assert [event.event_id for event in trend] == ["bls:cpi-2026-03"]
+    assert [event.event_id for event in trend] == ["cpi-2026-03"]
 
 
 def test_calendar_keyword_patterns_expand_nfp_provider_spellings(
@@ -293,9 +315,9 @@ def test_calendar_keyword_patterns_expand_nfp_provider_spellings(
 
     assert len(events) == 3
     assert {event.event_id for event in events} == {
-        "tradingeconomics:nfp-te",
-        "forexfactory:nfp-ff",
-        "investing:nfp-investing",
+        "nfp-te",
+        "nfp-ff",
+        "nfp-investing",
     }
 
 
@@ -321,7 +343,7 @@ def test_calendar_keyword_filter_matches_acronym_aliases(
 
     events = store.list_indicator_releases(indicator_keyword="CPI (Mar)", limit=10)
 
-    assert [event.event_id for event in events] == ["bls:cpi-official"]
+    assert [event.event_id for event in events] == ["cpi-official"]
 
 
 def test_calendar_keyword_filter_invalid_keyword_fails_closed(
@@ -388,7 +410,7 @@ def test_calendar_keyword_filter_uses_raw_title_spellings(
     latest = store.latest_released_event(indicator_keyword="CPI (Mar)")
 
     assert latest is not None
-    assert latest.event_id == "bls:cpi-mar"
+    assert latest.event_id == "cpi-mar"
 
 
 def test_calendar_keyword_filter_preserves_normalized_alias_lookup(
@@ -414,7 +436,7 @@ def test_calendar_keyword_filter_preserves_normalized_alias_lookup(
     latest = store.latest_released_event(indicator_keyword="Inflation   Rate (Mar)")
 
     assert latest is not None
-    assert latest.event_id == "tradingeconomics:inflation-yoy"
+    assert latest.event_id == "inflation-yoy"
 
 
 def test_recent_events_excludes_future_scheduled_rows(
@@ -443,7 +465,33 @@ def test_recent_events_excludes_future_scheduled_rows(
 
     events = store.list_recent_events(released_only=False, country="US")
 
-    assert [event.event_id for event in events] == ["bls:past-release"]
+    assert [event.event_id for event in events] == ["past-release"]
+
+
+def test_calendar_country_filter_accepts_iso_codes_outside_aliases(
+    store: SQLiteEngineStore,
+) -> None:
+    past = datetime.now(UTC) - timedelta(hours=1)
+    with store._connection(commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'tradingeconomics', 'de-cpi', ?, 'datetime',
+                'DE', 'Inflation', 'Germany CPI', 'high', '1.0', 'de-cpi',
+                1700000000000, '2026-04-23', '2026-04-23'
+            )
+            """,
+            (past.isoformat(),),
+        )
+
+    events = store.list_recent_events(released_only=True, country="DE")
+
+    assert [event.event_id for event in events] == ["de-cpi"]
+    assert events[0].country == "DE"
 
 
 def test_calendar_keyword_filter_keeps_normalized_base_title_match(
@@ -468,7 +516,7 @@ def test_calendar_keyword_filter_keeps_normalized_base_title_match(
     latest = store.latest_released_event(indicator_keyword="Retail Sales (Mar)")
 
     assert latest is not None
-    assert latest.event_id == "census:retail-sales"
+    assert latest.event_id == "retail-sales"
 
 
 def test_legacy_calendar_upcoming_helper_uses_economic_lane(
@@ -491,8 +539,8 @@ def test_legacy_calendar_upcoming_helper_uses_economic_lane(
             (tomorrow.isoformat(),),
         )
 
-    events = store.list_upcoming_events(country="US", category="Growth")
-    assert [event.event_id for event in events] == ["bea:gdp-future"]
+    events = store.list_upcoming_events(country="United States", category="Growth")
+    assert [event.event_id for event in events] == ["gdp-future"]
 
 
 def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
@@ -519,11 +567,15 @@ def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
         datetime(2026, 4, 23, 23, 59, 59, tzinfo=UTC).timestamp()
     )
 
-    events = store.list_events_in_range(date_from=start, date_to=end)
+    events = store.list_events_in_range(
+        date_from=start,
+        date_to=end,
+        country="United States",
+    )
 
     assert len(events) == 1
     assert events[0].timestamp == start
-    assert events[0].event_id == "tradingeconomics:date-only"
+    assert events[0].event_id == "date-only"
     assert events[0].event_time_utc == "2026-04-23"
     assert events[0].event_time_precision == "date"
     assert events[0].raw_json["event_time_utc"] == "2026-04-23"
@@ -561,7 +613,7 @@ def test_latest_released_event_prefers_newest_before_importance(
     latest = store.latest_released_event()
 
     assert latest is not None
-    assert latest.event_id == "bea:newer-low"
+    assert latest.event_id == "newer-low"
 
 
 def test_fetch_live_calendar_op_is_retired(

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -35,6 +35,14 @@ def _views(store: SQLiteEngineStore) -> set[str]:
         }
 
 
+def _indexes(store: SQLiteEngineStore, table: str) -> set[str]:
+    with store._connection(commit=False) as c:
+        return {
+            r[1]
+            for r in c.execute(f"PRAGMA index_list({table})").fetchall()
+        }
+
+
 def test_schema_creates_six_calendar_tables(store: SQLiteEngineStore) -> None:
     expected = {
         "cal_provider",
@@ -52,6 +60,22 @@ def test_schema_creates_unified_view(store: SQLiteEngineStore) -> None:
     with store._connection(commit=False) as c:
         rows = c.execute("SELECT * FROM v_calendar_item").fetchall()
     assert rows == []
+
+
+def test_schema_creates_calendar_time_expression_indexes(
+    store: SQLiteEngineStore,
+) -> None:
+    expected = {
+        "idx_cal_econ_event_datetime",
+        "idx_cal_econ_event_datetime_provider",
+        "idx_cal_econ_event_datetime_country",
+        "idx_cal_econ_event_datetime_indicator",
+        "idx_cal_econ_event_date",
+        "idx_cal_econ_event_date_provider",
+        "idx_cal_econ_event_date_country",
+        "idx_cal_econ_event_date_indicator",
+    }
+    assert expected <= _indexes(store, "cal_econ_event")
 
 
 def test_view_unions_both_lanes(store: SQLiteEngineStore) -> None:

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -207,6 +207,7 @@ def test_legacy_calendar_read_helpers_use_economic_lane(
     store: SQLiteEngineStore,
 ) -> None:
     now = datetime.now(UTC)
+    released_at = now - timedelta(minutes=1)
     with store._connection(commit=True) as c:
         c.execute(
             """
@@ -222,13 +223,13 @@ def test_legacy_calendar_read_helpers_use_economic_lane(
                 'hash1', 1700000000000, '2026-04-01', '2026-04-01'
             )
             """,
-            (now.isoformat(),),
+            (released_at.isoformat(),),
         )
     store.upsert_calendar_event(
         StoredEventRecord(
             source="legacy",
             event_id="legacy-cpi",
-            timestamp=int(now.timestamp()),
+            timestamp=int(released_at.timestamp()),
             country="US",
             indicator="Legacy CPI",
             category="Inflation",
@@ -246,8 +247,56 @@ def test_legacy_calendar_read_helpers_use_economic_lane(
     assert latest is not None
     assert latest.source == "bls"
     assert latest.actual == "3.1"
-    assert latest.surprise == -0.1
+    assert latest.surprise == pytest.approx(-0.1)
     assert [event.event_id for event in trend] == ["bls:cpi-2026-03"]
+
+
+def test_calendar_keyword_patterns_expand_nfp_provider_spellings(
+    store: SQLiteEngineStore,
+) -> None:
+    store.seed_calendar_indicators()
+    with store._connection(commit=True) as c:
+        c.executemany(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                ?, ?, '2026-04-10T12:30:00+00:00', 'datetime',
+                'US', 'Employment', ?, 'high', '1.0', ?,
+                1700000000000, '2026-04-23', '2026-04-23'
+            )
+            """,
+            [
+                (
+                    "tradingeconomics",
+                    "nfp-te",
+                    "Non Farm Payrolls",
+                    "nfp-te",
+                ),
+                (
+                    "forexfactory",
+                    "nfp-ff",
+                    "Non-Farm Payrolls",
+                    "nfp-ff",
+                ),
+                (
+                    "investing",
+                    "nfp-investing",
+                    "Nonfarm Payrolls",
+                    "nfp-investing",
+                ),
+            ],
+        )
+
+    events = store.list_indicator_releases(indicator_keyword="nfp", limit=10)
+
+    assert {event.event_id for event in events} == {
+        "tradingeconomics:nfp-te",
+        "forexfactory:nfp-ff",
+        "investing:nfp-investing",
+    }
 
 
 def test_calendar_keyword_patterns_match_raw_db_spellings_before_normalizing(

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
-from storage.sqlite import SQLiteEngineStore
+from storage.sqlite import SQLiteEngineStore, StoredEventRecord
 
 
 @pytest.fixture()
@@ -172,6 +173,120 @@ def test_importance_check_constraint_rejects_integer(store: SQLiteEngineStore) -
                 )
                 """
             )
+
+
+def test_legacy_calendar_read_helpers_use_economic_lane(
+    store: SQLiteEngineStore,
+) -> None:
+    now = datetime.now(timezone.utc)
+    with store._connection(commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                reference_date, reference_label, country_code, category, title,
+                importance, currency, unit, actual, previous, forecast,
+                content_hash, observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'bls', 'cpi-2026-03', ?, 'datetime',
+                '2026-03-01', 'March 2026', 'US', 'Inflation', 'Consumer Price Index',
+                'high', 'USD', '%', '3.1', '3.0', '3.2',
+                'hash1', 1700000000000, '2026-04-01', '2026-04-01'
+            )
+            """,
+            (now.isoformat(),),
+        )
+    store.upsert_calendar_event(
+        StoredEventRecord(
+            source="legacy",
+            event_id="legacy-cpi",
+            timestamp=int(now.timestamp()),
+            country="US",
+            indicator="Legacy CPI",
+            category="Inflation",
+            importance="high",
+            actual="9.9",
+            raw_json={},
+        )
+    )
+
+    recent = store.list_recent_events(released_only=True, country="US")
+    latest = store.latest_released_event(indicator_keyword="cpi")
+    trend = store.list_indicator_releases(indicator_keyword="cpi")
+
+    assert [event.source for event in recent] == ["bls"]
+    assert latest is not None
+    assert latest.source == "bls"
+    assert latest.actual == "3.1"
+    assert latest.surprise == -0.1
+    assert [event.event_id for event in trend] == ["bls:cpi-2026-03"]
+
+
+def test_legacy_calendar_upcoming_helper_uses_economic_lane(
+    store: SQLiteEngineStore,
+) -> None:
+    tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
+    with store._connection(commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'bea', 'gdp-future', ?, 'datetime',
+                'US', 'Growth', 'GDP Growth Rate', 'high', 'hash2',
+                1700000000000, '2026-04-01', '2026-04-01'
+            )
+            """,
+            (tomorrow.isoformat(),),
+        )
+
+    events = store.list_upcoming_events(country="US", category="Growth")
+    assert [event.event_id for event in events] == ["bea:gdp-future"]
+
+
+def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
+    store: SQLiteEngineStore,
+) -> None:
+    with store._connection(commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'tradingeconomics', 'date-only', '2026-04-23', 'date',
+                'US', 'Calendar', 'Date Only Release', 'medium', '1.0', 'hash3',
+                1700000000000, '2026-04-23', '2026-04-23'
+            )
+            """
+        )
+    start = int(datetime(2026, 4, 23, tzinfo=timezone.utc).timestamp())
+    end = int(
+        datetime(2026, 4, 23, 23, 59, 59, tzinfo=timezone.utc).timestamp()
+    )
+
+    events = store.list_events_in_range(date_from=start, date_to=end)
+
+    assert len(events) == 1
+    assert events[0].timestamp == start
+    assert events[0].event_id == "tradingeconomics:date-only"
+
+
+def test_fetch_live_calendar_op_is_retired(
+    store: SQLiteEngineStore,
+) -> None:
+    from macro_data.service import LocalMacroDataService
+
+    result = LocalMacroDataService(store=store).invoke("fetch_live_calendar", {})
+    assert result["retired"] is True
+    assert result["total_fetched"] == 0
+    assert result["events"] == []
+    assert result["replacement"]["read"] == (
+        "GET /v1/calendar or service op list_calendar_items"
+    )
 
 
 def test_event_subtype_check_constraint(store: SQLiteEngineStore) -> None:

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -275,6 +275,35 @@ def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
     assert events[0].event_id == "tradingeconomics:date-only"
 
 
+def test_latest_released_event_prefers_newest_before_importance(
+    store: SQLiteEngineStore,
+) -> None:
+    older = datetime(2026, 4, 22, 12, tzinfo=timezone.utc)
+    newer = datetime(2026, 4, 23, 12, tzinfo=timezone.utc)
+    with store._connection(commit=True) as c:
+        c.executemany(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                ?, ?, ?, 'datetime', 'US', 'Inflation', ?, ?, '1.0', ?,
+                1700000000000, '2026-04-23', '2026-04-23'
+            )
+            """,
+            [
+                ("bls", "older-high", older.isoformat(), "CPI", "high", "h1"),
+                ("bea", "newer-low", newer.isoformat(), "GDP", "low", "h2"),
+            ],
+        )
+
+    latest = store.latest_released_event()
+
+    assert latest is not None
+    assert latest.event_id == "bea:newer-low"
+
+
 def test_fetch_live_calendar_op_is_retired(
     store: SQLiteEngineStore,
 ) -> None:

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -206,7 +206,7 @@ def test_importance_check_constraint_rejects_integer(store: SQLiteEngineStore) -
 def test_legacy_calendar_read_helpers_use_economic_lane(
     store: SQLiteEngineStore,
 ) -> None:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     with store._connection(commit=True) as c:
         c.execute(
             """
@@ -361,7 +361,7 @@ def test_calendar_keyword_filter_keeps_normalized_base_title_match(
 def test_legacy_calendar_upcoming_helper_uses_economic_lane(
     store: SQLiteEngineStore,
 ) -> None:
-    tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
+    tomorrow = datetime.now(UTC) + timedelta(days=1)
     with store._connection(commit=True) as c:
         c.execute(
             """
@@ -399,9 +399,9 @@ def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
             )
             """
         )
-    start = int(datetime(2026, 4, 23, tzinfo=timezone.utc).timestamp())
+    start = int(datetime(2026, 4, 23, tzinfo=UTC).timestamp())
     end = int(
-        datetime(2026, 4, 23, 23, 59, 59, tzinfo=timezone.utc).timestamp()
+        datetime(2026, 4, 23, 23, 59, 59, tzinfo=UTC).timestamp()
     )
 
     events = store.list_events_in_range(date_from=start, date_to=end)
@@ -414,7 +414,7 @@ def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
 def test_latest_released_event_prefers_newest_before_importance(
     store: SQLiteEngineStore,
 ) -> None:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     older = now - timedelta(days=2)
     newer = now - timedelta(days=1)
     with store._connection(commit=True) as c:
@@ -476,13 +476,13 @@ def test_event_subtype_check_constraint(store: SQLiteEngineStore) -> None:
 
 def test_calendar_item_dto_extension() -> None:
     """Legacy construction still works; new fields have defaults."""
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
     from contracts import CalendarItem, Importance
 
     legacy = CalendarItem(
         event_id="x",
-        release_time=datetime.now(timezone.utc),
+        release_time=datetime.now(UTC),
         indicator="CPI",
         country="US",
         importance=Importance.HIGH,
@@ -494,7 +494,7 @@ def test_calendar_item_dto_extension() -> None:
 
     corp = CalendarItem(
         event_id="eodhd:abc",
-        release_time=datetime.now(timezone.utc),
+        release_time=datetime.now(UTC),
         indicator="",
         country="",
         importance=Importance.MEDIUM,

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -10,7 +10,6 @@ import pytest
 from storage.sqlite import (
     SQLiteEngineStore,
     StoredEventRecord,
-    _calendar_keyword_patterns_and_raw,
 )
 
 
@@ -300,22 +299,29 @@ def test_calendar_keyword_patterns_expand_nfp_provider_spellings(
     }
 
 
-def test_calendar_keyword_patterns_match_raw_db_spellings_before_normalizing(
+def test_calendar_keyword_filter_matches_acronym_aliases(
     store: SQLiteEngineStore,
 ) -> None:
     store.seed_calendar_indicators()
-
-    direct_aliases, _ = _calendar_keyword_patterns_and_raw("CPI (Mar)")
-    assert "consumer price index" in direct_aliases
-
-    with store._connection(commit=False) as c:
-        seeded_aliases, _ = _calendar_keyword_patterns_and_raw(
-            "Inflation   Rate (Mar)",
-            connection=c,
+    with store._connection(commit=True) as c:
+        c.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc, event_time_precision,
+                country_code, category, title, importance, actual, content_hash,
+                observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (
+                'bls', 'cpi-official', '2026-04-10T12:30:00+00:00',
+                'datetime', 'US', 'Inflation', 'Consumer Price Index',
+                'high', '1.0', 'cpi-official', 1700000000000,
+                '2026-04-23', '2026-04-23'
+            )
+            """
         )
 
-    assert "inflation rate mom" in seeded_aliases
-    assert "inflation rate yoy" in seeded_aliases
+    events = store.list_indicator_releases(indicator_keyword="CPI (Mar)", limit=10)
+
+    assert [event.event_id for event in events] == ["bls:cpi-official"]
 
 
 def test_calendar_keyword_filter_uses_raw_title_spellings(
@@ -435,6 +441,8 @@ def test_legacy_calendar_upcoming_helper_uses_economic_lane(
 def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
     store: SQLiteEngineStore,
 ) -> None:
+    from macro_data.service import LocalMacroDataService
+
     with store._connection(commit=True) as c:
         c.execute(
             """
@@ -459,6 +467,14 @@ def test_legacy_calendar_range_helper_handles_date_precision_as_utc(
     assert len(events) == 1
     assert events[0].timestamp == start
     assert events[0].event_id == "tradingeconomics:date-only"
+    assert events[0].event_time_utc == "2026-04-23"
+    assert events[0].event_time_precision == "date"
+    assert events[0].raw_json["event_time_utc"] == "2026-04-23"
+    assert events[0].raw_json["event_time_precision"] == "date"
+
+    result = LocalMacroDataService(store=store).invoke("get_latest_released_event", {})
+    assert result["event"]["event_time_utc"] == "2026-04-23"
+    assert result["event"]["event_time_precision"] == "date"
 
 
 def test_latest_released_event_prefers_newest_before_importance(
@@ -499,6 +515,7 @@ def test_fetch_live_calendar_op_is_retired(
     result = LocalMacroDataService(store=store).invoke("fetch_live_calendar", {})
     assert result["retired"] is True
     assert result["total_fetched"] == 0
+    assert result["returned"] == 0
     assert result["events"] == []
     assert result["replacement"] == {
         "read": "GET /v1/calendar or service op list_calendar_items",

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -10,7 +10,7 @@ import pytest
 from storage.sqlite import (
     SQLiteEngineStore,
     StoredEventRecord,
-    _calendar_keyword_patterns,
+    _calendar_keyword_patterns_and_raw,
 )
 
 
@@ -292,6 +292,7 @@ def test_calendar_keyword_patterns_expand_nfp_provider_spellings(
 
     events = store.list_indicator_releases(indicator_keyword="nfp", limit=10)
 
+    assert len(events) == 3
     assert {event.event_id for event in events} == {
         "tradingeconomics:nfp-te",
         "forexfactory:nfp-ff",
@@ -304,11 +305,11 @@ def test_calendar_keyword_patterns_match_raw_db_spellings_before_normalizing(
 ) -> None:
     store.seed_calendar_indicators()
 
-    direct_aliases = _calendar_keyword_patterns("CPI (Mar)")
+    direct_aliases, _ = _calendar_keyword_patterns_and_raw("CPI (Mar)")
     assert "consumer price index" in direct_aliases
 
     with store._connection(commit=False) as c:
-        seeded_aliases = _calendar_keyword_patterns(
+        seeded_aliases, _ = _calendar_keyword_patterns_and_raw(
             "Inflation   Rate (Mar)",
             connection=c,
         )
@@ -499,9 +500,11 @@ def test_fetch_live_calendar_op_is_retired(
     assert result["retired"] is True
     assert result["total_fetched"] == 0
     assert result["events"] == []
-    assert result["replacement"]["read"] == (
-        "GET /v1/calendar or service op list_calendar_items"
-    )
+    assert result["replacement"] == {
+        "read": "GET /v1/calendar or service op list_calendar_items",
+        "schedule_refresh": "calendar_econ_refresh_schedules",
+        "value_sweep": "calendar_econ_sweep_values",
+    }
 
 
 def test_event_subtype_check_constraint(store: SQLiteEngineStore) -> None:

--- a/tests/test_calendar_two_lane_schema.py
+++ b/tests/test_calendar_two_lane_schema.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from storage.sqlite import SQLiteEngineStore, StoredEventRecord
+from storage.sqlite import (
+    SQLiteEngineStore,
+    StoredEventRecord,
+    _calendar_keyword_patterns,
+)
 
 
 @pytest.fixture()
@@ -244,6 +248,24 @@ def test_legacy_calendar_read_helpers_use_economic_lane(
     assert latest.actual == "3.1"
     assert latest.surprise == -0.1
     assert [event.event_id for event in trend] == ["bls:cpi-2026-03"]
+
+
+def test_calendar_keyword_patterns_normalize_keyword_before_alias_lookup(
+    store: SQLiteEngineStore,
+) -> None:
+    store.seed_calendar_indicators()
+
+    direct_aliases = _calendar_keyword_patterns("CPI (Mar)")
+    assert "consumer price index" in direct_aliases
+
+    with store._connection(commit=False) as c:
+        seeded_aliases = _calendar_keyword_patterns(
+            "Inflation   Rate (Mar)",
+            connection=c,
+        )
+
+    assert "inflation rate mom" in seeded_aliases
+    assert "inflation rate yoy" in seeded_aliases
 
 
 def test_legacy_calendar_upcoming_helper_uses_economic_lane(

--- a/tests/test_ingestion_orchestrator.py
+++ b/tests/test_ingestion_orchestrator.py
@@ -221,6 +221,17 @@ class SourceFamilyTaggingTest(unittest.TestCase):
         self.assertEqual(by_name["reddit_trends"], "trend")
         self.assertEqual(by_name["rate_probability"], "signal")
 
+    def test_calendar_source_is_retired_noop(self) -> None:
+        orch = self._build_orchestrator()
+        report = orch.run_source("calendar")
+        self.assertEqual(report.source, "calendar")
+        self.assertEqual(report.stored, 0)
+        self.assertIsNone(report.fetched)
+        self.assertNotIn("calendar", orch._default_refresh_order)
+        orch.investing.fetch_range.assert_not_called()
+        orch.forexfactory.fetch.assert_not_called()
+        orch.tradingeconomics.fetch.assert_not_called()
+
     def test_registered_definition_picks_up_family_from_registry(self) -> None:
         orch = self._build_orchestrator()
         orch.register_source(

--- a/tests/test_source_capabilities.py
+++ b/tests/test_source_capabilities.py
@@ -153,6 +153,23 @@ def test_sync_latest_records_checkpoint_and_run() -> None:
     assert runs[0]["status"] == "success"
 
 
+def test_default_calendar_capability_is_discovery_only() -> None:
+    store = _make_store()
+    manager = SourceCapabilityManager(store)
+
+    capability = store.get_source_capability("calendar")
+    assert capability is not None
+    assert capability["supports_latest_sync"] is False
+    assert capability["is_default_scheduled"] is False
+
+    entities = manager.list_entities("calendar", limit=20)["entities"]
+    ids = {entity["entity_id"] for entity in entities}
+    assert {"tradingeconomics", "eodhd", "bls", "nar"} <= ids
+    assert manager.sync_latest("calendar") == {
+        "error": "latest sync unavailable for calendar"
+    }
+
+
 def _make_manager_with_fake_adapter() -> SourceCapabilityManager:
     """Minimal manager for health-dashboard tests — one trivial adapter
     keeps the sources array non-empty so we exercise the calendar


### PR DESCRIPTION
## Scope

Closes #8

Retires the legacy HTML-scraped calendar path after the two-lane calendar stack, official-source connectors, parity harness, and /v1/calendar surface have landed.

Changes:
- Removes the legacy `calendar` source from the default refresh order and turns explicit `run_source("calendar")` into an inert compatibility no-op.
- Changes `fetch_live_calendar` to return a retired-state response pointing callers to `GET /v1/calendar`, `calendar_econ_refresh_schedules`, and `calendar_econ_sweep_values`.
- Reroutes legacy read helpers from `calendar_events` to `cal_econ_event`.
- Preserves date-precision TE rows with UTC semantics and normalized SQLite datetime filtering.
- Keeps acronym keyword lookups such as `cpi` working against long official titles like Consumer Price Index.
- Computes legacy surprise values from economic-lane `actual` and forecast fields.
- Updates source capability metadata so calendar is discovery-only and reports storage freshness from observed ingest time.
- Updates architecture and storage docs for the retirement state.

## Review

Codex review round 1 found date-precision filtering/timezone, capability latest-sync, and storage freshness issues. Fixed with regression coverage.

Codex review round 2 found acronym keyword lookup and surprise-summary regressions. Fixed with regression coverage.

## Verification

- `python3 -m py_compile src/storage/sqlite.py src/ingestion/sources.py src/ingestion/source_capabilities.py src/macro_data/service.py` -> passed.
- `PYTHONPATH=src pytest tests/test_calendar_two_lane_schema.py tests/test_ingestion_orchestrator.py tests/test_source_capabilities.py` -> 35 passed.
- `PYTHONPATH=src pytest tests/test_calendar_http_route.py` -> 20 passed. This route test requires localhost socket binding.
- `git diff --check` -> passed.
