### PR TITLE
fix(calendar): #33 — dedup CAO GDP archive republications

### DIFF
--- a/src/ingestion/calendar/cao_gdp_api/scraper.py
+++ b/src/ingestion/calendar/cao_gdp_api/scraper.py
@@ -190,10 +190,15 @@ def parse_gdp_archive_html(
     *,
     base_url: str,
 ) -> list[CaoGdpReleaseEntry]:
-    """Extract GDP release rows from one yearly archive page."""
+    """Extract GDP release rows from one yearly archive page.
+
+    CAO occasionally republishes a ``(reference_date, stage)`` pair after
+    annual revisions; when that happens, keep the row with the most recent
+    ``release_date`` so downstream sees the latest revision anchor.
+    """
     soup = BeautifulSoup(html, "html.parser")
-    entries: list[CaoGdpReleaseEntry] = []
-    seen: set[tuple[date, str]] = set()
+    by_key: dict[tuple[date, str], CaoGdpReleaseEntry] = {}
+    order: list[tuple[date, str]] = []
     for row in soup.find_all("tr"):
         cells = row.find_all(["td", "th"], recursive=False)
         if len(cells) < 2:
@@ -208,23 +213,40 @@ def parse_gdp_archive_html(
         reference_date, reference_label = _parse_reference_period(title)
         stage = _parse_release_stage(title)
         key = (reference_date, stage)
-        if key in seen:
-            raise CaoGdpArchiveParseError(
-                f"duplicate CAO GDP archive row: {reference_date} {stage}"
-            )
-        seen.add(key)
         report_url = urljoin(base_url, str(anchor["href"]).strip())
-        entries.append(
-            CaoGdpReleaseEntry(
-                reference_date=reference_date,
-                reference_label=reference_label,
-                release_date=release_date,
-                release_stage=stage,
-                report_url=report_url,
-                release_title=title,
-            )
+        candidate = CaoGdpReleaseEntry(
+            reference_date=reference_date,
+            reference_label=reference_label,
+            release_date=release_date,
+            release_stage=stage,
+            report_url=report_url,
+            release_title=title,
         )
-    return entries
+        existing = by_key.get(key)
+        if existing is None:
+            by_key[key] = candidate
+            order.append(key)
+            continue
+        if candidate.release_date > existing.release_date:
+            logger.info(
+                "cao_gdp archive republished %s %s; keeping release_date=%s "
+                "over %s",
+                reference_date,
+                stage,
+                candidate.release_date,
+                existing.release_date,
+            )
+            by_key[key] = candidate
+        else:
+            logger.info(
+                "cao_gdp archive republished %s %s; keeping release_date=%s "
+                "over %s",
+                reference_date,
+                stage,
+                existing.release_date,
+                candidate.release_date,
+            )
+    return [by_key[key] for key in order]
 
 
 _HASH_FIELDS: tuple[str, ...] = (

--- a/tests/test_cao_gdp_calendar_api_scaffold.py
+++ b/tests/test_cao_gdp_calendar_api_scaffold.py
@@ -112,13 +112,16 @@ def test_archive_parser_extracts_staged_releases() -> None:
     assert entries[2].report_url.endswith("/2025/qe253_2/gdemenuea.html")
 
 
-def test_archive_parser_raises_on_duplicate_stage() -> None:
+def test_archive_parser_dedups_republished_release() -> None:
     html = """<html><body><table><tbody>
-    <tr><td>Dec 8, 2025</td><td><a href="/a.html">Quarterly Estimates of GDP for Jul.-Sep.2025 (The Second preliminary Estimates)</a></td></tr>
-    <tr><td>Dec 9, 2025</td><td><a href="/b.html">Quarterly Estimates of GDP for Jul.-Sep.2025 (The Second preliminary Estimates)</a></td></tr>
+    <tr><td>Jun 10, 2024</td><td><a href="/2024/qe241_2/gdemenuea.html">Quarterly Estimates of GDP for Jan.-Mar.2024 (The Second preliminary Estimates)</a></td></tr>
+    <tr><td>Dec  8, 2024</td><td><a href="/2024/qe241_2/gdemenuea.html">Quarterly Estimates of GDP for Jan.-Mar.2024 (The Second preliminary Estimates)</a></td></tr>
     </tbody></table></body></html>"""
-    with pytest.raises(CaoGdpArchiveParseError):
-        parse_gdp_archive_html(html, base_url=archive_year_url(2025))
+    entries = parse_gdp_archive_html(html, base_url=archive_year_url(2024))
+    assert len(entries) == 1
+    assert entries[0].reference_date == date(2024, 3, 31)
+    assert entries[0].release_stage == SECOND_PRELIMINARY
+    assert entries[0].release_date == date(2024, 12, 8)
 
 
 def test_build_report_url_matches_archive_shape() -> None:


### PR DESCRIPTION
## Summary
- Replace the hard-`raise` on duplicate `(reference_date, stage)` rows with a dedup that keeps the most recent `release_date` and preserves archive ordering.
- Log the dedup at INFO so republications are observable.
- Update the parser test that previously asserted the raise — now asserts dedup behavior.

## Why
ESRI republishes second-preliminary rows after the annual revision cycle (the original Q1 2024 second-preliminary released ~Jun 2024 reappears later in the archive once benchmark/baseline updates land). The first production fire of `calendar-schedule-refresh.timer` on 2026-04-26 04:00 UTC tripped the parser raise; this fix lets the schedule refresh succeed and pins the latest revision anchor.

## Codex review — deferred P2
Codex flagged that when an annual revision arrives **after** the original release value has been ingested, the schedule row gets the new `release_date`/`report_url` under the same `provider_event_id`, but `project_schedule_events` preserves the existing `actual`, and `_discover_pending_releases` only plans rows where `actual IS NULL`. So the revised CSV is never refetched and the database pairs the new revision anchor with the old actual.

This is a real correctness gap, but it lives in value-side projection / discovery, which the issue body scoped out (`Out of scope: Reworking schedule-side projection`). Filing a follow-up issue rather than expanding this slice.

## Test plan
- [x] `pytest tests/test_cao_gdp_calendar_api_scaffold.py` — 21 passed
- [x] `pytest tests/ -k calendar` — 798 passed

Closes #33