### PR TITLE
fix(calendar): #34 — INE button-wrapped section headers

### DIFF
--- a/src/ingestion/calendar/ine_api/schedule.py
+++ b/src/ingestion/calendar/ine_api/schedule.py
@@ -164,7 +164,9 @@ def _section_rows_from_tables(html: str) -> dict[str, list[tuple[date, str, str]
     }
     current: str | None = None
     current_year: int | None = None
-    for node in soup.find_all(["h1", "h2", "h3", "h4", "caption", "p", "li", "tr"]):
+    for node in soup.find_all(
+        ["h1", "h2", "h3", "h4", "caption", "p", "li", "tr", "button"]
+    ):
         node_text = unicodedata.normalize(
             "NFKC", node.get_text(" ", strip=True),
         ).strip()
@@ -174,11 +176,18 @@ def _section_rows_from_tables(html: str) -> dict[str, list[tuple[date, str, str]
         year_match = re.search(r"calendario\s+(\d{4})", norm)
         if year_match:
             current_year = int(year_match.group(1))
+        node_name = getattr(node, "name", "")
+        is_publication_header = node_name == "button" and "tit" in (
+            node.get("class") or []
+        )
         section = _section_key(node_text)
         if section is not None:
             current = section
             continue
-        if current is None or getattr(node, "name", "") != "tr":
+        if is_publication_header:
+            current = None
+            continue
+        if current is None or node_name != "tr":
             continue
         cells = [
             unicodedata.normalize("NFKC", cell.get_text(" ", strip=True)).strip()

--- a/tests/fixtures/ine_calendar/calendar_2026_live.html
+++ b/tests/fixtures/ine_calendar/calendar_2026_live.html
@@ -1,0 +1,10811 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<title>INEbase / Calendario de disponibilidad de estadísticas del INE</title>
+ <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta charset="UTF-8">
+<link rel="shortcut icon" href="/menus/img/favicon.ico" type="image/x-icon">
+<link href="/menus/img/favicon.png" rel="apple-touch-icon">
+<link href="/menus/img/apple-touch-icon-57x57-precomposed.png" rel="apple-touch-icon" sizes="57x57">
+<link href="/menus/img/apple-touch-icon-60x60-precomposed.png" rel="apple-touch-icon" sizes="60x60">
+<link href="/menus/img/apple-touch-icon-72x72-precomposed.png" rel="apple-touch-icon" sizes="76x76">
+<link href="/menus/img/apple-touch-icon-76x76-precomposed.png" rel="apple-touch-icon" sizes="76x76">
+<link href="/menus/img/apple-touch-icon-114x114-precomposed.png" rel="apple-touch-icon" sizes="114x114">
+<link href="/menus/img/apple-touch-icon-120x120-precomposed.png" rel="apple-touch-icon" sizes="120x120">
+<link href="/menus/img/apple-touch-icon-144x144-precomposed.png" rel="apple-touch-icon" sizes="144x144">
+<link href="/menus/img/apple-touch-icon-152x152-precomposed.png" rel="apple-touch-icon" sizes="152x152">
+<link href="/menus/img/apple-touch-icon-160x160-precomposed.png" rel="apple-touch-icon" sizes="160x160">
+<link href="/menus/img/apple-touch-icon-180x180-precomposed.png" rel="apple-touch-icon" sizes="180x180">
+<link href="/menus/img/favicon-192x192.png" rel="icon" sizes="192x192">
+<link href="/menus/img/favicon-160x160.png" rel="icon" sizes="160x160">
+<link href="/menus/img/favicon-128x128.png" rel="icon" sizes="128x128">
+<link href="/menus/img/favicon-96x96.png" rel="icon" sizes="96x96">
+<link href="/menus/img/favicon-32x32.png" rel="icon" sizes="32x32">
+<link href="/menus/img/favicon-16x16.png" rel="icon" sizes="16x16">
+<meta property="og:locale" content="es_ES" >
+	<meta property="og:type" content="website">
+<meta property="og:site_name" content="INE">
+<meta property="og:image" content="https://www.ine.es/menus/_b/img/logoINESocial.png">
+<meta property="og:image:secure_url" content="https://www.ine.es/menus/_b/img/logoINESocial.png">
+<meta property="og:image:alt" content="Logo">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="326">
+<meta property="og:image:height" content="126">
+<meta name="description" content="INE. Instituto Nacional de Estad&#237;stica. National Statistics Institute. Spanish Statistical Office. El INE elabora y distribuye estadisticas de Espana. Este servidor contiene: Censos de Poblacion y Viviendas 2001, Informacion general, Productos de difusion, Espana en cifras, Datos coyunturales, Datos municipales, etc.. Q2016.es">
+<meta name="keywords" content="Censos poblacion viviendas, ine, espa&#241;a, estadistica, statistics, instituto nacional de estad&#237;stica, National Statistics Institute, estad&#237;stica, coyuntura, precios, poblaci&#243;n, spain, consumer prices, statistics in spanish, statistical agency, datos estad&#237;sticos, precios de consumo de Espa&#241;a, Q2016.es">
+<meta content="True" name="HandheldFriendly">
+<meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=yes">
+<script type="text/javascript" src="/dynt3/ruxitagentjs_ICA7NVfgqrux_10335260306043831.js" data-dtconfig="app=50b3efb0f7e34fcb|owasp=1|featureHash=ICA7NVfgqrux|srsr=1000|rdnt=1|uxrgce=1|cuc=c132n50s|mel=100000|expw=1|dpvc=1|lastModification=1776651906948|postfix=c132n50s|tp=500,50,0|srbbv=2|agentUri=/dynt3/ruxitagentjs_ICA7NVfgqrux_10335260306043831.js|reportUrl=/dynt3/rb_bf23632fbc|rid=RID_1228884008|rpid=-1596238389|domain=ine.es"></script><script type="application/ld+json" id="Organization">
+{
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id" :"https://www.ine.es#Organization",
+    "name": "INE - Instituto Nacional de Estadística",
+    "url": "https://www.ine.es/",
+    "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Madrid, España",
+        "postalCode": "28050",
+        "streetAddress": "Avenida de Manoteras, 50-52"
+    },
+    "contactPoint": [
+        {
+        "@type": "ContactPoint",
+        "contactType" : "Escribir a InfoINE",
+        "url": "https://www.ine.es/infoine/"
+    },
+    {
+        "@type": "ContactPoint",
+        "telephone": "(+34) 91-583-91-00",
+        "faxNumber": "(+34) 91-583-91-58",
+        "contactType" : "Información al público y centralita",
+        "hoursAvailable":[
+            {
+                "@type": "OpeningHoursSpecification",
+                "dayOfWeek": [ "Monday", "Tuesday", "Wednesday", "Thursday"],
+                "opens": "09:00",
+                "closes": "14:00"
+            },
+            {
+                "@type": "OpeningHoursSpecification",
+                "dayOfWeek": [ "Monday", "Tuesday", "Wednesday", "Thursday"],
+                "opens": "16:00",
+                "closes": "18:00"
+            },
+            {
+                "@type": "OpeningHoursSpecification",
+                "dayOfWeek": [ "Friday"],
+                "opens": "09:00",
+                "closes": "14:00"            
+            }
+        ]
+    },
+    {
+        "@type": "ContactPoint",
+        "telephone": "(+34) 91-583-94-38",
+        "faxNumber": "(+34) 91-583-45-65",
+        "contactType" : "Librería Índice",
+        "email": "indice@ine.es"
+    },
+    {
+        "@type": "ContactPoint",
+        "telephone": "(+34) 91-583-94-11",
+        "contactType" : "Biblioteca",
+        "email": "biblioteca@ine.es"
+    }
+    ],
+    "logo": [
+        {
+            "@type": "ImageObject",
+            "@id": "https://www.ine.es/#logo",
+            "url": "https://www.ine.es/menus/_b/img/logoINESocial.png",
+            "width": 326,
+            "height": 125,
+            "name": "Logotipo INE (Instituto Nacional de Estadística)"
+        }
+    ],
+    "sameAs": [
+        "https://twitter.com/es_ine",
+        "https://www.youtube.com/@es_ine",
+        "https://www.instagram.com/es_ine_/",
+        "https://es.linkedin.com/company/ine-es"
+    ]
+}
+ 
+</script><script type="application/ld+json" id="WebSite">
+{
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": "https://www.ine.es/#WebSite",            
+    "name": "INE - Instituto Nacional de Estadística",
+    "inLanguage": "es",     
+    "headline": "Instituto Nacional de Estadística",
+    "description" : "El INE elabora y distribuye estadisticas de Espana. Este servidor contiene: Censos de Poblacion y Viviendas 2001, Informacion general, Productos de difusion, Espana en cifras, Datos coyunturales, Datos municipales, etc.. Q2016.es",
+    "url": "https://www.ine.es/", 
+    "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.ine.es/buscar/searchResults.do?L=1&searchString={query}",
+        "query" : "required",
+        "query-input": "required name=query"
+    }
+}</script> 
+<script src="/menus/_b/js/general.js?L=0&chars=UTF-8"></script>
+<script src="/menus/_b/js/component/ine.js?L=0"></script><noscript>
+		
+	</noscript>
+	
+	<script >
+		var sepMil= ".";var sepDec= ",";
+	 var docIsLoaded=false;
+		var HM_Menu_Dir="/menus/";
+		var HM_Menu_DirVersion="/menus/_b/";
+		var HM_imgDir="/menus/img/";
+		var HM_DirJs="/menus/js/";
+		var HM_idioma="es";
+		var HM_idiomaINE="0";
+		var othethickbox="";
+		var INE_Servidor="";
+		var INE_ServidorAbsoluta="https://www.ine.es";
+		var HTMLVersion=5;
+		var showBtnAddCesta=false;
+		var isIE=false;
+	</script>
+	
+	
+	
+	<link rel="preload" as="style" href="/menus/_b/css/component/components.css?L=0&amp;cbar=1&amp;ilp=1&amp;pnls=1&amp;smap=1&amp;emap=1&amp;sv=2&amp;tbtn=1" onload="this.rel='stylesheet'; this.removeAttribute('onload'); this.removeAttribute('as')">
+<noscript>
+    <link rel="stylesheet" href="/menus/_b/css/component/components.css?L=0&amp;cbar=1&amp;ilp=1&amp;pnls=1&amp;smap=1&amp;emap=1&amp;sv=2&amp;tbtn=1">
+</noscript>
+<script defer src="/menus/_b/js/component/components.js?L=0&amp;cbar=1&amp;ilp=1&amp;pnls=1&amp;smap=1&amp;emap=1&amp;sv=2&amp;tbtn=1"></script><script async src="/menus/_b/js/lazy.min.js"></script>
+	<link rel="preload" as="style"  onload="this.rel='stylesheet'; this.removeAttribute('onload'); this.removeAttribute('as')" href="/menus/_b/css/base.css?vnew=1">
+<link rel="preload" as="style"  onload="this.rel='stylesheet'; this.removeAttribute('onload'); this.removeAttribute('as')" href="/menus/_b/css/cabecera_pie.css">
+<link rel="preload" as="style"  onload="this.rel='stylesheet'; this.removeAttribute('onload'); this.removeAttribute('as')" href="/menus/_b/css/cabecera_pie_print.css" media="print">
+<link rel="preload" as="style"  onload="this.rel='stylesheet'; this.removeAttribute('onload'); this.removeAttribute('as')" href="/menus/_b/css/nav.css">
+<link rel="preload" as="style"  onload="this.rel='stylesheet'; this.removeAttribute('onload'); this.removeAttribute('as')" href="/menus/_b/css/nav_print.css" media="print">
+<link rel="preload" as="style"  onload="this.rel='stylesheet'; this.removeAttribute('onload'); this.removeAttribute('as')" href="/menus/_b/css/iconos.css"><noscript>
+	<link rel="stylesheet" href="/menus/_b/css/base.css?vnew=1">
+	<link rel="stylesheet" href="/menus/_b/css/cabecera_pie.css">
+	<link rel="stylesheet" href="/menus/_b/css/cabecera_pie_print.css" media="print">
+	<link rel="stylesheet" href="/menus/_b/css/nav.css">
+	<link rel="stylesheet" href="/menus/_b/css/nav_print.css" media="print">
+	<link rel="stylesheet" href="/menus/_b/css/iconos.css">
+</noscript>
+	
+	
+		<script async src="/menus/NC/status.js?L=0"></script>
+	
+	
+	
+	<link rel="preload" as="style"  onload="this.rel='stylesheet'; this.removeAttribute('onload'); this.removeAttribute('as'); try{loadUrlScript('/menus/_b/js/media.js',null,null);}catch{}" href="/menus/_b/css/media.css">
+			
+	
+	
+	
+	<script async src="/menus/js/cookie.js"></script>
+	
+	<script async src="/menus/plantillas/buscar/js/liveSearch.js" ></script>
+	<script async src="/menus/_b/js/cabecera.js?v=1&qz=0"></script>	
+	<script async src="/ua/urlcorta.js"></script>
+	<script async src="/menus/_b/js/social.js"></script>
+	<script async src="/menus/js/thickboxINE.js"></script>
+	
+	
+		
+	
+<script defer language="JavaScript" src="/menus/plantillas/raizweb/calendario/js/schedule.js"></script>
+<link rel="preload" as="style" href="/menus/plantillas/raizweb/calendario/css/schedule.css" onload="this.rel='stylesheet'; this.onload=null" >
+<link rel="preload" as="style" href="/menus/plantillas/raizweb/calendario/css/estilo.css" onload="this.rel='stylesheet'; this.onload=null">
+<noscript>
+	<link rel="stylesheet" href="/menus/plantillas/raizweb/calendario/cssschedule.css">
+	<link rel="stylesheet" href="/menus/plantillas/raizweb/calendario/css/estilo.css">
+</noscript>	</head>
+<body class="schedule-page">
+
+<div class="contenedor">
+	<div class="overlay"></div>
+	<header>
+	
+		 <div class="flex-block-left-auto">
+			<div class="ImagenLogoIne">
+				 <a href="/"><img src="/menus/_b/img/LogoINE.svg" alt="SIGLAS Instituto Nacional de Estad&#237;stica">
+							
+				</a>
+	
+			</div>
+		
+			<div class="MenuDch">
+				<div class="Menu_idioma">
+					
+<div class="Menu_cabeceraIdioma">
+	<ul class="barraIdiomas">
+	
+		<li class="bordeL idioma">
+			<a href="../en/calenHTML.htm" title="English Page" lang="en" role="button">English</a>
+		</li>
+	</ul>
+</div>
+				</div>
+	
+					<div  class="capa_Menu_cabeceraBuscador">
+					<form name="Menu_cabeceraBuscador" id="Menu_cabeceraBuscador"
+						  action="/buscar/searchResults.do" accept-charset="UTF-8"
+						  onsubmit="return Buscador_Valida();" method="get" class="">
+						<input tabindex="0" placeholder='Escriba el texto para buscar' aria-label='Escriba el texto para buscar' class="Menu_searchString" id="searchString" name="searchString" value="" autocomplete="off" type="search">
+						<button name="Menu_botonBuscador" id="Menu_botonBuscador" aria-label='Acci&#243;n de buscar en el sitio web'></button>
+						<input name="searchType" id="searchType" value="DEF_SEARCH" type="hidden">
+						<input name="startat" id="startat" value="0" type="hidden">
+						<input name="L"  value="0" type="hidden"> </form>
+				</div>
+				
+			</div>
+		
+		</div>
+	</header>
+	
+	
+	<nav aria-label="Menú Principal" class=" main-menu"  >
+	<div>
+		<div class="toggleBtn">
+			<a href="/indiceweb.htm" id="sidebarCollapse" class="btn btn-info no-events" aria-label="Mostrar/ocultar el menú principal de navegación" title="Men&#250; de navegaci&#243;n">
+			<i class="ii ii-bars"></i>
+		</a>
+		<script id="loaderFCPSC">
+			document.head.insertAdjacentHTML("beforeend", `<style id="loaderFCPST">
+				.loaderFCP { background-size: cover; width: 35px; height: 35px; transform: rotate(0deg); animation: rotationLoader 1s linear infinite; display: block; border: 2px solid white; border-radius: 100px; border-color: white white transparent white; }
+				@keyframes rotationLoader { 100% { transform: rotate(360deg); } }
+			</style>`);			document.querySelector(".main-menu .toggleBtn a").onclick=function(){
+				this.children[0].setAttribute("class", "loaderFCP")
+				return false;
+			}
+		</script>
+		
+		<img src="/menus/_b/img/LogoINESiglasMini.svg" class="nav-logo" alt="Instituto Nacional de Estadí­stica">
+		</div>		<div id="sidebarLayer" class="intellimenu-layer" style="display: none;">
+		</div>
+		<ul class="secondList">
+			<li>
+				<a class="tit" href="/dyngs/CEL/index.htm?cid=41" role="button" aria-haspopup="true" aria-expanded="false" aria-label="Censo Electoral" target="_blank">Censo Electoral</a></li>
+			<li>
+				<a class="tit" href="https://sede.ine.gob.es" role="button" aria-haspopup="true" aria-expanded="false"  aria-label="Sede electr&#243;nica" target="_blank" rel="noopener">Sede electr&#243;nica</a>
+			</li>			
+			<li class="dropdown">
+				<a id="shareBtn" data-toggle="drop-down" onclick="this.classList.toggle('active')" href="javascript:void(0)" role="button" aria-haspopup="true" aria-expanded="false"  aria-label="Compartir"> 
+					<span class="tit">Compartir</span>
+					<i class="ii ii-share"></i>
+				</a>
+				<ul class="dropdown-menu" title="Lista de redes para compartir p&#225;gina">
+					<li>
+						<a id="shareTwitter" data-social-text="INE. Instituto Nacional de Estad&#237;stica" data-social-via="es_ine" class="" href="#shareTwitter" target="SocialShared" title="Abre ventana nueva X">
+							<span class="tit">X</span>
+							<i class="ii ii-twitter-x"></i>
+						</a>
+					</li>
+					<li>
+						<a id="shareFacebook" data-social-text="INE. Instituto Nacional de Estad&#237;stica" href="#shareFacebook" target="SocialShared" title="Abre ventana nueva Facebook">
+							<span class="tit">Facebook</span>
+							<i class="ii ii-facebook"></i>
+						</a>
+					</li>
+					<li>
+						<a id="shareLinkedin" data-social-text="INE. Instituto Nacional de Estad&#237;stica" href="#shareLinkedin" target="SocialShared" title="Abre ventana nueva Linkedin">
+							<span class="tit">Linkedin</span>
+							<i class="ii ii-linkedin"></i>
+						</a>
+					</li>
+					<li>
+						<a id="shareWhatsapp" data-social-text="INE. Instituto Nacional de Estad&#237;stica" href="#shareWhatsapp" target="SocialShared" title="Abre ventana nueva WhatsApp">
+							<span class="tit">WhatsApp</span>
+							<i class="ii ii-whatsapp"></i>
+						</a>
+					</li>
+					<li>
+						<a id="shareMail" data-social-text="INE. Instituto Nacional de Estad&#237;stica" href="#shareMail" target="_self" title="Abre ventana nueva">
+							<span class="tit">Correo Electr&#243;nico</span>
+							<i class="ii ii-mail"></i>
+						</a>
+					</li>
+					<li>
+						<a id="shareClipboard" data-social-text="INE. Instituto Nacional de Estad&#237;stica" href="#shareClipboard" target="_self" title="Abre ventana nueva">
+							<span class="tit">Copiar al portapapeles</span>
+							<i class="ii ii-copy"></i>
+						</a>
+					</li>
+				</ul>
+			</li>
+			
+		</ul>
+	</div>
+</nav>
+	<main>
+	
+	
+	
+<div class="customBar cbMiga ">
+	<div class="group">
+			<nav class="cbMigaTitle" aria-label="Miga">
+				<ul>
+		<li><a href="/" title="Inicio">Inicio</a></li><li><span aria-current="page" title="Calendario 2026">Calendario 2026</span></li>
+	</ul></nav>
+		</div>
+	</div>
+<section class="schedule-header">
+		<h1 class="subrayado">Calendario 2026</h1> 					
+		<aside>
+			<p>Última actualización: 24 Abril 2026</p>
+		</aside>
+	</section>
+	
+	<section class="schedule">
+		<div class="bar customBar noBorder fixed-top" style="padding-right: 0;">
+			<div class="group left">			
+			<form class="content filter" action="" onsubmit="return select(this)" method="post">
+				<label id="mLbl" for="m" title="Ir a Mes">
+					Mes</label>
+				<select id="m" name="m" aria-labelledby="mLbl">
+					<option title="Ver el año completo" value="0" aria-controls="completo">Todos</option>
+					<option title="Seleccionar Enero" value="1" aria-controls="ene">Enero</option>
+					<option title="Seleccionar Febrero" value="2" aria-controls="feb">Febrero</option>
+					<option title="Seleccionar Marzo" value="3" aria-controls="mar">Marzo</option>
+					<option title="Seleccionar Abril" value="4" aria-controls="abr">Abril</option>
+					<option title="Seleccionar Mayo" value="5" aria-controls="may">Mayo</option>
+					<option title="Seleccionar Junio" value="6" aria-controls="jun">Junio</option>
+					<option title="Seleccionar Julio" value="7" aria-controls="jul">Julio</option>
+					<option title="Seleccionar Agosto" value="8" aria-controls="ago">Agosto</option>
+					<option title="Seleccionar Septiembre" value="9" aria-controls="sep">Septiembre</option>
+					<option title="Seleccionar Octubre" value="10" aria-controls="oct">Octubre</option>
+					<option title="Seleccionar Noviembre" value="11" aria-controls="nov">Noviembre</option>
+					<option title="Seleccionar Diciembre" value="12" aria-controls="dic">Diciembre</option>
+				</select>								
+				<label id="qLbl" for="q" title="Ir a Año">
+					Año</label>
+				<select id="q" name="q" aria-labelledby="qLbl">
+					<option  data-url="/daco/daco41/calen2016.htm" value="2016" >2016</option>
+								<option  data-url="/daco/daco41/calen2017.htm" value="2017" >2017</option>
+								<option  data-url="/daco/daco41/calen2018.htm" value="2018" >2018</option>
+								<option  data-url="/daco/daco41/calen2019.htm" value="2019" >2019</option>
+								<option  data-url="/daco/daco41/calen2020.htm" value="2020" >2020</option>
+								<option  data-url="/daco/daco41/calen2021.htm" value="2021" >2021</option>
+								<option  data-url="/daco/daco41/calen2022.htm" value="2022" >2022</option>
+								<option  data-url="/daco/daco41/calen2023.htm" value="2023" >2023</option>
+								<option  data-url="/dynt3/Calendario/calenHTML.htm?q=2024" value="2024" >2024</option>
+								<option  data-url="/dynt3/Calendario/calenHTML.htm?q=2025" value="2025" >2025</option>
+								<option  data-url="/dynt3/Calendario/calenHTML.htm?q=2026" value="2026"  selected >2026</option>
+								</select>
+				<button type="submit" title="Mostrar seleccionado">
+					<i class="ii ii-go"></i>
+				</button>
+			</form>
+			</div>
+			<div class="group right ">
+				<ul class="filtersearch" >
+				<li >
+					<ul >
+						<li class="current">
+							
+						</li>
+						<li class="searcher"></li>
+					</ul>
+				</li>
+			</ul>
+			</div>
+					
+		</div>
+ 
+		<div class="group" role="group">
+			<div class="customBar noBorder fixed-top" style="padding-right: 0;">
+				<div class="group right">
+					<button type="button">
+			            <i class="ii ii-link IcoRef"></i>
+			        </button>
+			        <ul class="content ii-group">
+			        	<li>
+						<a href="/daco/daco41/calen_ics.htm" 
+						   class="ii ii-small ii-files-ical btn" 
+						   title="iCalendar de las estadísticas."
+						   role="button">
+							<span class="sr-only">iCalendar de las estadísticas.</span>
+						   </a>
+						 </li>
+						<li>
+						
+						<button 
+							class="ii ii-small ii-print btn"
+							onclick="ine.abrirVentanaImpresion(' calenPRINT.pdf?q=2026')"><span class="sr-only">Calendario en versión imprimible</span></button>
+										
+						</li>
+						</ul>
+				</div>	
+			</div>	
+			<div id="completo" class="datapub">
+				<div class="tipo Publicacion">
+	<h2>Estadísticas coyunturales</h2>
+	<ul class="twoCols">
+	<li tabindex="0" role="button">
+						<button  id="idPubli_14" class="toggle-button nocircle tit">Contabilidad Nacional Trimestral de España</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581" 								
+										title="Información detallada de: Contabilidad Nacional Trimestral de España: Principales Agregados "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p14" scope="col">Día</th>
+							   		<th id="col2_p14" scope="col">Mes</th>
+							    	<th id="col3_p14" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p14">30</td>
+								<td headers="col2_p14">Enero</td>
+								<td headers="col3_p14">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p14">26</td>
+								<td headers="col2_p14">Marzo</td>
+								<td headers="col3_p14">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p14">30</td>
+								<td headers="col2_p14">Abril</td>
+								<td headers="col3_p14">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p14">25</td>
+								<td headers="col2_p14">Junio</td>
+								<td headers="col3_p14">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p14">30</td>
+								<td headers="col2_p14">Julio</td>
+								<td headers="col3_p14">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p14">25</td>
+								<td headers="col2_p14">Septiembre</td>
+								<td headers="col3_p14">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p14">30</td>
+								<td headers="col2_p14">Octubre</td>
+								<td headers="col3_p14">Trimestre 3/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p14">23</td>
+								<td headers="col2_p14">Diciembre</td>
+								<td headers="col3_p14">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_1" class="toggle-button nocircle tit">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de Ocupación Hotelera "></a>
+									<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 								
+										title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero "></a>
+									<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 								
+										title="Información detallada de: Índice de Precios Hoteleros "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p1" scope="col">Día</th>
+							   		<th id="col2_p1" scope="col">Mes</th>
+							    	<th id="col3_p1" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p1">26</td>
+								<td headers="col2_p1">Enero</td>
+								<td headers="col3_p1">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">24</td>
+								<td headers="col2_p1">Febrero</td>
+								<td headers="col3_p1">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">23</td>
+								<td headers="col2_p1">Marzo</td>
+								<td headers="col3_p1">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">23</td>
+								<td headers="col2_p1">Abril</td>
+								<td headers="col3_p1">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">25</td>
+								<td headers="col2_p1">Mayo</td>
+								<td headers="col3_p1">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">23</td>
+								<td headers="col2_p1">Junio</td>
+								<td headers="col3_p1">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">24</td>
+								<td headers="col2_p1">Julio</td>
+								<td headers="col3_p1">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">21</td>
+								<td headers="col2_p1">Agosto</td>
+								<td headers="col3_p1">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">22</td>
+								<td headers="col2_p1">Septiembre</td>
+								<td headers="col3_p1">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">23</td>
+								<td headers="col2_p1">Octubre</td>
+								<td headers="col3_p1">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">23</td>
+								<td headers="col2_p1">Noviembre</td>
+								<td headers="col3_p1">Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p1">22</td>
+								<td headers="col2_p1">Diciembre</td>
+								<td headers="col3_p1">Noviembre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_26" class="toggle-button nocircle tit">Cuentas Trimestrales no Financieras de los Sectores Institucionales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736165305&idp=1254735576581" 								
+										title="Información detallada de: Cuentas Trimestrales no Financieras de los Sectores Institucionales "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p26" scope="col">Día</th>
+							   		<th id="col2_p26" scope="col">Mes</th>
+							    	<th id="col3_p26" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p26">1</td>
+								<td headers="col2_p26">Abril</td>
+								<td headers="col3_p26">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p26">30</td>
+								<td headers="col2_p26">Junio</td>
+								<td headers="col3_p26">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p26">30</td>
+								<td headers="col2_p26">Septiembre</td>
+								<td headers="col3_p26">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p26">30</td>
+								<td headers="col2_p26">Diciembre</td>
+								<td headers="col3_p26">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_469" class="toggle-button nocircle tit">Encuesta Coyuntural sobre Stocks y Existencias-Trimestral</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176995&idp=1254735576799" 								
+										title="Información detallada de: Encuesta Coyuntural sobre Stocks y Existencias "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p469" scope="col">Día</th>
+							   		<th id="col2_p469" scope="col">Mes</th>
+							    	<th id="col3_p469" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p469">4</td>
+								<td headers="col2_p469">Marzo</td>
+								<td headers="col3_p469">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p469">4</td>
+								<td headers="col2_p469">Junio</td>
+								<td headers="col3_p469">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p469">4</td>
+								<td headers="col2_p469">Septiembre</td>
+								<td headers="col3_p469">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p469">3</td>
+								<td headers="col2_p469">Diciembre</td>
+								<td headers="col3_p469">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_451" class="toggle-button nocircle tit">Encuesta Coyuntural sobre Stocks y Existencias. Ponderaciones</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176995&idp=1254735576799" 								
+										title="Información detallada de: Encuesta Coyuntural sobre Stocks y Existencias "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p451" scope="col">Día</th>
+							   		<th id="col2_p451" scope="col">Mes</th>
+							    	<th id="col3_p451" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p451">4</td>
+								<td headers="col2_p451">Junio</td>
+								<td headers="col3_p451">Año 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p451">4</td>
+								<td headers="col2_p451">Septiembre</td>
+								<td headers="col3_p451">Año 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_360" class="toggle-button nocircle tit">Encuesta Trimestral de Coste Laboral</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736045053&idp=1254735976596" 								
+										title="Información detallada de: Encuesta Trimestral de Coste Laboral (ETCL) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p360" scope="col">Día</th>
+							   		<th id="col2_p360" scope="col">Mes</th>
+							    	<th id="col3_p360" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p360">17</td>
+								<td headers="col2_p360">Marzo</td>
+								<td headers="col3_p360">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p360">16</td>
+								<td headers="col2_p360">Junio</td>
+								<td headers="col3_p360">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p360">17</td>
+								<td headers="col2_p360">Septiembre</td>
+								<td headers="col3_p360">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p360">17</td>
+								<td headers="col2_p360">Diciembre</td>
+								<td headers="col3_p360">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_443" class="toggle-button nocircle tit">Encuesta de  turismo de residentes. Mensual</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de turismo de residentes "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p443" scope="col">Día</th>
+							   		<th id="col2_p443" scope="col">Mes</th>
+							    	<th id="col3_p443" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p443">26</td>
+								<td headers="col2_p443">Marzo</td>
+								<td headers="col3_p443">Diciembre 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_472" class="toggle-button nocircle tit">Encuesta de Gasto Turístico</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de Gasto Turístico "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p472" scope="col">Día</th>
+							   		<th id="col2_p472" scope="col">Mes</th>
+							    	<th id="col3_p472" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p472">3</td>
+								<td headers="col2_p472">Febrero</td>
+								<td headers="col3_p472">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p472">4</td>
+								<td headers="col2_p472">Marzo</td>
+								<td headers="col3_p472">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_408" class="toggle-button nocircle tit">Encuesta de Gasto Turístico Mensual</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de Gasto Turístico "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p408" scope="col">Día</th>
+							   		<th id="col2_p408" scope="col">Mes</th>
+							    	<th id="col3_p408" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p408">2</td>
+								<td headers="col2_p408">Enero</td>
+								<td headers="col3_p408">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">3</td>
+								<td headers="col2_p408">Febrero</td>
+								<td headers="col3_p408">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">4</td>
+								<td headers="col2_p408">Marzo</td>
+								<td headers="col3_p408">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">1</td>
+								<td headers="col2_p408">Abril</td>
+								<td headers="col3_p408">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">5</td>
+								<td headers="col2_p408">Mayo</td>
+								<td headers="col3_p408">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">2</td>
+								<td headers="col2_p408">Junio</td>
+								<td headers="col3_p408">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">2</td>
+								<td headers="col2_p408">Julio</td>
+								<td headers="col3_p408">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">3</td>
+								<td headers="col2_p408">Agosto</td>
+								<td headers="col3_p408">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">1</td>
+								<td headers="col2_p408">Septiembre</td>
+								<td headers="col3_p408">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">2</td>
+								<td headers="col2_p408">Octubre</td>
+								<td headers="col3_p408">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">4</td>
+								<td headers="col2_p408">Noviembre</td>
+								<td headers="col3_p408">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p408">2</td>
+								<td headers="col2_p408">Diciembre</td>
+								<td headers="col3_p408">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_330" class="toggle-button nocircle tit">Encuesta de Población Activa</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176918&idp=1254735976595" 								
+										title="Información detallada de: Encuesta de Población Activa (EPA) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p330" scope="col">Día</th>
+							   		<th id="col2_p330" scope="col">Mes</th>
+							    	<th id="col3_p330" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p330">27</td>
+								<td headers="col2_p330">Enero</td>
+								<td headers="col3_p330">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p330">28</td>
+								<td headers="col2_p330">Abril</td>
+								<td headers="col3_p330">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p330">28</td>
+								<td headers="col2_p330">Julio</td>
+								<td headers="col3_p330">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p330">27</td>
+								<td headers="col2_p330">Octubre</td>
+								<td headers="col3_p330">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_2" class="toggle-button nocircle tit">Encuesta de ocupación en alojamientos turísticos extrahoteleros</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de Ocupación en Albergues "></a>
+									<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural "></a>
+									<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos "></a>
+									<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de Ocupación en Campings "></a>
+									<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 								
+										title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural "></a>
+									<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 								
+										title="Información detallada de: Índice de Precios de Apartamentos Turísticos "></a>
+									<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 								
+										title="Información detallada de: Índice de Precios de Camping "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p2" scope="col">Día</th>
+							   		<th id="col2_p2" scope="col">Mes</th>
+							    	<th id="col3_p2" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p2">2</td>
+								<td headers="col2_p2">Enero</td>
+								<td headers="col3_p2">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">2</td>
+								<td headers="col2_p2">Febrero</td>
+								<td headers="col3_p2">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">3</td>
+								<td headers="col2_p2">Marzo</td>
+								<td headers="col3_p2">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">31</td>
+								<td headers="col2_p2">Marzo</td>
+								<td headers="col3_p2">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">4</td>
+								<td headers="col2_p2">Mayo</td>
+								<td headers="col3_p2">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">1</td>
+								<td headers="col2_p2">Junio</td>
+								<td headers="col3_p2">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">1</td>
+								<td headers="col2_p2">Julio</td>
+								<td headers="col3_p2">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">31</td>
+								<td headers="col2_p2">Julio</td>
+								<td headers="col3_p2">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">31</td>
+								<td headers="col2_p2">Agosto</td>
+								<td headers="col3_p2">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">1</td>
+								<td headers="col2_p2">Octubre</td>
+								<td headers="col3_p2">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">3</td>
+								<td headers="col2_p2">Noviembre</td>
+								<td headers="col3_p2">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p2">1</td>
+								<td headers="col2_p2">Diciembre</td>
+								<td headers="col3_p2">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_445" class="toggle-button nocircle tit">Encuesta de turismo de residentes</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de turismo de residentes "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p445" scope="col">Día</th>
+							   		<th id="col2_p445" scope="col">Mes</th>
+							    	<th id="col3_p445" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p445">26</td>
+								<td headers="col2_p445">Marzo</td>
+								<td headers="col3_p445">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p445">29</td>
+								<td headers="col2_p445">Junio</td>
+								<td headers="col3_p445">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p445">24</td>
+								<td headers="col2_p445">Septiembre</td>
+								<td headers="col3_p445">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p445">21</td>
+								<td headers="col2_p445">Diciembre</td>
+								<td headers="col3_p445">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_462" class="toggle-button nocircle tit">Encuesta de turismo de residentes anual</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863" 								
+										title="Información detallada de: Encuesta de turismo de residentes "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p462" scope="col">Día</th>
+							   		<th id="col2_p462" scope="col">Mes</th>
+							    	<th id="col3_p462" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p462">26</td>
+								<td headers="col2_p462">Marzo</td>
+								<td headers="col3_p462">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_610" class="toggle-button nocircle tit">Estadística Continua de Población</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177095&idp=1254735572981" 								
+										title="Información detallada de: Estadística Continua de Población "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p610" scope="col">Día</th>
+							   		<th id="col2_p610" scope="col">Mes</th>
+							    	<th id="col3_p610" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p610">12</td>
+								<td headers="col2_p610">Febrero</td>
+								<td headers="col3_p610">2026-01-01</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p610">7</td>
+								<td headers="col2_p610">Mayo</td>
+								<td headers="col3_p610">2026-04-01</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p610">6</td>
+								<td headers="col2_p610">Agosto</td>
+								<td headers="col3_p610">2026-07-01</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p610">12</td>
+								<td headers="col2_p610">Noviembre</td>
+								<td headers="col3_p610">2026-10-01</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_399" class="toggle-button nocircle tit">Estadística de Flujos de la Población Activa</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176907&idp=1254735976595" 								
+										title="Información detallada de: Flujos de la Población Activa "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p399" scope="col">Día</th>
+							   		<th id="col2_p399" scope="col">Mes</th>
+							    	<th id="col3_p399" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p399">27</td>
+								<td headers="col2_p399">Enero</td>
+								<td headers="col3_p399">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p399">28</td>
+								<td headers="col2_p399">Abril</td>
+								<td headers="col3_p399">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p399">28</td>
+								<td headers="col2_p399">Julio</td>
+								<td headers="col3_p399">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p399">27</td>
+								<td headers="col2_p399">Octubre</td>
+								<td headers="col3_p399">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_28" class="toggle-button nocircle tit">Estadística de Transmisiones de Derechos de la Propiedad</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606" 								
+										title="Información detallada de: Estadística de Transmisión de Derechos de la Propiedad "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p28" scope="col">Día</th>
+							   		<th id="col2_p28" scope="col">Mes</th>
+							    	<th id="col3_p28" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p28">19</td>
+								<td headers="col2_p28">Enero</td>
+								<td headers="col3_p28">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">20</td>
+								<td headers="col2_p28">Febrero</td>
+								<td headers="col3_p28">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">24</td>
+								<td headers="col2_p28">Marzo</td>
+								<td headers="col3_p28">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">23</td>
+								<td headers="col2_p28">Abril</td>
+								<td headers="col3_p28">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">18</td>
+								<td headers="col2_p28">Mayo</td>
+								<td headers="col3_p28">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">19</td>
+								<td headers="col2_p28">Junio</td>
+								<td headers="col3_p28">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">14</td>
+								<td headers="col2_p28">Julio</td>
+								<td headers="col3_p28">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">7</td>
+								<td headers="col2_p28">Agosto</td>
+								<td headers="col3_p28">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">25</td>
+								<td headers="col2_p28">Septiembre</td>
+								<td headers="col3_p28">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">26</td>
+								<td headers="col2_p28">Octubre</td>
+								<td headers="col3_p28">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">17</td>
+								<td headers="col2_p28">Noviembre</td>
+								<td headers="col3_p28">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p28">16</td>
+								<td headers="col2_p28">Diciembre</td>
+								<td headers="col3_p28">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_298" class="toggle-button nocircle tit">Estadística de Transmisiones de Derechos de la Propiedad. Resultados anuales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606" 								
+										title="Información detallada de: Estadística de Transmisión de Derechos de la Propiedad "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p298" scope="col">Día</th>
+							   		<th id="col2_p298" scope="col">Mes</th>
+							    	<th id="col3_p298" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p298">20</td>
+								<td headers="col2_p298">Febrero</td>
+								<td headers="col3_p298">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p298">25</td>
+								<td headers="col2_p298">Septiembre</td>
+								<td headers="col3_p298">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_355" class="toggle-button nocircle tit">Estadística de Transporte de Viajeros</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820" 								
+										title="Información detallada de: Estadística de Transporte de Viajeros "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p355" scope="col">Día</th>
+							   		<th id="col2_p355" scope="col">Mes</th>
+							    	<th id="col3_p355" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p355">12</td>
+								<td headers="col2_p355">Enero</td>
+								<td headers="col3_p355">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">10</td>
+								<td headers="col2_p355">Febrero</td>
+								<td headers="col3_p355">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">11</td>
+								<td headers="col2_p355">Marzo</td>
+								<td headers="col3_p355">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">10</td>
+								<td headers="col2_p355">Abril</td>
+								<td headers="col3_p355">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">12</td>
+								<td headers="col2_p355">Mayo</td>
+								<td headers="col3_p355">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">11</td>
+								<td headers="col2_p355">Junio</td>
+								<td headers="col3_p355">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">10</td>
+								<td headers="col2_p355">Julio</td>
+								<td headers="col3_p355">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">7</td>
+								<td headers="col2_p355">Agosto</td>
+								<td headers="col3_p355">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">10</td>
+								<td headers="col2_p355">Septiembre</td>
+								<td headers="col3_p355">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">9</td>
+								<td headers="col2_p355">Octubre</td>
+								<td headers="col3_p355">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">12</td>
+								<td headers="col2_p355">Noviembre</td>
+								<td headers="col3_p355">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p355">11</td>
+								<td headers="col2_p355">Diciembre</td>
+								<td headers="col3_p355">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_345" class="toggle-button nocircle tit">Estadística sobre Ejecuciones Hipotecarias</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176993&idp=1254735576606" 								
+										title="Información detallada de: Estadística sobre Ejecuciones Hipotecarias "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p345" scope="col">Día</th>
+							   		<th id="col2_p345" scope="col">Mes</th>
+							    	<th id="col3_p345" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p345">6</td>
+								<td headers="col2_p345">Marzo</td>
+								<td headers="col3_p345">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p345">4</td>
+								<td headers="col2_p345">Junio</td>
+								<td headers="col3_p345">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p345">16</td>
+								<td headers="col2_p345">Septiembre</td>
+								<td headers="col3_p345">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p345">4</td>
+								<td headers="col2_p345">Diciembre</td>
+								<td headers="col3_p345">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_415" class="toggle-button nocircle tit">Estadística sobre Ejecuciones Hipotecarias. Anual</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176993&idp=1254735576606" 								
+										title="Información detallada de: Estadística sobre Ejecuciones Hipotecarias "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p415" scope="col">Día</th>
+							   		<th id="col2_p415" scope="col">Mes</th>
+							    	<th id="col3_p415" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p415">6</td>
+								<td headers="col2_p415">Marzo</td>
+								<td headers="col3_p415">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p415">16</td>
+								<td headers="col2_p415">Septiembre</td>
+								<td headers="col3_p415">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_187" class="toggle-button nocircle tit">Estadística sobre Transporte Ferroviario</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177040&idp=1254735576820" 								
+										title="Información detallada de: Estadística sobre Transporte Ferroviario "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p187" scope="col">Día</th>
+							   		<th id="col2_p187" scope="col">Mes</th>
+							    	<th id="col3_p187" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p187">2</td>
+								<td headers="col2_p187">Marzo</td>
+								<td headers="col3_p187">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p187">3</td>
+								<td headers="col2_p187">Junio</td>
+								<td headers="col3_p187">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p187">3</td>
+								<td headers="col2_p187">Septiembre</td>
+								<td headers="col3_p187">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p187">30</td>
+								<td headers="col2_p187">Noviembre</td>
+								<td headers="col3_p187">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_562" class="toggle-button nocircle tit">Estimación Mensual de Nacimientos</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+								href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002" 							
+								title="Información detallada de: Estimación Mensual de Nacimientos "></a>
+						<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p562" scope="col">Día</th>
+							   		<th id="col2_p562" scope="col">Mes</th>
+							    	<th id="col3_p562" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p562">21</td>
+								<td headers="col2_p562">Enero</td>
+								<td headers="col3_p562">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">18</td>
+								<td headers="col2_p562">Febrero</td>
+								<td headers="col3_p562">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">18</td>
+								<td headers="col2_p562">Marzo</td>
+								<td headers="col3_p562">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">22</td>
+								<td headers="col2_p562">Abril</td>
+								<td headers="col3_p562">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">20</td>
+								<td headers="col2_p562">Mayo</td>
+								<td headers="col3_p562">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">17</td>
+								<td headers="col2_p562">Junio</td>
+								<td headers="col3_p562">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">22</td>
+								<td headers="col2_p562">Julio</td>
+								<td headers="col3_p562">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">19</td>
+								<td headers="col2_p562">Agosto</td>
+								<td headers="col3_p562">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">16</td>
+								<td headers="col2_p562">Septiembre</td>
+								<td headers="col3_p562">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">21</td>
+								<td headers="col2_p562">Octubre</td>
+								<td headers="col3_p562">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">18</td>
+								<td headers="col2_p562">Noviembre</td>
+								<td headers="col3_p562">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p562">23</td>
+								<td headers="col2_p562">Diciembre</td>
+								<td headers="col3_p562">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_632" class="toggle-button nocircle tit">Estimación del número de defunciones mensuales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002" 								
+										title="Información detallada de: Estimacion del numero de defunciones semanales (EDeS) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p632" scope="col">Día</th>
+							   		<th id="col2_p632" scope="col">Mes</th>
+							    	<th id="col3_p632" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p632">21</td>
+								<td headers="col2_p632">Enero</td>
+								<td headers="col3_p632">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">18</td>
+								<td headers="col2_p632">Febrero</td>
+								<td headers="col3_p632">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">18</td>
+								<td headers="col2_p632">Marzo</td>
+								<td headers="col3_p632">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">22</td>
+								<td headers="col2_p632">Abril</td>
+								<td headers="col3_p632">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">20</td>
+								<td headers="col2_p632">Mayo</td>
+								<td headers="col3_p632">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">17</td>
+								<td headers="col2_p632">Junio</td>
+								<td headers="col3_p632">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">22</td>
+								<td headers="col2_p632">Julio</td>
+								<td headers="col3_p632">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">19</td>
+								<td headers="col2_p632">Agosto</td>
+								<td headers="col3_p632">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">16</td>
+								<td headers="col2_p632">Septiembre</td>
+								<td headers="col3_p632">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">21</td>
+								<td headers="col2_p632">Octubre</td>
+								<td headers="col3_p632">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">18</td>
+								<td headers="col2_p632">Noviembre</td>
+								<td headers="col3_p632">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p632">23</td>
+								<td headers="col2_p632">Diciembre</td>
+								<td headers="col3_p632">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_544" class="toggle-button nocircle tit">Estimación del número de defunciones semanales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+								href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002" 							
+								title="Información detallada de: Estimación del número de defunciones semanales "></a>
+						<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p544" scope="col">Día</th>
+							   		<th id="col2_p544" scope="col">Mes</th>
+							    	<th id="col3_p544" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p544">21</td>
+								<td headers="col2_p544">Enero</td>
+								<td headers="col3_p544">Semana 1 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">18</td>
+								<td headers="col2_p544">Febrero</td>
+								<td headers="col3_p544">Semana 5 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">18</td>
+								<td headers="col2_p544">Marzo</td>
+								<td headers="col3_p544">Semana 9 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">22</td>
+								<td headers="col2_p544">Abril</td>
+								<td headers="col3_p544">Semana 14 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">20</td>
+								<td headers="col2_p544">Mayo</td>
+								<td headers="col3_p544">Semana 18 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">17</td>
+								<td headers="col2_p544">Junio</td>
+								<td headers="col3_p544">Semana 22 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">22</td>
+								<td headers="col2_p544">Julio</td>
+								<td headers="col3_p544">Semana 27 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">19</td>
+								<td headers="col2_p544">Agosto</td>
+								<td headers="col3_p544">Semana 31 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">16</td>
+								<td headers="col2_p544">Septiembre</td>
+								<td headers="col3_p544">Semana 35 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">21</td>
+								<td headers="col2_p544">Octubre</td>
+								<td headers="col3_p544">Semana 40 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">18</td>
+								<td headers="col2_p544">Noviembre</td>
+								<td headers="col3_p544">Semana 44 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p544">23</td>
+								<td headers="col2_p544">Diciembre</td>
+								<td headers="col3_p544">Semana 49 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_289" class="toggle-button nocircle tit">Hipotecas</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606" 								
+										title="Información detallada de: Estadística de Hipotecas "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p289" scope="col">Día</th>
+							   		<th id="col2_p289" scope="col">Mes</th>
+							    	<th id="col3_p289" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p289">19</td>
+								<td headers="col2_p289">Febrero</td>
+								<td headers="col3_p289">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p289">28</td>
+								<td headers="col2_p289">Septiembre</td>
+								<td headers="col3_p289">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_3" class="toggle-button nocircle tit">Hipotecas Mensual</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606" 								
+										title="Información detallada de: Estadística de Hipotecas "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p3" scope="col">Día</th>
+							   		<th id="col2_p3" scope="col">Mes</th>
+							    	<th id="col3_p3" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p3">26</td>
+								<td headers="col2_p3">Enero</td>
+								<td headers="col3_p3">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">19</td>
+								<td headers="col2_p3">Febrero</td>
+								<td headers="col3_p3">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">24</td>
+								<td headers="col2_p3">Marzo</td>
+								<td headers="col3_p3">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">24</td>
+								<td headers="col2_p3">Abril</td>
+								<td headers="col3_p3">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">27</td>
+								<td headers="col2_p3">Mayo</td>
+								<td headers="col3_p3">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">22</td>
+								<td headers="col2_p3">Junio</td>
+								<td headers="col3_p3">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">20</td>
+								<td headers="col2_p3">Julio</td>
+								<td headers="col3_p3">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">26</td>
+								<td headers="col2_p3">Agosto</td>
+								<td headers="col3_p3">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">28</td>
+								<td headers="col2_p3">Septiembre</td>
+								<td headers="col3_p3">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">26</td>
+								<td headers="col2_p3">Octubre</td>
+								<td headers="col3_p3">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">25</td>
+								<td headers="col2_p3">Noviembre</td>
+								<td headers="col3_p3">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p3">18</td>
+								<td headers="col2_p3">Diciembre</td>
+								<td headers="col3_p3">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_61" class="toggle-button nocircle tit">Indicadores de Confianza Empresarial</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736163552&idp=1254735576550" 								
+										title="Información detallada de: Indicadores de Confianza Empresarial "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p61" scope="col">Día</th>
+							   		<th id="col2_p61" scope="col">Mes</th>
+							    	<th id="col3_p61" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p61">21</td>
+								<td headers="col2_p61">Enero</td>
+								<td headers="col3_p61">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p61">14</td>
+								<td headers="col2_p61">Abril</td>
+								<td headers="col3_p61">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p61">14</td>
+								<td headers="col2_p61">Julio</td>
+								<td headers="col3_p61">Trimestre 3/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p61">20</td>
+								<td headers="col2_p61">Octubre</td>
+								<td headers="col3_p61">Trimestre 4/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_4" class="toggle-button nocircle tit">Indicadores de actividad del sector servicios</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778" 								
+										title="Información detallada de: Indicadores de Actividad del Sector Servicios "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p4" scope="col">Día</th>
+							   		<th id="col2_p4" scope="col">Mes</th>
+							    	<th id="col3_p4" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p4">16</td>
+								<td headers="col2_p4">Enero</td>
+								<td headers="col3_p4">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">20</td>
+								<td headers="col2_p4">Febrero</td>
+								<td headers="col3_p4">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">23</td>
+								<td headers="col2_p4">Marzo</td>
+								<td headers="col3_p4">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">17</td>
+								<td headers="col2_p4">Abril</td>
+								<td headers="col3_p4">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">21</td>
+								<td headers="col2_p4">Mayo</td>
+								<td headers="col3_p4">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">22</td>
+								<td headers="col2_p4">Junio</td>
+								<td headers="col3_p4">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">17</td>
+								<td headers="col2_p4">Julio</td>
+								<td headers="col3_p4">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">14</td>
+								<td headers="col2_p4">Agosto</td>
+								<td headers="col3_p4">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">21</td>
+								<td headers="col2_p4">Septiembre</td>
+								<td headers="col3_p4">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">16</td>
+								<td headers="col2_p4">Octubre</td>
+								<td headers="col3_p4">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">20</td>
+								<td headers="col2_p4">Noviembre</td>
+								<td headers="col3_p4">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p4">17</td>
+								<td headers="col2_p4">Diciembre</td>
+								<td headers="col3_p4">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_310" class="toggle-button nocircle tit">Indicadores de actividad del sector servicios. Ponderaciones</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778" 								
+										title="Información detallada de: Indicadores de Actividad del Sector Servicios "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p310" scope="col">Día</th>
+							   		<th id="col2_p310" scope="col">Mes</th>
+							    	<th id="col3_p310" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p310">23</td>
+								<td headers="col2_p310">Marzo</td>
+								<td headers="col3_p310">Año 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p310">17</td>
+								<td headers="col2_p310">Abril</td>
+								<td headers="col3_p310">Año 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p310">21</td>
+								<td headers="col2_p310">Mayo</td>
+								<td headers="col3_p310">Año 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p310">22</td>
+								<td headers="col2_p310">Junio</td>
+								<td headers="col3_p310">Año 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_407" class="toggle-button nocircle tit">Movimientos Turísticos en Fronteras</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863" 								
+										title="Información detallada de: Movimientos Turísticos en Fronteras "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p407" scope="col">Día</th>
+							   		<th id="col2_p407" scope="col">Mes</th>
+							    	<th id="col3_p407" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p407">2</td>
+								<td headers="col2_p407">Enero</td>
+								<td headers="col3_p407">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">3</td>
+								<td headers="col2_p407">Febrero</td>
+								<td headers="col3_p407">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">4</td>
+								<td headers="col2_p407">Marzo</td>
+								<td headers="col3_p407">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">1</td>
+								<td headers="col2_p407">Abril</td>
+								<td headers="col3_p407">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">5</td>
+								<td headers="col2_p407">Mayo</td>
+								<td headers="col3_p407">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">2</td>
+								<td headers="col2_p407">Junio</td>
+								<td headers="col3_p407">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">2</td>
+								<td headers="col2_p407">Julio</td>
+								<td headers="col3_p407">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">3</td>
+								<td headers="col2_p407">Agosto</td>
+								<td headers="col3_p407">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">1</td>
+								<td headers="col2_p407">Septiembre</td>
+								<td headers="col3_p407">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">2</td>
+								<td headers="col2_p407">Octubre</td>
+								<td headers="col3_p407">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">4</td>
+								<td headers="col2_p407">Noviembre</td>
+								<td headers="col3_p407">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p407">2</td>
+								<td headers="col2_p407">Diciembre</td>
+								<td headers="col3_p407">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_471" class="toggle-button nocircle tit">Movimientos turísticos en fronteras</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863" 								
+										title="Información detallada de: Movimientos Turísticos en Fronteras "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p471" scope="col">Día</th>
+							   		<th id="col2_p471" scope="col">Mes</th>
+							    	<th id="col3_p471" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p471">3</td>
+								<td headers="col2_p471">Febrero</td>
+								<td headers="col3_p471">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p471">4</td>
+								<td headers="col2_p471">Marzo</td>
+								<td headers="col3_p471">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_470" class="toggle-button nocircle tit">Ponderaciones IPC</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607" 								
+										title="Información detallada de: Índice de Precios de Consumo (IPC) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p470" scope="col">Día</th>
+							   		<th id="col2_p470" scope="col">Mes</th>
+							    	<th id="col3_p470" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p470">30</td>
+								<td headers="col2_p470">Enero</td>
+								<td headers="col3_p470">Año 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_353" class="toggle-button nocircle tit">Ponderaciones IPCA</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607" 								
+										title="Información detallada de: Índice de Precios de Consumo Armonizado (IPCA) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p353" scope="col">Día</th>
+							   		<th id="col2_p353" scope="col">Mes</th>
+							    	<th id="col3_p353" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p353">30</td>
+								<td headers="col2_p353">Enero</td>
+								<td headers="col3_p353">Año 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_24" class="toggle-button nocircle tit">Sociedades Mercantiles Mensual</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550" 								
+										title="Información detallada de: Estadística de Sociedades Mercantiles "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p24" scope="col">Día</th>
+							   		<th id="col2_p24" scope="col">Mes</th>
+							    	<th id="col3_p24" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p24">14</td>
+								<td headers="col2_p24">Enero</td>
+								<td headers="col3_p24">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">11</td>
+								<td headers="col2_p24">Febrero</td>
+								<td headers="col3_p24">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">11</td>
+								<td headers="col2_p24">Marzo</td>
+								<td headers="col3_p24">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">13</td>
+								<td headers="col2_p24">Abril</td>
+								<td headers="col3_p24">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">13</td>
+								<td headers="col2_p24">Mayo</td>
+								<td headers="col3_p24">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">10</td>
+								<td headers="col2_p24">Junio</td>
+								<td headers="col3_p24">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">10</td>
+								<td headers="col2_p24">Julio</td>
+								<td headers="col3_p24">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">12</td>
+								<td headers="col2_p24">Agosto</td>
+								<td headers="col3_p24">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">10</td>
+								<td headers="col2_p24">Septiembre</td>
+								<td headers="col3_p24">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">13</td>
+								<td headers="col2_p24">Octubre</td>
+								<td headers="col3_p24">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">12</td>
+								<td headers="col2_p24">Noviembre</td>
+								<td headers="col3_p24">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p24">11</td>
+								<td headers="col2_p24">Diciembre</td>
+								<td headers="col3_p24">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_346" class="toggle-button nocircle tit">Índice de Cifra de Negocios Empresarial</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550" 								
+										title="Información detallada de: Índice de Cifra de Negocios Empresarial "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p346" scope="col">Día</th>
+							   		<th id="col2_p346" scope="col">Mes</th>
+							    	<th id="col3_p346" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p346">20</td>
+								<td headers="col2_p346">Enero</td>
+								<td headers="col3_p346">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">24</td>
+								<td headers="col2_p346">Febrero</td>
+								<td headers="col3_p346">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">24</td>
+								<td headers="col2_p346">Marzo</td>
+								<td headers="col3_p346">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">22</td>
+								<td headers="col2_p346">Abril</td>
+								<td headers="col3_p346">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">22</td>
+								<td headers="col2_p346">Mayo</td>
+								<td headers="col3_p346">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">23</td>
+								<td headers="col2_p346">Junio</td>
+								<td headers="col3_p346">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">20</td>
+								<td headers="col2_p346">Julio</td>
+								<td headers="col3_p346">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">17</td>
+								<td headers="col2_p346">Agosto</td>
+								<td headers="col3_p346">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">23</td>
+								<td headers="col2_p346">Septiembre</td>
+								<td headers="col3_p346">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">19</td>
+								<td headers="col2_p346">Octubre</td>
+								<td headers="col3_p346">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">24</td>
+								<td headers="col2_p346">Noviembre</td>
+								<td headers="col3_p346">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p346">18</td>
+								<td headers="col2_p346">Diciembre</td>
+								<td headers="col3_p346">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_6" class="toggle-button nocircle tit">Índice de Cifras de Negocios en la Industria</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715" 								
+										title="Información detallada de: Índices de Cifras de Negocios en la Industria "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p6" scope="col">Día</th>
+							   		<th id="col2_p6" scope="col">Mes</th>
+							    	<th id="col3_p6" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p6">16</td>
+								<td headers="col2_p6">Enero</td>
+								<td headers="col3_p6">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">20</td>
+								<td headers="col2_p6">Febrero</td>
+								<td headers="col3_p6">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">23</td>
+								<td headers="col2_p6">Marzo</td>
+								<td headers="col3_p6">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">17</td>
+								<td headers="col2_p6">Abril</td>
+								<td headers="col3_p6">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">21</td>
+								<td headers="col2_p6">Mayo</td>
+								<td headers="col3_p6">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">22</td>
+								<td headers="col2_p6">Junio</td>
+								<td headers="col3_p6">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">17</td>
+								<td headers="col2_p6">Julio</td>
+								<td headers="col3_p6">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">14</td>
+								<td headers="col2_p6">Agosto</td>
+								<td headers="col3_p6">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">21</td>
+								<td headers="col2_p6">Septiembre</td>
+								<td headers="col3_p6">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">16</td>
+								<td headers="col2_p6">Octubre</td>
+								<td headers="col3_p6">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">20</td>
+								<td headers="col2_p6">Noviembre</td>
+								<td headers="col3_p6">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p6">17</td>
+								<td headers="col2_p6">Diciembre</td>
+								<td headers="col3_p6">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_27" class="toggle-button nocircle tit">Índice de Coste Laboral Armonizado</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736053992&idp=1254735976596" 								
+										title="Información detallada de: Índice de Coste Laboral Armonizado "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p27" scope="col">Día</th>
+							   		<th id="col2_p27" scope="col">Mes</th>
+							    	<th id="col3_p27" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p27">10</td>
+								<td headers="col2_p27">Marzo</td>
+								<td headers="col3_p27">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p27">9</td>
+								<td headers="col2_p27">Junio</td>
+								<td headers="col3_p27">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p27">8</td>
+								<td headers="col2_p27">Septiembre</td>
+								<td headers="col3_p27">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p27">9</td>
+								<td headers="col2_p27">Diciembre</td>
+								<td headers="col3_p27">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_417" class="toggle-button nocircle tit">Índice de Garantía de la Competitividad</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607" 								
+										title="Información detallada de: Índice de Garantía de la Competitividad "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p417" scope="col">Día</th>
+							   		<th id="col2_p417" scope="col">Mes</th>
+							    	<th id="col3_p417" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p417">20</td>
+								<td headers="col2_p417">Enero</td>
+								<td headers="col3_p417">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">25</td>
+								<td headers="col2_p417">Febrero</td>
+								<td headers="col3_p417">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">20</td>
+								<td headers="col2_p417">Marzo</td>
+								<td headers="col3_p417">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">17</td>
+								<td headers="col2_p417">Abril</td>
+								<td headers="col3_p417">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">21</td>
+								<td headers="col2_p417">Mayo</td>
+								<td headers="col3_p417">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">18</td>
+								<td headers="col2_p417">Junio</td>
+								<td headers="col3_p417">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">20</td>
+								<td headers="col2_p417">Julio</td>
+								<td headers="col3_p417">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">20</td>
+								<td headers="col2_p417">Agosto</td>
+								<td headers="col3_p417">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">18</td>
+								<td headers="col2_p417">Septiembre</td>
+								<td headers="col3_p417">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">19</td>
+								<td headers="col2_p417">Octubre</td>
+								<td headers="col3_p417">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">19</td>
+								<td headers="col2_p417">Noviembre</td>
+								<td headers="col3_p417">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p417">18</td>
+								<td headers="col2_p417">Diciembre</td>
+								<td headers="col3_p417">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_11" class="toggle-button nocircle tit">Índice de Precios Industriales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715" 								
+										title="Información detallada de: Índices de Precios Industriales "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p11" scope="col">Día</th>
+							   		<th id="col2_p11" scope="col">Mes</th>
+							    	<th id="col3_p11" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p11">26</td>
+								<td headers="col2_p11">Enero</td>
+								<td headers="col3_p11">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">25</td>
+								<td headers="col2_p11">Febrero</td>
+								<td headers="col3_p11">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">25</td>
+								<td headers="col2_p11">Marzo</td>
+								<td headers="col3_p11">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">24</td>
+								<td headers="col2_p11">Abril</td>
+								<td headers="col3_p11">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">26</td>
+								<td headers="col2_p11">Mayo</td>
+								<td headers="col3_p11">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">25</td>
+								<td headers="col2_p11">Junio</td>
+								<td headers="col3_p11">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">24</td>
+								<td headers="col2_p11">Julio</td>
+								<td headers="col3_p11">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">25</td>
+								<td headers="col2_p11">Agosto</td>
+								<td headers="col3_p11">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">24</td>
+								<td headers="col2_p11">Septiembre</td>
+								<td headers="col3_p11">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">26</td>
+								<td headers="col2_p11">Octubre</td>
+								<td headers="col3_p11">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">24</td>
+								<td headers="col2_p11">Noviembre</td>
+								<td headers="col3_p11">Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p11">23</td>
+								<td headers="col2_p11">Diciembre</td>
+								<td headers="col3_p11">Noviembre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_8" class="toggle-button nocircle tit">Índice de Precios de Consumo</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607" 								
+										title="Información detallada de: Índice de Precios de Consumo (IPC) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p8" scope="col">Día</th>
+							   		<th id="col2_p8" scope="col">Mes</th>
+							    	<th id="col3_p8" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p8">15</td>
+								<td headers="col2_p8">Enero</td>
+								<td headers="col3_p8">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">30</td>
+								<td headers="col2_p8">Enero</td>
+								<td headers="col3_p8">Avance. Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">13</td>
+								<td headers="col2_p8">Febrero</td>
+								<td headers="col3_p8">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">27</td>
+								<td headers="col2_p8">Febrero</td>
+								<td headers="col3_p8">Avance. Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">13</td>
+								<td headers="col2_p8">Marzo</td>
+								<td headers="col3_p8">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">27</td>
+								<td headers="col2_p8">Marzo</td>
+								<td headers="col3_p8">Avance. Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">14</td>
+								<td headers="col2_p8">Abril</td>
+								<td headers="col3_p8">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">29</td>
+								<td headers="col2_p8">Abril</td>
+								<td headers="col3_p8">Avance. Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">14</td>
+								<td headers="col2_p8">Mayo</td>
+								<td headers="col3_p8">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">29</td>
+								<td headers="col2_p8">Mayo</td>
+								<td headers="col3_p8">Avance. Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">12</td>
+								<td headers="col2_p8">Junio</td>
+								<td headers="col3_p8">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">29</td>
+								<td headers="col2_p8">Junio</td>
+								<td headers="col3_p8">Avance. Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">15</td>
+								<td headers="col2_p8">Julio</td>
+								<td headers="col3_p8">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">30</td>
+								<td headers="col2_p8">Julio</td>
+								<td headers="col3_p8">Avance. Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">13</td>
+								<td headers="col2_p8">Agosto</td>
+								<td headers="col3_p8">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">28</td>
+								<td headers="col2_p8">Agosto</td>
+								<td headers="col3_p8">Avance. Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">15</td>
+								<td headers="col2_p8">Septiembre</td>
+								<td headers="col3_p8">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">29</td>
+								<td headers="col2_p8">Septiembre</td>
+								<td headers="col3_p8">Avance. Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">14</td>
+								<td headers="col2_p8">Octubre</td>
+								<td headers="col3_p8">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">30</td>
+								<td headers="col2_p8">Octubre</td>
+								<td headers="col3_p8">Avance. Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">13</td>
+								<td headers="col2_p8">Noviembre</td>
+								<td headers="col3_p8">Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">27</td>
+								<td headers="col2_p8">Noviembre</td>
+								<td headers="col3_p8">Avance. Noviembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">15</td>
+								<td headers="col2_p8">Diciembre</td>
+								<td headers="col3_p8">Noviembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p8">30</td>
+								<td headers="col2_p8">Diciembre</td>
+								<td headers="col3_p8">Avance. Diciembre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_21" class="toggle-button nocircle tit">Índice de Precios de Vivienda</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736152838&idp=1254735976607" 								
+										title="Información detallada de: Índice de Precios de la Vivienda (IPV) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p21" scope="col">Día</th>
+							   		<th id="col2_p21" scope="col">Mes</th>
+							    	<th id="col3_p21" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p21">6</td>
+								<td headers="col2_p21">Marzo</td>
+								<td headers="col3_p21">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p21">8</td>
+								<td headers="col2_p21">Junio</td>
+								<td headers="col3_p21">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p21">7</td>
+								<td headers="col2_p21">Septiembre</td>
+								<td headers="col3_p21">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p21">4</td>
+								<td headers="col2_p21">Diciembre</td>
+								<td headers="col3_p21">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_49" class="toggle-button nocircle tit">Índice de Precios de Vivienda. Medias Anuales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736152838&idp=1254735976607" 								
+										title="Información detallada de: Índice de Precios de la Vivienda (IPV) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p49" scope="col">Día</th>
+							   		<th id="col2_p49" scope="col">Mes</th>
+							    	<th id="col3_p49" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p49">6</td>
+								<td headers="col2_p49">Marzo</td>
+								<td headers="col3_p49">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_20" class="toggle-button nocircle tit">Índice de Precios del Sector Servicios</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778" 								
+										title="Información detallada de: Índices de Precios del Sector Servicios "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p20" scope="col">Día</th>
+							   		<th id="col2_p20" scope="col">Mes</th>
+							    	<th id="col3_p20" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p20">17</td>
+								<td headers="col2_p20">Marzo</td>
+								<td headers="col3_p20">Trimestre 4/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p20">16</td>
+								<td headers="col2_p20">Junio</td>
+								<td headers="col3_p20">Trimestre 1/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p20">15</td>
+								<td headers="col2_p20">Septiembre</td>
+								<td headers="col3_p20">Trimestre 2/2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p20">15</td>
+								<td headers="col2_p20">Diciembre</td>
+								<td headers="col3_p20">Trimestre 3/2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_319" class="toggle-button nocircle tit">Índice de Precios del Sector Servicios. Medias anuales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778" 								
+										title="Información detallada de: Índices de Precios del Sector Servicios "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p319" scope="col">Día</th>
+							   		<th id="col2_p319" scope="col">Mes</th>
+							    	<th id="col3_p319" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p319">17</td>
+								<td headers="col2_p319">Marzo</td>
+								<td headers="col3_p319">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p319">16</td>
+								<td headers="col2_p319">Junio</td>
+								<td headers="col3_p319">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p319">15</td>
+								<td headers="col2_p319">Septiembre</td>
+								<td headers="col3_p319">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p319">15</td>
+								<td headers="col2_p319">Diciembre</td>
+								<td headers="col3_p319">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_10" class="toggle-button nocircle tit">Índice de Producción Industrial</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715" 								
+										title="Información detallada de: Índices de Producción Industrial "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p10" scope="col">Día</th>
+							   		<th id="col2_p10" scope="col">Mes</th>
+							    	<th id="col3_p10" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p10">9</td>
+								<td headers="col2_p10">Enero</td>
+								<td headers="col3_p10">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">6</td>
+								<td headers="col2_p10">Febrero</td>
+								<td headers="col3_p10">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">5</td>
+								<td headers="col2_p10">Marzo</td>
+								<td headers="col3_p10">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">9</td>
+								<td headers="col2_p10">Abril</td>
+								<td headers="col3_p10">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">8</td>
+								<td headers="col2_p10">Mayo</td>
+								<td headers="col3_p10">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">4</td>
+								<td headers="col2_p10">Junio</td>
+								<td headers="col3_p10">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">3</td>
+								<td headers="col2_p10">Julio</td>
+								<td headers="col3_p10">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">6</td>
+								<td headers="col2_p10">Agosto</td>
+								<td headers="col3_p10">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">10</td>
+								<td headers="col2_p10">Septiembre</td>
+								<td headers="col3_p10">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">6</td>
+								<td headers="col2_p10">Octubre</td>
+								<td headers="col3_p10">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">6</td>
+								<td headers="col2_p10">Noviembre</td>
+								<td headers="col3_p10">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p10">4</td>
+								<td headers="col2_p10">Diciembre</td>
+								<td headers="col3_p10">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_664" class="toggle-button nocircle tit">Índice de Producción de la Construcción</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+								href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757" 							
+								title="Información detallada de: Índice de Producción de la Construcción "></a>
+						<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p664" scope="col">Día</th>
+							   		<th id="col2_p664" scope="col">Mes</th>
+							    	<th id="col3_p664" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p664">13</td>
+								<td headers="col2_p664">Marzo</td>
+								<td headers="col3_p664">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">13</td>
+								<td headers="col2_p664">Abril</td>
+								<td headers="col3_p664">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">13</td>
+								<td headers="col2_p664">Mayo</td>
+								<td headers="col3_p664">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">12</td>
+								<td headers="col2_p664">Junio</td>
+								<td headers="col3_p664">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">13</td>
+								<td headers="col2_p664">Julio</td>
+								<td headers="col3_p664">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">13</td>
+								<td headers="col2_p664">Agosto</td>
+								<td headers="col3_p664">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">14</td>
+								<td headers="col2_p664">Septiembre</td>
+								<td headers="col3_p664">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">14</td>
+								<td headers="col2_p664">Octubre</td>
+								<td headers="col3_p664">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">13</td>
+								<td headers="col2_p664">Noviembre</td>
+								<td headers="col3_p664">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p664">14</td>
+								<td headers="col2_p664">Diciembre</td>
+								<td headers="col3_p664">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_626" class="toggle-button nocircle tit">Índice de Producción del Sector Servicios</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+								href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778" 							
+								title="Información detallada de: Índice de Producción del Sector Servicios "></a>
+						<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p626" scope="col">Día</th>
+							   		<th id="col2_p626" scope="col">Mes</th>
+							    	<th id="col3_p626" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p626">20</td>
+								<td headers="col2_p626">Enero</td>
+								<td headers="col3_p626">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">24</td>
+								<td headers="col2_p626">Febrero</td>
+								<td headers="col3_p626">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">25</td>
+								<td headers="col2_p626">Marzo</td>
+								<td headers="col3_p626">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">21</td>
+								<td headers="col2_p626">Abril</td>
+								<td headers="col3_p626">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">25</td>
+								<td headers="col2_p626">Mayo</td>
+								<td headers="col3_p626">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">24</td>
+								<td headers="col2_p626">Junio</td>
+								<td headers="col3_p626">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">21</td>
+								<td headers="col2_p626">Julio</td>
+								<td headers="col3_p626">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">18</td>
+								<td headers="col2_p626">Agosto</td>
+								<td headers="col3_p626">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">23</td>
+								<td headers="col2_p626">Septiembre</td>
+								<td headers="col3_p626">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">20</td>
+								<td headers="col2_p626">Octubre</td>
+								<td headers="col3_p626">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">24</td>
+								<td headers="col2_p626">Noviembre</td>
+								<td headers="col3_p626">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p626">21</td>
+								<td headers="col2_p626">Diciembre</td>
+								<td headers="col3_p626">Octubre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_627" class="toggle-button nocircle tit">Índice de Producción del Sector Servicios. Ponderaciones</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778" 								
+										title="Información detallada de: Índice de Producción del Sector Servicios "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p627" scope="col">Día</th>
+							   		<th id="col2_p627" scope="col">Mes</th>
+							    	<th id="col3_p627" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p627">25</td>
+								<td headers="col2_p627">Marzo</td>
+								<td headers="col3_p627">Año 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_654" class="toggle-button nocircle tit">Índice de Referencia de Arrendamientos de Vivienda</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607" 								
+										title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p654" scope="col">Día</th>
+							   		<th id="col2_p654" scope="col">Mes</th>
+							    	<th id="col3_p654" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p654">15</td>
+								<td headers="col2_p654">Enero</td>
+								<td headers="col3_p654">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">13</td>
+								<td headers="col2_p654">Febrero</td>
+								<td headers="col3_p654">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">13</td>
+								<td headers="col2_p654">Marzo</td>
+								<td headers="col3_p654">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">14</td>
+								<td headers="col2_p654">Abril</td>
+								<td headers="col3_p654">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">14</td>
+								<td headers="col2_p654">Mayo</td>
+								<td headers="col3_p654">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">12</td>
+								<td headers="col2_p654">Junio</td>
+								<td headers="col3_p654">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">15</td>
+								<td headers="col2_p654">Julio</td>
+								<td headers="col3_p654">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">13</td>
+								<td headers="col2_p654">Agosto</td>
+								<td headers="col3_p654">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">15</td>
+								<td headers="col2_p654">Septiembre</td>
+								<td headers="col3_p654">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">14</td>
+								<td headers="col2_p654">Octubre</td>
+								<td headers="col3_p654">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">13</td>
+								<td headers="col2_p654">Noviembre</td>
+								<td headers="col3_p654">Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p654">15</td>
+								<td headers="col2_p654">Diciembre</td>
+								<td headers="col3_p654">Noviembre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_5" class="toggle-button nocircle tit">Índices de Comercio al por menor</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799" 								
+										title="Información detallada de: Índices de Comercio al por Menor "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p5" scope="col">Día</th>
+							   		<th id="col2_p5" scope="col">Mes</th>
+							    	<th id="col3_p5" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p5">29</td>
+								<td headers="col2_p5">Enero</td>
+								<td headers="col3_p5">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">11</td>
+								<td headers="col2_p5">Marzo</td>
+								<td headers="col3_p5">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">30</td>
+								<td headers="col2_p5">Marzo</td>
+								<td headers="col3_p5">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">28</td>
+								<td headers="col2_p5">Abril</td>
+								<td headers="col3_p5">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">28</td>
+								<td headers="col2_p5">Mayo</td>
+								<td headers="col3_p5">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">29</td>
+								<td headers="col2_p5">Junio</td>
+								<td headers="col3_p5">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">28</td>
+								<td headers="col2_p5">Julio</td>
+								<td headers="col3_p5">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">28</td>
+								<td headers="col2_p5">Agosto</td>
+								<td headers="col3_p5">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">29</td>
+								<td headers="col2_p5">Septiembre</td>
+								<td headers="col3_p5">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">29</td>
+								<td headers="col2_p5">Octubre</td>
+								<td headers="col3_p5">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">27</td>
+								<td headers="col2_p5">Noviembre</td>
+								<td headers="col3_p5">Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p5">30</td>
+								<td headers="col2_p5">Diciembre</td>
+								<td headers="col3_p5">Noviembre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_313" class="toggle-button nocircle tit">Índices de Comercio al por menor. Ponderaciones </button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799" 								
+										title="Información detallada de: Índices de Comercio al por Menor "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p313" scope="col">Día</th>
+							   		<th id="col2_p313" scope="col">Mes</th>
+							    	<th id="col3_p313" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p313">11</td>
+								<td headers="col2_p313">Marzo</td>
+								<td headers="col3_p313">Año 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p313">30</td>
+								<td headers="col2_p313">Marzo</td>
+								<td headers="col3_p313">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_9" class="toggle-button nocircle tit">Índices de Precios de Consumo Armonizado</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607" 								
+										title="Información detallada de: Índice de Precios de Consumo Armonizado (IPCA) "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p9" scope="col">Día</th>
+							   		<th id="col2_p9" scope="col">Mes</th>
+							    	<th id="col3_p9" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p9">15</td>
+								<td headers="col2_p9">Enero</td>
+								<td headers="col3_p9">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">30</td>
+								<td headers="col2_p9">Enero</td>
+								<td headers="col3_p9">Avance. Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">13</td>
+								<td headers="col2_p9">Febrero</td>
+								<td headers="col3_p9">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">27</td>
+								<td headers="col2_p9">Febrero</td>
+								<td headers="col3_p9">Avance. Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">13</td>
+								<td headers="col2_p9">Marzo</td>
+								<td headers="col3_p9">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">27</td>
+								<td headers="col2_p9">Marzo</td>
+								<td headers="col3_p9">Avance. Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">14</td>
+								<td headers="col2_p9">Abril</td>
+								<td headers="col3_p9">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">29</td>
+								<td headers="col2_p9">Abril</td>
+								<td headers="col3_p9">Avance. Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">14</td>
+								<td headers="col2_p9">Mayo</td>
+								<td headers="col3_p9">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">29</td>
+								<td headers="col2_p9">Mayo</td>
+								<td headers="col3_p9">Avance. Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">12</td>
+								<td headers="col2_p9">Junio</td>
+								<td headers="col3_p9">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">29</td>
+								<td headers="col2_p9">Junio</td>
+								<td headers="col3_p9">Avance. Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">15</td>
+								<td headers="col2_p9">Julio</td>
+								<td headers="col3_p9">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">30</td>
+								<td headers="col2_p9">Julio</td>
+								<td headers="col3_p9">Avance. Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">13</td>
+								<td headers="col2_p9">Agosto</td>
+								<td headers="col3_p9">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">28</td>
+								<td headers="col2_p9">Agosto</td>
+								<td headers="col3_p9">Avance. Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">15</td>
+								<td headers="col2_p9">Septiembre</td>
+								<td headers="col3_p9">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">29</td>
+								<td headers="col2_p9">Septiembre</td>
+								<td headers="col3_p9">Avance. Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">14</td>
+								<td headers="col2_p9">Octubre</td>
+								<td headers="col3_p9">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">30</td>
+								<td headers="col2_p9">Octubre</td>
+								<td headers="col3_p9">Avance. Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">13</td>
+								<td headers="col2_p9">Noviembre</td>
+								<td headers="col3_p9">Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">27</td>
+								<td headers="col2_p9">Noviembre</td>
+								<td headers="col3_p9">Avance. Noviembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">15</td>
+								<td headers="col2_p9">Diciembre</td>
+								<td headers="col3_p9">Noviembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p9">30</td>
+								<td headers="col2_p9">Diciembre</td>
+								<td headers="col3_p9">Avance. Diciembre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_12" class="toggle-button nocircle tit">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715" 								
+										title="Información detallada de: Índices de Precios de Exportación y de Importación de Productos Industriales "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p12" scope="col">Día</th>
+							   		<th id="col2_p12" scope="col">Mes</th>
+							    	<th id="col3_p12" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p12">30</td>
+								<td headers="col2_p12">Enero</td>
+								<td headers="col3_p12">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">27</td>
+								<td headers="col2_p12">Febrero</td>
+								<td headers="col3_p12">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">30</td>
+								<td headers="col2_p12">Marzo</td>
+								<td headers="col3_p12">Febrero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">30</td>
+								<td headers="col2_p12">Abril</td>
+								<td headers="col3_p12">Marzo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">29</td>
+								<td headers="col2_p12">Mayo</td>
+								<td headers="col3_p12">Abril 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">30</td>
+								<td headers="col2_p12">Junio</td>
+								<td headers="col3_p12">Mayo 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">29</td>
+								<td headers="col2_p12">Julio</td>
+								<td headers="col3_p12">Junio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">28</td>
+								<td headers="col2_p12">Agosto</td>
+								<td headers="col3_p12">Julio 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">30</td>
+								<td headers="col2_p12">Septiembre</td>
+								<td headers="col3_p12">Agosto 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">30</td>
+								<td headers="col2_p12">Octubre</td>
+								<td headers="col3_p12">Septiembre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">30</td>
+								<td headers="col2_p12">Noviembre</td>
+								<td headers="col3_p12">Octubre 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p12">29</td>
+								<td headers="col2_p12">Diciembre</td>
+								<td headers="col3_p12">Noviembre 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	</ul>
+	</div>
+	<div class="tipo Dominio">
+		<h2>Estadísticas estructurales<sup>(1)</sup></h2>		
+		<ul class="twoCols" >	
+			<li tabindex="0" role="button">
+ 		<button class="toggle-button nocircle tit">Ciencia y tecnología</button>		
+		<div class="toggle-container content">
+					<table  class=" dominio">
+						<caption hidden></caption> 	  
+							<thead>
+								<tr>
+									<th id="col1_d13" scope="col">Día</th>
+									<th id="col2_d13" scope="col">Mes</th>
+							   		<th id="col3_d13" scope="col">Publicación</th>
+							    	<th id="col4_d13" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>					
+				<tr data-id="pub.77_12314">		
+								<td headers="col1_d13">26</td>
+									<td headers="col2_d13">Febrero</td>
+									<td headers="col3_d13">Estadística sobre el uso de biotecnología</td>
+								<td headers="col4_d13">Año 2024</td>
+							</tr>
+			<tr data-id="pub.78_12322">		
+								<td headers="col1_d13" colspan="2" >Julio</td>
+  									<td headers="col3_d13">Indicadores de Alta Tecnología</td>
+								<td headers="col4_d13">Año 2024</td>
+							</tr>
+			<tr data-id="pub.92_12323">		
+								<td headers="col1_d13" colspan="2" >Julio</td>
+  									<td headers="col3_d13">Indicadores del Sector de Tecnologías de la Información y las Comunicaciones (TIC)</td>
+								<td headers="col4_d13">Año 2024</td>
+							</tr>
+			<tr data-id="pub.94_12326">		
+								<td headers="col1_d13" colspan="2" >Octubre</td>
+  									<td headers="col3_d13">Encuesta sobre el Uso de Tecnologías de la Información y las Comunicaciones y del Comercio Electrónico en las Empresas</td>
+								<td headers="col4_d13">2025-2026</td>
+							</tr>
+			<tr data-id="pub.267_12332">		
+								<td headers="col1_d13" colspan="2" >Noviembre</td>
+  									<td headers="col3_d13">Estadística sobre actividades en I+D</td>
+								<td headers="col4_d13">Año 2025</td>
+							</tr>
+			</tbody>	
+			</table> 
+			</div>
+		</li> 
+<li tabindex="0" role="button">
+ 		<button class="toggle-button nocircle tit">Demografía y población</button>		
+		<div class="toggle-container content">
+					<table  class=" dominio">
+						<caption hidden></caption> 	  
+							<thead>
+								<tr>
+									<th id="col1_d1" scope="col">Día</th>
+									<th id="col2_d1" scope="col">Mes</th>
+							   		<th id="col3_d1" scope="col">Publicación</th>
+							    	<th id="col4_d1" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>					
+				<tr data-id="pub.64_12356">		
+								<td headers="col1_d1">28</td>
+									<td headers="col2_d1">Enero</td>
+									<td headers="col3_d1">Nomenclátor: Población por Unidad Poblacional</td>
+								<td headers="col4_d1">01/01/2025</td>
+							</tr>
+			<tr data-id="pub.67_12357">		
+								<td headers="col1_d1">4</td>
+									<td headers="col2_d1">Febrero</td>
+									<td headers="col3_d1">Relación de municipios, provincias, comunidades autónomas y sus códigos</td>
+								<td headers="col4_d1">01/01/2026</td>
+							</tr>
+			<tr data-id="pub.76_12313">		
+								<td headers="col1_d1">19</td>
+									<td headers="col2_d1">Marzo</td>
+									<td headers="col3_d1">Estadística del Padrón de la Población Española Residente en el Extranjero</td>
+								<td headers="col4_d1">01/01/2026</td>
+							</tr>
+			<tr data-id="pub.79_12359">		
+								<td headers="col1_d1">23</td>
+									<td headers="col2_d1">Abril</td>
+									<td headers="col3_d1">Apellidos y nombres más frecuentes</td>
+								<td headers="col4_d1">01/01/2025</td>
+							</tr>
+			<tr data-id="pub.651_12358">		
+								<td headers="col1_d1">29</td>
+									<td headers="col2_d1">Abril</td>
+									<td headers="col3_d1">Censos Anuales de Población. Variables de residencia, educativas y laborales.</td>
+								<td headers="col4_d1">01/01/2024 y 01/01/2025</td>
+							</tr>
+			<tr data-id="pub.459_12360">		
+								<td headers="col1_d1">28</td>
+									<td headers="col2_d1">Mayo</td>
+									<td headers="col3_d1">Estadística de Adquisiciones de Nacionalidad Española de Residentes</td>
+								<td headers="col4_d1">Año 2025</td>
+							</tr>
+			<tr data-id="pub.400_12365">		
+								<td headers="col1_d1">17</td>
+									<td headers="col2_d1">Junio</td>
+									<td headers="col3_d1">Proyecciones de Población</td>
+								<td headers="col4_d1">2026-2076</td>
+							</tr>
+			<tr data-id="pub.115_12366">		
+								<td headers="col1_d1">17</td>
+									<td headers="col2_d1">Junio</td>
+									<td headers="col3_d1">Proyección de Hogares</td>
+								<td headers="col4_d1">2026-2041</td>
+							</tr>
+			<tr data-id="pub.489_12384">		
+								<td headers="col1_d1" colspan="2" >Septiembre</td>
+  									<td headers="col3_d1">Encuesta de Fecundidad</td>
+								<td headers="col4_d1">Año 2025</td>
+							</tr>
+			<tr data-id="pub.652_12363">		
+								<td headers="col1_d1" colspan="2" >Noviembre</td>
+  									<td headers="col3_d1">Censos Anuales de Población. Ocupación y actividad.</td>
+								<td headers="col4_d1">01/01/2024,  01/01/2025 y 01/01/2026</td>
+							</tr>
+			<tr data-id="pub.622_12364">		
+								<td headers="col1_d1" colspan="2" >Noviembre</td>
+  									<td headers="col3_d1">Estadística de Migraciones y Cambios de Residencia</td>
+								<td headers="col4_d1">2025</td>
+							</tr>
+			<tr data-id="pub.365_12361">		
+								<td headers="col1_d1" colspan="2" >Noviembre</td>
+  									<td headers="col3_d1">Movimiento Natural de Población (Matrimonios, Nacimientos y Defunciones)</td>
+								<td headers="col4_d1">Año 2025</td>
+							</tr>
+			<tr data-id="pub.66_12362">		
+								<td headers="col1_d1" colspan="2" >Noviembre</td>
+  									<td headers="col3_d1">Tablas de mortalidad</td>
+								<td headers="col4_d1">Año 2025</td>
+							</tr>
+			<tr data-id="pub.29_12389">		
+								<td headers="col1_d1" colspan="2" >Depende de BOE</td>
+  									<td headers="col3_d1">Cifras oficiales de población de los municipios españoles: revisión del Padrón municipal</td>
+								<td headers="col4_d1">Año 2026</td>
+							</tr>
+			<tr data-id="pub.489_12385">		
+								<td headers="col1_d1" colspan="2" >Diciembre</td>
+  									<td headers="col3_d1">Encuesta de Fecundidad</td>
+								<td headers="col4_d1">Año 2025</td>
+							</tr>
+			</tbody>	
+			</table> 
+			</div>
+		</li> 
+<li tabindex="0" role="button">
+ 		<button class="toggle-button nocircle tit">Economía</button>		
+		<div class="toggle-container content">
+					<table  class=" dominio">
+						<caption hidden></caption> 	  
+							<thead>
+								<tr>
+									<th id="col1_d2" scope="col">Día</th>
+									<th id="col2_d2" scope="col">Mes</th>
+							   		<th id="col3_d2" scope="col">Publicación</th>
+							    	<th id="col4_d2" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>					
+				<tr data-id="pub.646_12388">		
+								<td headers="col1_d2">26</td>
+									<td headers="col2_d2">Febrero</td>
+									<td headers="col3_d2">Cuenta satélite de la economía social</td>
+								<td headers="col4_d2">Años 2019-2023</td>
+							</tr>
+			<tr data-id="pub.325_12301">		
+								<td headers="col1_d2">24</td>
+									<td headers="col2_d2">Abril</td>
+									<td headers="col3_d2">Contabilidad regional de España. Gasto en consumo final de los hogares</td>
+								<td headers="col4_d2">Serie 2016-2023</td>
+							</tr>
+			<tr data-id="pub.326_12302">		
+								<td headers="col1_d2">24</td>
+									<td headers="col2_d2">Abril</td>
+									<td headers="col3_d2">Índices de Reparto Regional del IVA y los Impuestos Especiales sobre la Cerveza, sobre el Alcohol y Bebidas derivadas y sobre productos Intermedios</td>
+								<td headers="col4_d2">Año 2024</td>
+							</tr>
+			<tr data-id="pub.403_12312">		
+								<td headers="col1_d2" colspan="2" >Septiembre</td>
+  									<td headers="col3_d2">Contabilidad Regional de España</td>
+								<td headers="col4_d2">Avance PIB. Serie 2000-2025</td>
+							</tr>
+			<tr data-id="pub.494_12303">		
+								<td headers="col1_d2" colspan="2" >Septiembre</td>
+  									<td headers="col3_d2">Contabilidad nacional anual de España: agregados por rama de actividad</td>
+								<td headers="col4_d2">Serie 1995-2025</td>
+							</tr>
+			<tr data-id="pub.493_12305">		
+								<td headers="col1_d2" colspan="2" >Septiembre</td>
+  									<td headers="col3_d2">Contabilidad nacional anual de España: principales agregados</td>
+								<td headers="col4_d2">Serie 1995-2025</td>
+							</tr>
+			<tr data-id="pub.496_12307">		
+								<td headers="col1_d2" colspan="2" >Septiembre</td>
+  									<td headers="col3_d2">Contabilidad nacional anual de España: tablas de Origen y Destino</td>
+								<td headers="col4_d2">Año 2023</td>
+							</tr>
+			<tr data-id="pub.447_12306">		
+								<td headers="col1_d2" colspan="2" >Septiembre</td>
+  									<td headers="col3_d2">Cuentas anuales no Financieras de los Sectores Institucionales.</td>
+								<td headers="col4_d2">Serie 1999-2025</td>
+							</tr>
+			<tr data-id="pub.110_12324">		
+								<td headers="col1_d2" colspan="2" >Septiembre</td>
+  									<td headers="col3_d2">Estadística de Empresas según su pertenencia a grupos</td>
+								<td headers="col4_d2">Año 2024</td>
+							</tr>
+			<tr data-id="pub.107_12325">		
+								<td headers="col1_d2" colspan="2" >Septiembre</td>
+  									<td headers="col3_d2">Estadística de filiales de empresas españolas en el exterior</td>
+								<td headers="col4_d2">Año 2024</td>
+							</tr>
+			<tr data-id="pub.494_12304">		
+								<td headers="col1_d2" colspan="2" >Septiembre</td>
+  									<td headers="col3_d2">Contabilidad Nacional Anual de España. Agregados por rama de actividad. Balances no financieros por rama de actividad</td>
+								<td headers="col4_d2">Serie 2000-2024</td>
+							</tr>
+			<tr data-id="pub.496_12308">		
+								<td headers="col1_d2" colspan="2" >Octubre</td>
+  									<td headers="col3_d2">Contabilidad nacional anual de España: tablas de Origen y Destino</td>
+								<td headers="col4_d2">Datos provisionales 2024</td>
+							</tr>
+			<tr data-id="pub.268_12331">		
+								<td headers="col1_d2" colspan="2" >Noviembre</td>
+  									<td headers="col3_d2">Demografía Armonizada de Empresas</td>
+								<td headers="col4_d2">Año 2024</td>
+							</tr>
+			<tr data-id="pub.403_12309">		
+								<td headers="col1_d2" colspan="2" >Diciembre</td>
+  									<td headers="col3_d2">Contabilidad Regional de España</td>
+								<td headers="col4_d2">Serie 2000-2025</td>
+							</tr>
+			<tr data-id="pub.497_12311">		
+								<td headers="col1_d2" colspan="2" >Diciembre</td>
+  									<td headers="col3_d2">Contabilidad nacional anual de España: tablas Input-Output</td>
+								<td headers="col4_d2">Año 2023</td>
+							</tr>
+			<tr data-id="pub.461_12336">		
+								<td headers="col1_d2" colspan="2" >Diciembre</td>
+  									<td headers="col3_d2">Cuenta Satélite del Turismo de España</td>
+								<td headers="col4_d2">Año 2025</td>
+							</tr>
+			<tr data-id="pub.447_12310">		
+								<td headers="col1_d2" colspan="2" >Diciembre</td>
+  									<td headers="col3_d2">Cuentas anuales no Financieras de los Sectores Institucionales.</td>
+								<td headers="col4_d2">Serie 1995-2025</td>
+							</tr>
+			<tr data-id="pub.30_12340">		
+								<td headers="col1_d2" colspan="2" >Diciembre</td>
+  									<td headers="col3_d2">Explotación Estadística del Directorio Central de Empresas</td>
+								<td headers="col4_d2">01/01/2026</td>
+							</tr>
+			<tr data-id="pub.555_12803">		
+								<td headers="col1_d2" colspan="2" >Diciembre</td>
+  									<td headers="col3_d2">Tabla de Pensiones</td>
+								<td headers="col4_d2">Año 2024</td>
+							</tr>
+			</tbody>	
+			</table> 
+			</div>
+		</li> 
+<li tabindex="0" role="button">
+ 		<button class="toggle-button nocircle tit">Entorno físico y medio ambiente</button>		
+		<div class="toggle-container content">
+					<table  class=" dominio">
+						<caption hidden></caption> 	  
+							<thead>
+								<tr>
+									<th id="col1_d12" scope="col">Día</th>
+									<th id="col2_d12" scope="col">Mes</th>
+							   		<th id="col3_d12" scope="col">Publicación</th>
+							    	<th id="col4_d12" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>					
+				<tr data-id="pub.342_12804">		
+								<td headers="col1_d12" colspan="2" >Julio</td>
+  									<td headers="col3_d12">Estadísticas sobre el Suministro y Saneamiento del Agua</td>
+								<td headers="col4_d12">Año 2024</td>
+							</tr>
+			<tr data-id="pub.100_12335">		
+								<td headers="col1_d12" colspan="2" >Julio</td>
+  									<td headers="col3_d12">Estadísticas sobre las actividades de protección medioambiental</td>
+								<td headers="col4_d12">Año 2024</td>
+							</tr>
+			<tr data-id="pub.339_12338">		
+								<td headers="col1_d12" colspan="2" >Noviembre</td>
+  									<td headers="col3_d12">Cuentas Medioambientales. Cuentas de flujos de materiales</td>
+								<td headers="col4_d12">serie 2008-2025</td>
+							</tr>
+			<tr data-id="pub.337_12328">		
+								<td headers="col1_d12" colspan="2" >Noviembre</td>
+  									<td headers="col3_d12">Cuentas Medioambientales: Cuenta de Emisiones a la Atmósfera</td>
+								<td headers="col4_d12">serie 2008-2025</td>
+							</tr>
+			<tr data-id="pub.338_12330">		
+								<td headers="col1_d12" colspan="2" >Noviembre</td>
+  									<td headers="col3_d12">Cuentas Medioambientales: Cuenta de Impuestos Ambientales</td>
+								<td headers="col4_d12">serie 2008-2025</td>
+							</tr>
+			<tr data-id="pub.512_12327">		
+								<td headers="col1_d12" colspan="2" >Noviembre</td>
+  									<td headers="col3_d12">Cuentas Medioambientales: Cuenta de los Residuos</td>
+								<td headers="col4_d12">serie 2015-2024</td>
+							</tr>
+			<tr data-id="pub.485_12329">		
+								<td headers="col1_d12" colspan="2" >Noviembre</td>
+  									<td headers="col3_d12">Cuentas medioambientales: Cuenta de flujos físicos de la energía</td>
+								<td headers="col4_d12">serie 2015-2024</td>
+							</tr>
+			<tr data-id="pub.340_12333">		
+								<td headers="col1_d12" colspan="2" >Noviembre</td>
+  									<td headers="col3_d12">Estadísticas sobre Recogida y Tratamiento de Residuos</td>
+								<td headers="col4_d12">Año 2024</td>
+							</tr>
+			<tr data-id="pub.104_12334">		
+								<td headers="col1_d12" colspan="2" >Noviembre</td>
+  									<td headers="col3_d12">Estadísticas sobre generación de residuos</td>
+								<td headers="col4_d12">Año 2024</td>
+							</tr>
+			<tr data-id="pub.663_12386">		
+								<td headers="col1_d12" colspan="2" >Diciembre</td>
+  									<td headers="col3_d12">Cuentas Medioambientales: Cuenta de Subvenciones Medioambientales y Otras Transferencias Similares</td>
+								<td headers="col4_d12">serie 2020-2024</td>
+							</tr>
+			<tr data-id="pub.484_12339">		
+								<td headers="col1_d12" colspan="2" >Diciembre</td>
+  									<td headers="col3_d12">Cuentas medioambientales: Cuenta de gasto en protección medioambiental </td>
+								<td headers="col4_d12">serie 2014-2025</td>
+							</tr>
+			<tr data-id="pub.490_12337">		
+								<td headers="col1_d12" colspan="2" >Diciembre</td>
+  									<td headers="col3_d12">Cuentas medioambientales: bienes y servicios ambientales</td>
+								<td headers="col4_d12">serie 2014-2025</td>
+							</tr>
+			</tbody>	
+			</table> 
+			</div>
+		</li> 
+<li tabindex="0" role="button">
+ 		<button class="toggle-button nocircle tit">Industria, energía y construcción</button>		
+		<div class="toggle-container content">
+					<table  class=" dominio">
+						<caption hidden></caption> 	  
+							<thead>
+								<tr>
+									<th id="col1_d3" scope="col">Día</th>
+									<th id="col2_d3" scope="col">Mes</th>
+							   		<th id="col3_d3" scope="col">Publicación</th>
+							    	<th id="col4_d3" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>					
+				<tr data-id="pub.57_12320">		
+								<td headers="col1_d3">31</td>
+									<td headers="col2_d3">Marzo</td>
+									<td headers="col3_d3">Estadística Estructural de Empresas: Sector Industrial</td>
+								<td headers="col4_d3">Año 2024</td>
+							</tr>
+			<tr data-id="pub.145_12315">		
+								<td headers="col1_d3">26</td>
+									<td headers="col2_d3">Mayo</td>
+									<td headers="col3_d3">Encuesta de Consumos Energéticos</td>
+								<td headers="col4_d3">Año 2024</td>
+							</tr>
+			<tr data-id="pub.647_12342">		
+								<td headers="col1_d3">3</td>
+									<td headers="col2_d3">Junio</td>
+									<td headers="col3_d3">Estadística estructural de empresas: Sector Construcción</td>
+								<td headers="col4_d3">Año 2024</td>
+							</tr>
+			<tr data-id="pub.88_12316">		
+								<td headers="col1_d3">26</td>
+									<td headers="col2_d3">Junio</td>
+									<td headers="col3_d3">Encuesta Industrial Anual de Productos</td>
+								<td headers="col4_d3">Año 2025</td>
+							</tr>
+			</tbody>	
+			</table> 
+			</div>
+		</li> 
+<li tabindex="0" role="button">
+ 		<button class="toggle-button nocircle tit">Servicios</button>		
+		<div class="toggle-container content">
+					<table  class=" dominio">
+						<caption hidden></caption> 	  
+							<thead>
+								<tr>
+									<th id="col1_d4" scope="col">Día</th>
+									<th id="col2_d4" scope="col">Mes</th>
+							   		<th id="col3_d4" scope="col">Publicación</th>
+							    	<th id="col4_d4" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>					
+				<tr data-id="pub.629_12345">		
+								<td headers="col1_d4">29</td>
+									<td headers="col2_d4">Enero</td>
+									<td headers="col3_d4">Comercio Internacional de Servicios por Modos de Suministro (MoS)</td>
+								<td headers="col4_d4">Año 2024</td>
+							</tr>
+			<tr data-id="pub.630_12344">		
+								<td headers="col1_d4">19</td>
+									<td headers="col2_d4">Febrero</td>
+									<td headers="col3_d4">Comercio Internacional de Servicios por Características de las Empresas (STEC)</td>
+								<td headers="col4_d4">Año 2023</td>
+							</tr>
+			<tr data-id="pub.68_12319">		
+								<td headers="col1_d4">31</td>
+									<td headers="col2_d4">Marzo</td>
+									<td headers="col3_d4">Estadística estructural de empresas: Sector Comercio</td>
+								<td headers="col4_d4">Año 2024</td>
+							</tr>
+			<tr data-id="pub.84_12321">		
+								<td headers="col1_d4">31</td>
+									<td headers="col2_d4">Marzo</td>
+									<td headers="col3_d4">Estadística estructural de empresas: Sector Servicios</td>
+								<td headers="col4_d4">Año 2024</td>
+							</tr>
+			<tr data-id="pub.112_12317">		
+								<td headers="col1_d4">26</td>
+									<td headers="col2_d4">Mayo</td>
+									<td headers="col3_d4">Estadística de Productos en el Sector Comercio</td>
+								<td headers="col4_d4">Año 2024</td>
+							</tr>
+			<tr data-id="pub.85_12318">		
+								<td headers="col1_d4">26</td>
+									<td headers="col2_d4">Mayo</td>
+									<td headers="col3_d4">Estadística de Productos en el Sector Servicios</td>
+								<td headers="col4_d4">Año 2024</td>
+							</tr>
+			<tr data-id="pub.480_12343">		
+								<td headers="col1_d4" colspan="2" >Julio</td>
+  									<td headers="col3_d4">Estadística sobre Transporte Ferroviario. Anuales</td>
+								<td headers="col4_d4">Año 2025</td>
+							</tr>
+			</tbody>	
+			</table> 
+			</div>
+		</li> 
+<li tabindex="0" role="button">
+ 		<button class="toggle-button nocircle tit">Sociedad y condiciones de vida</button>		
+		<div class="toggle-container content">
+					<table  class=" dominio">
+						<caption hidden></caption> 	  
+							<thead>
+								<tr>
+									<th id="col1_d5" scope="col">Día</th>
+									<th id="col2_d5" scope="col">Mes</th>
+							   		<th id="col3_d5" scope="col">Publicación</th>
+							    	<th id="col4_d5" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>					
+				<tr data-id="pub.344_12368">		
+								<td headers="col1_d5">5</td>
+									<td headers="col2_d5">Febrero</td>
+									<td headers="col3_d5">Encuesta de Condiciones de Vida</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.172_12996">		
+								<td headers="col1_d5">17</td>
+									<td headers="col2_d5">Febrero</td>
+									<td headers="col3_d5">Encuesta de Discapacidad Autonomía Personal y Situaciones de Dependencia</td>
+								<td headers="col4_d5">Esperanzas de vida libre de discapacidad</td>
+							</tr>
+			<tr data-id="pub.341_12346">		
+								<td headers="col1_d5">25</td>
+									<td headers="col2_d5">Febrero</td>
+									<td headers="col3_d5">Encuesta de Población Activa. Media de los cuatro trimestres del año</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.347_12347">		
+								<td headers="col1_d5">25</td>
+									<td headers="col2_d5">Marzo</td>
+									<td headers="col3_d5">Encuesta de Población Activa. Variables de submuestra.</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.170_12367">		
+								<td headers="col1_d5">26</td>
+									<td headers="col2_d5">Marzo</td>
+									<td headers="col3_d5">Encuesta de Morbilidad Hospitalaria</td>
+								<td headers="col4_d5">Año 2024</td>
+							</tr>
+			<tr data-id="pub.420_12369">		
+								<td headers="col1_d5">30</td>
+									<td headers="col2_d5">Marzo</td>
+									<td headers="col3_d5">Encuesta de condiciones de Vida. Módulos.</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.674_13019">		
+								<td headers="col1_d5">27</td>
+									<td headers="col2_d5">Abril</td>
+									<td headers="col3_d5">Encuesta de Condiciones de Vida. Módulo Dificultades de acceso a la vivienda</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.312_12372">		
+								<td headers="col1_d5">30</td>
+									<td headers="col2_d5">Abril</td>
+									<td headers="col3_d5">Estadística de Violencia Doméstica y Violencia de Género</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.90_12371">		
+								<td headers="col1_d5">27</td>
+									<td headers="col2_d5">Mayo</td>
+									<td headers="col3_d5">Estadística de Profesionales Sanitarios Colegiados</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.163_12348">		
+								<td headers="col1_d5">28</td>
+									<td headers="col2_d5">Mayo</td>
+									<td headers="col3_d5">Encuesta Anual de Estructura Salarial</td>
+								<td headers="col4_d5">Definitivos 2024</td>
+							</tr>
+			<tr data-id="pub.374_12350">		
+								<td headers="col1_d5">19</td>
+									<td headers="col2_d5">Junio</td>
+									<td headers="col3_d5">Módulo EPA. Conciliación vida familiar y laboral</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.381_12373">		
+								<td headers="col1_d5">25</td>
+									<td headers="col2_d5">Junio</td>
+									<td headers="col3_d5">Encuesta de Presupuestos Familiares</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.161_12349">		
+								<td headers="col1_d5">26</td>
+									<td headers="col2_d5">Junio</td>
+									<td headers="col3_d5">Índice de precios del trabajo</td>
+								<td headers="col4_d5">Año 2024</td>
+							</tr>
+			<tr data-id="pub.74_12377">		
+								<td headers="col1_d5">30</td>
+									<td headers="col2_d5">Junio</td>
+									<td headers="col3_d5">Estadística de defunciones según la causa de muerte</td>
+								<td headers="col4_d5">Resultados provisionales 2025</td>
+							</tr>
+			<tr data-id="pub.162_12351">		
+								<td headers="col1_d5" colspan="2" >Julio</td>
+  									<td headers="col3_d5">Encuesta Anual de Coste Laboral</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.108_12375">		
+								<td headers="col1_d5" colspan="2" >Julio</td>
+  									<td headers="col3_d5">Estadística de Condenados: Adultos</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.109_12376">		
+								<td headers="col1_d5" colspan="2" >Julio</td>
+  									<td headers="col3_d5">Estadística de Condenados: Menores</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.552_12352">		
+								<td headers="col1_d5" colspan="2" >Julio</td>
+  									<td headers="col3_d5">Estadística de Discapacidad y Mercado Laboral: Vida Laboral</td>
+								<td headers="col4_d5">Año 2024</td>
+							</tr>
+			<tr data-id="pub.106_12374">		
+								<td headers="col1_d5" colspan="2" >Julio</td>
+  									<td headers="col3_d5">Estadística de nulidades, separaciones y divorcios</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.315_12353">		
+								<td headers="col1_d5" colspan="2" >Septiembre</td>
+  									<td headers="col3_d5">Estadística de Discapacidad y Mercado Laboral: Salarios</td>
+								<td headers="col4_d5">Año 2024</td>
+							</tr>
+			<tr data-id="pub.644_12382">		
+								<td headers="col1_d5" colspan="2" >Octubre</td>
+  									<td headers="col3_d5">Encuesta de Salud de España</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.507_12378">		
+								<td headers="col1_d5" colspan="2" >Octubre</td>
+  									<td headers="col3_d5">Atlas de distribución de renta de los hogares</td>
+								<td headers="col4_d5">Año 2024</td>
+							</tr>
+			<tr data-id="pub.405_12370">		
+								<td headers="col1_d5" colspan="2" >Octubre</td>
+  									<td headers="col3_d5">Indicadores Urbanos</td>
+								<td headers="col4_d5">Edición 2026</td>
+							</tr>
+			<tr data-id="pub.237_12379">		
+								<td headers="col1_d5" colspan="2" >Octubre</td>
+  									<td headers="col3_d5">Indicadores de Calidad de Vida. Anual</td>
+								<td headers="col4_d5">Edición 2026</td>
+							</tr>
+			<tr data-id="pub.348_12354">		
+								<td headers="col1_d5" colspan="2" >Noviembre</td>
+  									<td headers="col3_d5">Encuesta de población activa. Decil de salarios del empleo principal</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.175_12380">		
+								<td headers="col1_d5" colspan="2" >Noviembre</td>
+  									<td headers="col3_d5">Encuesta sobre Equipamiento y Uso de Tecnologías de Información y Comunicación de los Hogares (TIC-H)</td>
+								<td headers="col4_d5">Año 2026</td>
+							</tr>
+			<tr data-id="pub.174_12387">		
+								<td headers="col1_d5" colspan="2" >Diciembre</td>
+  									<td headers="col3_d5">Encuesta de Empleo del Tiempo</td>
+								<td headers="col4_d5">2024/2025</td>
+							</tr>
+			<tr data-id="pub.176_12383">		
+								<td headers="col1_d5" colspan="2" >Diciembre</td>
+  									<td headers="col3_d5">Encuesta de Transición Educativa - Formativa e Inserción Laboral</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.165_12355">		
+								<td headers="col1_d5" colspan="2" >Diciembre</td>
+  									<td headers="col3_d5">Estadística de Discapacidad y Mercado Laboral: Empleo</td>
+								<td headers="col4_d5">Año 2025</td>
+							</tr>
+			<tr data-id="pub.74_12381">		
+								<td headers="col1_d5" colspan="2" >Diciembre</td>
+  									<td headers="col3_d5">Estadística de defunciones según la causa de muerte</td>
+								<td headers="col4_d5">Resultados definitivos 2025</td>
+							</tr>
+			</tbody>	
+			</table> 
+			</div>
+		</li> 
+</ul> 
+</div>
+	<div class="tipo Publicacion">
+	<h2>Estadísticas Experimentales</h2>
+	<ul class="twoCols">
+	<li tabindex="0" role="button">
+						<button  id="idPubli_649" class="toggle-button nocircle tit">Experimental: Cuentas Trimestrales de Emisiones a la Atmósfera</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/ceatr/experimental_ceatr.htm" 								
+										title="Información detallada de: Cuentas de Emisiones a la Atmósfera Trimestrales "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p649" scope="col">Día</th>
+							   		<th id="col2_p649" scope="col">Mes</th>
+							    	<th id="col3_p649" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p649">28</td>
+								<td headers="col2_p649">Enero</td>
+								<td headers="col3_p649">Trimestre 3/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p649">18</td>
+								<td headers="col2_p649">Febrero</td>
+								<td headers="col3_p649">Trimestre 3/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p649">28</td>
+								<td headers="col2_p649">Abril</td>
+								<td headers="col3_p649">Trimestre 4/2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_558" class="toggle-button nocircle tit">Experimental: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/gasto_tarjetas/trimestral.htm" 								
+										title="Información detallada de: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p558" scope="col">Día</th>
+							   		<th id="col2_p558" scope="col">Mes</th>
+							    	<th id="col3_p558" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p558">1</td>
+								<td headers="col2_p558">Abril</td>
+								<td headers="col3_p558">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_559" class="toggle-button nocircle tit">Experimental: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/gasto_tarjetas/trimestral.htm" 								
+										title="Información detallada de: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p559" scope="col">Día</th>
+							   		<th id="col2_p559" scope="col">Mes</th>
+							    	<th id="col3_p559" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p559">2</td>
+								<td headers="col2_p559">Enero</td>
+								<td headers="col3_p559">Trimestre 3/2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p559">1</td>
+								<td headers="col2_p559">Abril</td>
+								<td headers="col3_p559">Trimestre 4/2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_612" class="toggle-button nocircle tit">Experimental: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/turismo_gasto/turistas_residentes_gasto_extranjero.htm" 								
+										title="Información detallada de: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p612" scope="col">Día</th>
+							   		<th id="col2_p612" scope="col">Mes</th>
+							    	<th id="col3_p612" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p612">20</td>
+								<td headers="col2_p612">Abril</td>
+								<td headers="col3_p612">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_613" class="toggle-button nocircle tit">Experimental: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/turismo_gasto/turistas_residentes_gasto_extranjero.htm" 								
+										title="Información detallada de: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p613" scope="col">Día</th>
+							   		<th id="col2_p613" scope="col">Mes</th>
+							    	<th id="col3_p613" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p613">5</td>
+								<td headers="col2_p613">Enero</td>
+								<td headers="col3_p613">Septiembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p613">20</td>
+								<td headers="col2_p613">Abril</td>
+								<td headers="col3_p613">Diciembre 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_596" class="toggle-button nocircle tit">Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_emisor" 								
+										title="Información detallada de: Medición del turismo emisor a partir de la posición de los teléfonos móviles "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p596" scope="col">Día</th>
+							   		<th id="col2_p596" scope="col">Mes</th>
+							    	<th id="col3_p596" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p596">14</td>
+								<td headers="col2_p596">Enero</td>
+								<td headers="col3_p596">Octubre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p596">10</td>
+								<td headers="col2_p596">Febrero</td>
+								<td headers="col3_p596">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p596">17</td>
+								<td headers="col2_p596">Febrero</td>
+								<td headers="col3_p596">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p596">12</td>
+								<td headers="col2_p596">Marzo</td>
+								<td headers="col3_p596">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p596">15</td>
+								<td headers="col2_p596">Abril</td>
+								<td headers="col3_p596">Febrero 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_597" class="toggle-button nocircle tit">Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles_interno.htm" 								
+										title="Información detallada de: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p597" scope="col">Día</th>
+							   		<th id="col2_p597" scope="col">Mes</th>
+							    	<th id="col3_p597" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p597">14</td>
+								<td headers="col2_p597">Enero</td>
+								<td headers="col3_p597">Octubre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p597">10</td>
+								<td headers="col2_p597">Febrero</td>
+								<td headers="col3_p597">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p597">17</td>
+								<td headers="col2_p597">Febrero</td>
+								<td headers="col3_p597">Diciembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p597">12</td>
+								<td headers="col2_p597">Marzo</td>
+								<td headers="col3_p597">Enero 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p597">15</td>
+								<td headers="col2_p597">Abril</td>
+								<td headers="col3_p597">Febrero 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_595" class="toggle-button nocircle tit">Experimental: Medición del turismo receptor a partir de la posición de los teléfonos móviles</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_receptor" 								
+										title="Información detallada de: Medición del turismo receptor a partir de la posición de los teléfonos móviles "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p595" scope="col">Día</th>
+							   		<th id="col2_p595" scope="col">Mes</th>
+							    	<th id="col3_p595" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p595">14</td>
+								<td headers="col2_p595">Enero</td>
+								<td headers="col3_p595">Octubre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p595">10</td>
+								<td headers="col2_p595">Febrero</td>
+								<td headers="col3_p595">Noviembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p595">17</td>
+								<td headers="col2_p595">Febrero</td>
+								<td headers="col3_p595">Diciembre 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_571" class="toggle-button nocircle tit">Experimental: Ocupación en alojamientos turísticos. Mensual</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/ocupacion/experimental_ocupacion.htm" 								
+										title="Información detallada de: Ocupación en alojamientos turísticos "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p571" scope="col">Día</th>
+							   		<th id="col2_p571" scope="col">Mes</th>
+							    	<th id="col3_p571" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p571">9</td>
+								<td headers="col2_p571">Enero</td>
+								<td headers="col3_p571">Septiembre 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p571">8</td>
+								<td headers="col2_p571">Abril</td>
+								<td headers="col3_p571">Diciembre 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_662" class="toggle-button nocircle tit">Experimental: Visualizador de multilocalización empresarial (VIME)</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+								href="https://www.ine.es/experimental/VIME/experimental_visualizador_empresarial.htm" 							
+								title="Información detallada de: Experimental: Visualizador de multilocalización empresarial (VIME) "></a>
+						<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p662" scope="col">Día</th>
+							   		<th id="col2_p662" scope="col">Mes</th>
+							    	<th id="col3_p662" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p662">19</td>
+								<td headers="col2_p662">Febrero</td>
+								<td headers="col3_p662">Año 2024</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_556" class="toggle-button nocircle tit">Experimental: Viviendas turísticas en España</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/viv_turistica/experimental_viv_turistica.htm" 								
+										title="Información detallada de: Viviendas turísticas en España "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p556" scope="col">Día</th>
+							   		<th id="col2_p556" scope="col">Mes</th>
+							    	<th id="col3_p556" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p556">9</td>
+								<td headers="col2_p556">Febrero</td>
+								<td headers="col3_p556">Noviembre 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_548" class="toggle-button nocircle tit">Experimental: Índice Diario de Comercio al por Menor</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="https://www.ine.es/experimental/cdmge/" 								
+										title="Información detallada de: Comercio diario al por menor de grandes empresas "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p548" scope="col">Día</th>
+							   		<th id="col2_p548" scope="col">Mes</th>
+							    	<th id="col3_p548" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p548">16</td>
+								<td headers="col2_p548">Enero</td>
+								<td headers="col3_p548"> 2025</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">20</td>
+								<td headers="col2_p548">Febrero</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">13</td>
+								<td headers="col2_p548">Marzo</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">20</td>
+								<td headers="col2_p548">Marzo</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">6</td>
+								<td headers="col2_p548">Abril</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">24</td>
+								<td headers="col2_p548">Abril</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">8</td>
+								<td headers="col2_p548">Mayo</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">22</td>
+								<td headers="col2_p548">Mayo</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">5</td>
+								<td headers="col2_p548">Junio</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">19</td>
+								<td headers="col2_p548">Junio</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">3</td>
+								<td headers="col2_p548">Julio</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">24</td>
+								<td headers="col2_p548">Julio</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">31</td>
+								<td headers="col2_p548">Julio</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">21</td>
+								<td headers="col2_p548">Agosto</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">4</td>
+								<td headers="col2_p548">Septiembre</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">25</td>
+								<td headers="col2_p548">Septiembre</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">2</td>
+								<td headers="col2_p548">Octubre</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">23</td>
+								<td headers="col2_p548">Octubre</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">6</td>
+								<td headers="col2_p548">Noviembre</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">20</td>
+								<td headers="col2_p548">Noviembre</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">4</td>
+								<td headers="col2_p548">Diciembre</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p548">18</td>
+								<td headers="col2_p548">Diciembre</td>
+								<td headers="col3_p548"> 2026</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_580" class="toggle-button nocircle tit">Experimental: Índice de Precios de Vivienda en Alquiler</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+								href="https://www.ine.es/experimental/ipva/experimental_precios_vivienda_alquiler.htm" 							
+								title="Información detallada de: Experimental: Índice de Precios de Vivienda en Alquiler "></a>
+						<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p580" scope="col">Día</th>
+							   		<th id="col2_p580" scope="col">Mes</th>
+							    	<th id="col3_p580" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p580">11</td>
+								<td headers="col2_p580">Mayo</td>
+								<td headers="col3_p580">2024</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	</ul>
+	</div>
+	<div class="tipo Publicacion">
+	<h2>Otros</h2>
+	<ul class="twoCols">
+	<li tabindex="0" role="button">
+						<button  id="idPubli_455" class="toggle-button nocircle tit">Mujeres y Hombres en España. Delito y violencia</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176984&idp=1254735576508" 								
+										title="Información detallada de: Mujeres y Hombres en España "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p455" scope="col">Día</th>
+							   		<th id="col2_p455" scope="col">Mes</th>
+							    	<th id="col3_p455" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p455">12</td>
+								<td headers="col2_p455">Febrero</td>
+								<td headers="col3_p455">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_456" class="toggle-button nocircle tit">Mujeres y Hombres en España. Poder y toma de decisiones</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+										href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176984&idp=1254735576508" 								
+										title="Información detallada de: Mujeres y Hombres en España "></a>
+									<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p456" scope="col">Día</th>
+							   		<th id="col2_p456" scope="col">Mes</th>
+							    	<th id="col3_p456" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p456">12</td>
+								<td headers="col2_p456">Febrero</td>
+								<td headers="col3_p456">Año 2025</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	<li tabindex="0" role="button">
+						<button  id="idPubli_636" class="toggle-button nocircle tit">Panel de Indicadores Ambientales</button>											
+						<div class="content toggle-container">		
+						<a class="ii ii-file"						
+								href="https://ine.es/infografias/medioambiente/panel_ind_medioambiente.htm" 							
+								title="Información detallada de: Panel de Indicadores Ambientales "></a>
+						<table class="publicacion">
+							<caption hidden></caption>
+							<thead>
+								<tr>
+									<th id="col1_p636" scope="col">Día</th>
+							   		<th id="col2_p636" scope="col">Mes</th>
+							    	<th id="col3_p636" scope="col">Periodo de referencia</th>
+								</tr>
+							</thead>
+							<tbody>
+				<tr>
+					 		<td headers="col1_p636">19</td>
+								<td headers="col2_p636">Marzo</td>
+								<td headers="col3_p636">Año 2024</td>
+						 	</tr>
+			<tr>
+					 		<td headers="col1_p636">5</td>
+								<td headers="col2_p636">Junio</td>
+								<td headers="col3_p636">Año 2024</td>
+						 	</tr>
+			</tbody>
+				</table>
+			</div>					
+		</li>
+	</ul>
+	</div>
+	</div>
+		
+			<div id="ene" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Enero 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0120261" scope="col">Día</th>
+		<th id="field2_0120262" scope="col">Operación Estadística</th>
+		<th id="field2_0120263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0120261">2</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">2</td>			
+			<td headers="field2_0120262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">2</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">9</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">12</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">14</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">15</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0120263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">15</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0120263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">15</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0120263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">16</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">16</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">19</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">20</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">20</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">20</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">21</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">21</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">21</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0120263">Semana 1 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">21</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736163552&idp=1254735576550"
+				title="Información detallada de: Indicadores de Confianza Empresarial ">Indicadores de Confianza Empresarial</a>
+                </td>
+			<td headers="field2_0120263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">26</td>			
+			<td headers="field2_0120262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0120263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">26</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0120263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">26</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0120263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">27</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176918&idp=1254735976595"
+				title="Información detallada de: Encuesta de Población Activa ">Encuesta de Población Activa</a>
+                </td>
+			<td headers="field2_0120263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">27</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176907&idp=1254735976595"
+				title="Información detallada de: Estadística de Flujos de la Población Activa ">Estadística de Flujos de la Población Activa</a>
+                </td>
+			<td headers="field2_0120263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">29</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0120263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">30</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Trimestral de España ">Contabilidad Nacional Trimestral de España</a>
+                </td>
+			<td headers="field2_0120263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">30</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Ponderaciones IPC ">Ponderaciones IPC</a>
+                </td>
+			<td headers="field2_0120263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">30</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Ponderaciones IPCA ">Ponderaciones IPCA</a>
+                </td>
+			<td headers="field2_0120263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">30</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0120263">Avance. Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">30</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0120263">Avance. Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0120261">30</td>			
+			<td headers="field2_0120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0120263">Diciembre 2025</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Enero 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_0120261" scope="col">Día</th>
+		<th id="field1_0120262" scope="col">Operación Estadística</th>
+		<th id="field1_0120263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_0120261">28</td>			
+			<td headers="field1_0120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177010&idp=1254735572981"
+				title="Información detallada de: Nomenclátor: Población por Unidad Poblacional ">Nomenclátor: Población por Unidad Poblacional</a>
+                </td>
+			<td headers="field1_0120263">01/01/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0120261">29</td>			
+			<td headers="field1_0120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177111&idp=1254735576778"
+				title="Información detallada de: Comercio Internacional de Servicios por Modos de Suministro (MoS) ">Comercio Internacional de Servicios por Modos de Suministro (MoS)</a>
+                </td>
+			<td headers="field1_0120263">Año 2024</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Enero 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0120261" scope="col">Día</th>
+		<th id="field3_0120262" scope="col">Operación Estadística</th>
+		<th id="field3_0120263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0120261">2</td>			
+			<td headers="field3_0120262">
+			<a 
+				href="https://www.ine.es/experimental/gasto_tarjetas/trimestral.htm"
+				title="Información detallada de: Experimental: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España ">Experimental: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España</a>
+                </td>
+			<td headers="field3_0120263">Trimestre 3/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0120261">5</td>			
+			<td headers="field3_0120262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_gasto/turistas_residentes_gasto_extranjero.htm"
+				title="Información detallada de: Experimental: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino ">Experimental: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino</a>
+                </td>
+			<td headers="field3_0120263">Septiembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0120261">9</td>			
+			<td headers="field3_0120262">
+			<a 
+				href="https://www.ine.es/experimental/ocupacion/experimental_ocupacion.htm"
+				title="Información detallada de: Experimental: Ocupación en alojamientos turísticos. Mensual ">Experimental: Ocupación en alojamientos turísticos. Mensual</a>
+                </td>
+			<td headers="field3_0120263">Septiembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0120261">14</td>			
+			<td headers="field3_0120262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_emisor"
+				title="Información detallada de: Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0120263">Octubre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0120261">14</td>			
+			<td headers="field3_0120262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles_interno.htm"
+				title="Información detallada de: Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0120263">Octubre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0120261">14</td>			
+			<td headers="field3_0120262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_receptor"
+				title="Información detallada de: Experimental: Medición del turismo receptor a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo receptor a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0120263">Octubre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0120261">16</td>			
+			<td headers="field3_0120262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0120263"> 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0120261">28</td>			
+			<td headers="field3_0120262">
+			<a 
+				href="https://www.ine.es/experimental/ceatr/experimental_ceatr.htm"
+				title="Información detallada de: Experimental: Cuentas Trimestrales de Emisiones a la Atmósfera ">Experimental: Cuentas Trimestrales de Emisiones a la Atmósfera</a>
+                </td>
+			<td headers="field3_0120263">Trimestre 3/2025</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+
+			<div id="feb" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Febrero 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0220261" scope="col">Día</th>
+		<th id="field2_0220262" scope="col">Operación Estadística</th>
+		<th id="field2_0220263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0220261">2</td>			
+			<td headers="field2_0220262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">3</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico ">Encuesta de Gasto Turístico</a>
+                </td>
+			<td headers="field2_0220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">3</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">3</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">3</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos turísticos en fronteras ">Movimientos turísticos en fronteras</a>
+                </td>
+			<td headers="field2_0220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">6</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">10</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">11</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">12</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177095&idp=1254735572981"
+				title="Información detallada de: Estadística Continua de Población ">Estadística Continua de Población</a>
+                </td>
+			<td headers="field2_0220263">2026-01-01</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">13</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0220263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">13</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0220263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">13</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0220263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">18</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">18</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">18</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0220263">Semana 5 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">19</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas ">Hipotecas</a>
+                </td>
+			<td headers="field2_0220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">19</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">20</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">20</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad. Resultados anuales ">Estadística de Transmisiones de Derechos de la Propiedad. Resultados anuales</a>
+                </td>
+			<td headers="field2_0220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">20</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">20</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">24</td>			
+			<td headers="field2_0220262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0220263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">24</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">24</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">25</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">25</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0220263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">27</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0220263">Avance. Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">27</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0220263">Avance. Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0220261">27</td>			
+			<td headers="field2_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0220263">Enero 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Febrero 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_0220261" scope="col">Día</th>
+		<th id="field1_0220262" scope="col">Operación Estadística</th>
+		<th id="field1_0220263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_0220261">4</td>			
+			<td headers="field1_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177031&idp=1254734710990"
+				title="Información detallada de: Relación de municipios, provincias, comunidades autónomas y sus códigos ">Relación de municipios, provincias, comunidades autónomas y sus códigos</a>
+                </td>
+			<td headers="field1_0220263">01/01/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0220261">5</td>			
+			<td headers="field1_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176807&idp=1254735976608"
+				title="Información detallada de: Encuesta de Condiciones de Vida ">Encuesta de Condiciones de Vida</a>
+                </td>
+			<td headers="field1_0220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0220261">17</td>			
+			<td headers="field1_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176782&idp=1254735573175"
+				title="Información detallada de: Encuesta de Discapacidad Autonomía Personal y Situaciones de Dependencia ">Encuesta de Discapacidad Autonomía Personal y Situaciones de Dependencia</a>
+                </td>
+			<td headers="field1_0220263">Esperanzas de vida libre de discapacidad</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0220261">19</td>			
+			<td headers="field1_0220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177112&idp=1254735576778"
+				title="Información detallada de: Comercio Internacional de Servicios por Características de las Empresas (STEC) ">Comercio Internacional de Servicios por Características de las Empresas (STEC)</a>
+                </td>
+			<td headers="field1_0220263">Año 2023</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0220261">25</td>			
+			<td headers="field1_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176918&idp=1254735976595"
+				title="Información detallada de: Encuesta de Población Activa. Media de los cuatro trimestres del año ">Encuesta de Población Activa. Media de los cuatro trimestres del año</a>
+                </td>
+			<td headers="field1_0220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0220261">26</td>			
+			<td headers="field1_0220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177120&idp=1254735576581"
+				title="Información detallada de: Cuenta satélite de la economía social ">Cuenta satélite de la economía social</a>
+                </td>
+			<td headers="field1_0220263">Años 2019-2023</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0220261">26</td>			
+			<td headers="field1_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176808&idp=1254735576669"
+				title="Información detallada de: Estadística sobre el uso de biotecnología ">Estadística sobre el uso de biotecnología</a>
+                </td>
+			<td headers="field1_0220263">Año 2024</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Febrero 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0220261" scope="col">Día</th>
+		<th id="field3_0220262" scope="col">Operación Estadística</th>
+		<th id="field3_0220263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0220261">9</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/viv_turistica/experimental_viv_turistica.htm"
+				title="Información detallada de: Experimental: Viviendas turísticas en España ">Experimental: Viviendas turísticas en España</a>
+                </td>
+			<td headers="field3_0220263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">10</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_emisor"
+				title="Información detallada de: Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0220263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">10</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles_interno.htm"
+				title="Información detallada de: Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0220263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">10</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_receptor"
+				title="Información detallada de: Experimental: Medición del turismo receptor a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo receptor a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0220263">Noviembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">17</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_emisor"
+				title="Información detallada de: Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">17</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles_interno.htm"
+				title="Información detallada de: Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">17</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_receptor"
+				title="Información detallada de: Experimental: Medición del turismo receptor a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo receptor a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0220263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">18</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/ceatr/experimental_ceatr.htm"
+				title="Información detallada de: Experimental: Cuentas Trimestrales de Emisiones a la Atmósfera ">Experimental: Cuentas Trimestrales de Emisiones a la Atmósfera</a>
+                </td>
+			<td headers="field3_0220263">Trimestre 3/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">19</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/VIME/experimental_visualizador_empresarial.htm"
+				title="Información detallada de: Experimental: Visualizador de multilocalización empresarial (VIME) ">Experimental: Visualizador de multilocalización empresarial (VIME)</a>
+                </td>
+			<td headers="field3_0220263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0220261">20</td>			
+			<td headers="field3_0220262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0220263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Otros Febrero 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field4_0220261" scope="col">Día</th>
+		<th id="field4_0220262" scope="col">Operación Estadística</th>
+		<th id="field4_0220263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field4_0220261">12</td>			
+			<td headers="field4_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176984&idp=1254735576508"
+				title="Información detallada de: Mujeres y Hombres en España. Delito y violencia ">Mujeres y Hombres en España. Delito y violencia</a>
+                </td>
+			<td headers="field4_0220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field4_0220261">12</td>			
+			<td headers="field4_0220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176984&idp=1254735576508"
+				title="Información detallada de: Mujeres y Hombres en España. Poder y toma de decisiones ">Mujeres y Hombres en España. Poder y toma de decisiones</a>
+                </td>
+			<td headers="field4_0220263">Año 2025</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+
+			<div id="mar" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Marzo 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0320261" scope="col">Día</th>
+		<th id="field2_0320262" scope="col">Operación Estadística</th>
+		<th id="field2_0320263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0320261">2</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177040&idp=1254735576820"
+				title="Información detallada de: Estadística sobre Transporte Ferroviario ">Estadística sobre Transporte Ferroviario</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">3</td>			
+			<td headers="field2_0320262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">4</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176995&idp=1254735576799"
+				title="Información detallada de: Encuesta Coyuntural sobre Stocks y Existencias-Trimestral ">Encuesta Coyuntural sobre Stocks y Existencias-Trimestral</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">4</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico ">Encuesta de Gasto Turístico</a>
+                </td>
+			<td headers="field2_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">4</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">4</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">4</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos turísticos en fronteras ">Movimientos turísticos en fronteras</a>
+                </td>
+			<td headers="field2_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">5</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">6</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176993&idp=1254735576606"
+				title="Información detallada de: Estadística sobre Ejecuciones Hipotecarias ">Estadística sobre Ejecuciones Hipotecarias</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">6</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176993&idp=1254735576606"
+				title="Información detallada de: Estadística sobre Ejecuciones Hipotecarias. Anual ">Estadística sobre Ejecuciones Hipotecarias. Anual</a>
+                </td>
+			<td headers="field2_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">6</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736152838&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Vivienda ">Índice de Precios de Vivienda</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">6</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736152838&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Vivienda. Medias Anuales ">Índice de Precios de Vivienda. Medias Anuales</a>
+                </td>
+			<td headers="field2_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">10</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736053992&idp=1254735976596"
+				title="Información detallada de: Índice de Coste Laboral Armonizado ">Índice de Coste Laboral Armonizado</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">11</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">11</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">11</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">11</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor. Ponderaciones  ">Índices de Comercio al por menor. Ponderaciones </a>
+                </td>
+			<td headers="field2_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">13</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0320263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">13</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">13</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0320263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">13</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0320263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">17</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736045053&idp=1254735976596"
+				title="Información detallada de: Encuesta Trimestral de Coste Laboral ">Encuesta Trimestral de Coste Laboral</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">17</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778"
+				title="Información detallada de: Índice de Precios del Sector Servicios ">Índice de Precios del Sector Servicios</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">17</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778"
+				title="Información detallada de: Índice de Precios del Sector Servicios. Medias anuales ">Índice de Precios del Sector Servicios. Medias anuales</a>
+                </td>
+			<td headers="field2_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">18</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">18</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">18</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0320263">Semana 9 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">20</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">23</td>			
+			<td headers="field2_0320262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0320263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">23</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">23</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios. Ponderaciones ">Indicadores de actividad del sector servicios. Ponderaciones</a>
+                </td>
+			<td headers="field2_0320263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">23</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">24</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">24</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">24</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">25</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0320263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">25</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">25</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios. Ponderaciones ">Índice de Producción del Sector Servicios. Ponderaciones</a>
+                </td>
+			<td headers="field2_0320263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">26</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Trimestral de España ">Contabilidad Nacional Trimestral de España</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">26</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863"
+				title="Información detallada de: Encuesta de  turismo de residentes. Mensual ">Encuesta de  turismo de residentes. Mensual</a>
+                </td>
+			<td headers="field2_0320263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">26</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863"
+				title="Información detallada de: Encuesta de turismo de residentes ">Encuesta de turismo de residentes</a>
+                </td>
+			<td headers="field2_0320263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">26</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863"
+				title="Información detallada de: Encuesta de turismo de residentes anual ">Encuesta de turismo de residentes anual</a>
+                </td>
+			<td headers="field2_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">27</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0320263">Avance. Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">27</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0320263">Avance. Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">30</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0320263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">30</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor. Ponderaciones  ">Índices de Comercio al por menor. Ponderaciones </a>
+                </td>
+			<td headers="field2_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">30</td>			
+			<td headers="field2_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0320263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0320261">31</td>			
+			<td headers="field2_0320262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0320263">Febrero 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Marzo 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_0320261" scope="col">Día</th>
+		<th id="field1_0320262" scope="col">Operación Estadística</th>
+		<th id="field1_0320263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_0320261">19</td>			
+			<td headers="field1_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177014&idp=1254734710990"
+				title="Información detallada de: Estadística del Padrón de la Población Española Residente en el Extranjero ">Estadística del Padrón de la Población Española Residente en el Extranjero</a>
+                </td>
+			<td headers="field1_0320263">01/01/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0320261">25</td>			
+			<td headers="field1_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176918&idp=1254735976595"
+				title="Información detallada de: Encuesta de Población Activa. Variables de submuestra. ">Encuesta de Población Activa. Variables de submuestra.</a>
+                </td>
+			<td headers="field1_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0320261">26</td>			
+			<td headers="field1_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176778&idp=1254735573175"
+				title="Información detallada de: Encuesta de Morbilidad Hospitalaria ">Encuesta de Morbilidad Hospitalaria</a>
+                </td>
+			<td headers="field1_0320263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0320261">30</td>			
+			<td headers="field1_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176807&idp=1254735976608"
+				title="Información detallada de: Encuesta de condiciones de Vida. Módulos. ">Encuesta de condiciones de Vida. Módulos.</a>
+                </td>
+			<td headers="field1_0320263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0320261">31</td>			
+			<td headers="field1_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736143952&idp=1254735576715"
+				title="Información detallada de: Estadística Estructural de Empresas: Sector Industrial ">Estadística Estructural de Empresas: Sector Industrial</a>
+                </td>
+			<td headers="field1_0320263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0320261">31</td>			
+			<td headers="field1_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176902&idp=1254735576799"
+				title="Información detallada de: Estadística estructural de empresas: Sector Comercio ">Estadística estructural de empresas: Sector Comercio</a>
+                </td>
+			<td headers="field1_0320263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0320261">31</td>			
+			<td headers="field1_0320262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176865&idp=1254735576778"
+				title="Información detallada de: Estadística estructural de empresas: Sector Servicios ">Estadística estructural de empresas: Sector Servicios</a>
+                </td>
+			<td headers="field1_0320263">Año 2024</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Marzo 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0320261" scope="col">Día</th>
+		<th id="field3_0320262" scope="col">Operación Estadística</th>
+		<th id="field3_0320263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0320261">12</td>			
+			<td headers="field3_0320262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_emisor"
+				title="Información detallada de: Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0320261">12</td>			
+			<td headers="field3_0320262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles_interno.htm"
+				title="Información detallada de: Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0320263">Enero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0320261">13</td>			
+			<td headers="field3_0320262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0320263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0320261">20</td>			
+			<td headers="field3_0320262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0320263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Otros Marzo 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field4_0320261" scope="col">Día</th>
+		<th id="field4_0320262" scope="col">Operación Estadística</th>
+		<th id="field4_0320263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field4_0320261">19</td>			
+			<td headers="field4_0320262">
+			<a 
+				href="https://ine.es/infografias/medioambiente/panel_ind_medioambiente.htm"
+				title="Información detallada de: Panel de Indicadores Ambientales ">Panel de Indicadores Ambientales</a>
+                </td>
+			<td headers="field4_0320263">Año 2024</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div id="abr" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Abril 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0420261" scope="col">Día</th>
+		<th id="field2_0420262" scope="col">Operación Estadística</th>
+		<th id="field2_0420263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0420261">1</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736165305&idp=1254735576581"
+				title="Información detallada de: Cuentas Trimestrales no Financieras de los Sectores Institucionales ">Cuentas Trimestrales no Financieras de los Sectores Institucionales</a>
+                </td>
+			<td headers="field2_0420263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">1</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">1</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">9</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">10</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">13</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">13</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">14</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736163552&idp=1254735576550"
+				title="Información detallada de: Indicadores de Confianza Empresarial ">Indicadores de Confianza Empresarial</a>
+                </td>
+			<td headers="field2_0420263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">14</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0420263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">14</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0420263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">14</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0420263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">17</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">17</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios. Ponderaciones ">Indicadores de actividad del sector servicios. Ponderaciones</a>
+                </td>
+			<td headers="field2_0420263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">17</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">17</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">21</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">22</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">22</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">22</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0420263">Semana 14 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">22</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">23</td>			
+			<td headers="field2_0420262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0420263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">23</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">24</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">24</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0420263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">28</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176918&idp=1254735976595"
+				title="Información detallada de: Encuesta de Población Activa ">Encuesta de Población Activa</a>
+                </td>
+			<td headers="field2_0420263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">28</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176907&idp=1254735976595"
+				title="Información detallada de: Estadística de Flujos de la Población Activa ">Estadística de Flujos de la Población Activa</a>
+                </td>
+			<td headers="field2_0420263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">28</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0420263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">29</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0420263">Avance. Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">29</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0420263">Avance. Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">30</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Trimestral de España ">Contabilidad Nacional Trimestral de España</a>
+                </td>
+			<td headers="field2_0420263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0420261">30</td>			
+			<td headers="field2_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0420263">Marzo 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Abril 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_0420261" scope="col">Día</th>
+		<th id="field1_0420262" scope="col">Operación Estadística</th>
+		<th id="field1_0420263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_0420261">23</td>			
+			<td headers="field1_0420262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177009&idp=1254735572981"
+				title="Información detallada de: Apellidos y nombres más frecuentes ">Apellidos y nombres más frecuentes</a>
+                </td>
+			<td headers="field1_0420263">01/01/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0420261">24</td>			
+			<td headers="field1_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736167628&idp=1254735576581"
+				title="Información detallada de: Contabilidad regional de España. Gasto en consumo final de los hogares ">Contabilidad regional de España. Gasto en consumo final de los hogares</a>
+                </td>
+			<td headers="field1_0420263">Serie 2016-2023</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0420261">24</td>			
+			<td headers="field1_0420262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736167628&idp=1254735576581"
+				title="Información detallada de: Índices de Reparto Regional del IVA y los Impuestos Especiales sobre la Cerveza, sobre el Alcohol y Bebidas derivadas y sobre productos Intermedios ">Índices de Reparto Regional del IVA y los Impuestos Especiales sobre la Cerveza, sobre el Alcohol y Bebidas derivadas y sobre productos Intermedios</a>
+                </td>
+			<td headers="field1_0420263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0420261">27</td>			
+			<td headers="field1_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176807&idp=1254735976608"
+				title="Información detallada de: Encuesta de Condiciones de Vida. Módulo Dificultades de acceso a la vivienda ">Encuesta de Condiciones de Vida. Módulo Dificultades de acceso a la vivienda</a>
+                </td>
+			<td headers="field1_0420263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0420261">29</td>			
+			<td headers="field1_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176992&idp=1254735572981"
+				title="Información detallada de: Censos Anuales de Población. Variables de residencia, educativas y laborales. ">Censos Anuales de Población. Variables de residencia, educativas y laborales.</a>
+                </td>
+			<td headers="field1_0420263">01/01/2024 y 01/01/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0420261">30</td>			
+			<td headers="field1_0420262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176866&idp=1254735573206"
+				title="Información detallada de: Estadística de Violencia Doméstica y Violencia de Género ">Estadística de Violencia Doméstica y Violencia de Género</a>
+                </td>
+			<td headers="field1_0420263">Año 2025</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Abril 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0420261" scope="col">Día</th>
+		<th id="field3_0420262" scope="col">Operación Estadística</th>
+		<th id="field3_0420263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0420261">1</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/gasto_tarjetas/trimestral.htm"
+				title="Información detallada de: Experimental: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España ">Experimental: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España</a>
+                </td>
+			<td headers="field3_0420263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">1</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/gasto_tarjetas/trimestral.htm"
+				title="Información detallada de: Experimental: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España ">Experimental: Distribución del gasto en destino realizado por los visitantes extranjeros en sus visitas a España</a>
+                </td>
+			<td headers="field3_0420263">Trimestre 4/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">6</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0420263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">8</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/ocupacion/experimental_ocupacion.htm"
+				title="Información detallada de: Experimental: Ocupación en alojamientos turísticos. Mensual ">Experimental: Ocupación en alojamientos turísticos. Mensual</a>
+                </td>
+			<td headers="field3_0420263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">15</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles.htm#!turismo_emisor"
+				title="Información detallada de: Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo emisor a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">15</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_moviles/experimental_turismo_moviles_interno.htm"
+				title="Información detallada de: Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles ">Experimental: Medición del turismo interno interprovincial a partir de la posición de los teléfonos móviles</a>
+                </td>
+			<td headers="field3_0420263">Febrero 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">20</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_gasto/turistas_residentes_gasto_extranjero.htm"
+				title="Información detallada de: Experimental: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino ">Experimental: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino</a>
+                </td>
+			<td headers="field3_0420263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">20</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/turismo_gasto/turistas_residentes_gasto_extranjero.htm"
+				title="Información detallada de: Experimental: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino ">Experimental: Distribución del gasto realizado por los residentes en sus visitas al Extranjero según país de destino</a>
+                </td>
+			<td headers="field3_0420263">Diciembre 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">24</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0420263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0420261">28</td>			
+			<td headers="field3_0420262">
+			<a 
+				href="https://www.ine.es/experimental/ceatr/experimental_ceatr.htm"
+				title="Información detallada de: Experimental: Cuentas Trimestrales de Emisiones a la Atmósfera ">Experimental: Cuentas Trimestrales de Emisiones a la Atmósfera</a>
+                </td>
+			<td headers="field3_0420263">Trimestre 4/2025</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+
+			<div id="may" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Mayo 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0520261" scope="col">Día</th>
+		<th id="field2_0520262" scope="col">Operación Estadística</th>
+		<th id="field2_0520263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0520261">4</td>			
+			<td headers="field2_0520262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">5</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">5</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">7</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177095&idp=1254735572981"
+				title="Información detallada de: Estadística Continua de Población ">Estadística Continua de Población</a>
+                </td>
+			<td headers="field2_0520263">2026-04-01</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">8</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">12</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">13</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">13</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">14</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0520263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">14</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0520263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">14</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0520263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">18</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">20</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">20</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">20</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0520263">Semana 18 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">21</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">21</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios. Ponderaciones ">Indicadores de actividad del sector servicios. Ponderaciones</a>
+                </td>
+			<td headers="field2_0520263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">21</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">21</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">22</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">25</td>			
+			<td headers="field2_0520262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0520263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">25</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">26</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0520263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">27</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0520263">Marzo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">28</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0520263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">29</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0520263">Avance. Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">29</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0520263">Avance. Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0520261">29</td>			
+			<td headers="field2_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0520263">Abril 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Mayo 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_0520261" scope="col">Día</th>
+		<th id="field1_0520262" scope="col">Operación Estadística</th>
+		<th id="field1_0520263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_0520261">26</td>			
+			<td headers="field1_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736146240&idp=1254735576715"
+				title="Información detallada de: Encuesta de Consumos Energéticos ">Encuesta de Consumos Energéticos</a>
+                </td>
+			<td headers="field1_0520263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0520261">26</td>			
+			<td headers="field1_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176903&idp=1254735576799"
+				title="Información detallada de: Estadística de Productos en el Sector Comercio ">Estadística de Productos en el Sector Comercio</a>
+                </td>
+			<td headers="field1_0520263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0520261">26</td>			
+			<td headers="field1_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176898&idp=1254735576778"
+				title="Información detallada de: Estadística de Productos en el Sector Servicios ">Estadística de Productos en el Sector Servicios</a>
+                </td>
+			<td headers="field1_0520263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0520261">27</td>			
+			<td headers="field1_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176781&idp=1254735573175"
+				title="Información detallada de: Estadística de Profesionales Sanitarios Colegiados ">Estadística de Profesionales Sanitarios Colegiados</a>
+                </td>
+			<td headers="field1_0520263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0520261">28</td>			
+			<td headers="field1_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177025&idp=1254735976596"
+				title="Información detallada de: Encuesta Anual de Estructura Salarial ">Encuesta Anual de Estructura Salarial</a>
+                </td>
+			<td headers="field1_0520263">Definitivos 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0520261">28</td>			
+			<td headers="field1_0520262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177001&idp=1254735573002"
+				title="Información detallada de: Estadística de Adquisiciones de Nacionalidad Española de Residentes ">Estadística de Adquisiciones de Nacionalidad Española de Residentes</a>
+                </td>
+			<td headers="field1_0520263">Año 2025</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Mayo 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0520261" scope="col">Día</th>
+		<th id="field3_0520262" scope="col">Operación Estadística</th>
+		<th id="field3_0520263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0520261">8</td>			
+			<td headers="field3_0520262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0520263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0520261">11</td>			
+			<td headers="field3_0520262">
+			<a 
+				href="https://www.ine.es/experimental/ipva/experimental_precios_vivienda_alquiler.htm"
+				title="Información detallada de: Experimental: Índice de Precios de la Vivienda en Alquiler ">Experimental: Índice de Precios de la Vivienda en Alquiler</a>
+                </td>
+			<td headers="field3_0520263">2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0520261">22</td>			
+			<td headers="field3_0520262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0520263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div id="jun" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Junio 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0620261" scope="col">Día</th>
+		<th id="field2_0620262" scope="col">Operación Estadística</th>
+		<th id="field2_0620263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0620261">1</td>			
+			<td headers="field2_0620262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">2</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">2</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">3</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177040&idp=1254735576820"
+				title="Información detallada de: Estadística sobre Transporte Ferroviario ">Estadística sobre Transporte Ferroviario</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">4</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176995&idp=1254735576799"
+				title="Información detallada de: Encuesta Coyuntural sobre Stocks y Existencias-Trimestral ">Encuesta Coyuntural sobre Stocks y Existencias-Trimestral</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">4</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176995&idp=1254735576799"
+				title="Información detallada de: Encuesta Coyuntural sobre Stocks y Existencias. Ponderaciones ">Encuesta Coyuntural sobre Stocks y Existencias. Ponderaciones</a>
+                </td>
+			<td headers="field2_0620263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">4</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176993&idp=1254735576606"
+				title="Información detallada de: Estadística sobre Ejecuciones Hipotecarias ">Estadística sobre Ejecuciones Hipotecarias</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">4</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">8</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736152838&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Vivienda ">Índice de Precios de Vivienda</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">9</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736053992&idp=1254735976596"
+				title="Información detallada de: Índice de Coste Laboral Armonizado ">Índice de Coste Laboral Armonizado</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">10</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">11</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">12</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0620263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">12</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">12</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0620263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">12</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0620263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">16</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736045053&idp=1254735976596"
+				title="Información detallada de: Encuesta Trimestral de Coste Laboral ">Encuesta Trimestral de Coste Laboral</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">16</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778"
+				title="Información detallada de: Índice de Precios del Sector Servicios ">Índice de Precios del Sector Servicios</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">16</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778"
+				title="Información detallada de: Índice de Precios del Sector Servicios. Medias anuales ">Índice de Precios del Sector Servicios. Medias anuales</a>
+                </td>
+			<td headers="field2_0620263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">17</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">17</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">17</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0620263">Semana 22 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">18</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">19</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">22</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">22</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">22</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios. Ponderaciones ">Indicadores de actividad del sector servicios. Ponderaciones</a>
+                </td>
+			<td headers="field2_0620263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">22</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">23</td>			
+			<td headers="field2_0620262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0620263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">23</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">24</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0620263">Abril 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">25</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Trimestral de España ">Contabilidad Nacional Trimestral de España</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">25</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0620263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">29</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863"
+				title="Información detallada de: Encuesta de turismo de residentes ">Encuesta de turismo de residentes</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">29</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0620263">Avance. Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">29</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0620263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">29</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0620263">Avance. Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">30</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736165305&idp=1254735576581"
+				title="Información detallada de: Cuentas Trimestrales no Financieras de los Sectores Institucionales ">Cuentas Trimestrales no Financieras de los Sectores Institucionales</a>
+                </td>
+			<td headers="field2_0620263">Trimestre 1/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0620261">30</td>			
+			<td headers="field2_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0620263">Mayo 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Junio 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_0620261" scope="col">Día</th>
+		<th id="field1_0620262" scope="col">Operación Estadística</th>
+		<th id="field1_0620263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_0620261">3</td>			
+			<td headers="field1_0620262">
+			Estadística estructural de empresas: Sector Construcción</td>
+			<td headers="field1_0620263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0620261">17</td>			
+			<td headers="field1_0620262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736176953&idp=1254735572981"
+				title="Información detallada de: Proyecciones de Población ">Proyecciones de Población</a>
+                </td>
+			<td headers="field1_0620263">2026-2076</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0620261">17</td>			
+			<td headers="field1_0620262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736176954&idp=1254735572981"
+				title="Información detallada de: Proyección de Hogares ">Proyección de Hogares</a>
+                </td>
+			<td headers="field1_0620263">2026-2041</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0620261">19</td>			
+			<td headers="field1_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176918&idp=1254735976595"
+				title="Información detallada de: Módulo EPA. Conciliación vida familiar y laboral ">Módulo EPA. Conciliación vida familiar y laboral</a>
+                </td>
+			<td headers="field1_0620263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0620261">25</td>			
+			<td headers="field1_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176806&idp=1254735976608"
+				title="Información detallada de: Encuesta de Presupuestos Familiares ">Encuesta de Presupuestos Familiares</a>
+                </td>
+			<td headers="field1_0620263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0620261">26</td>			
+			<td headers="field1_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736149053&idp=1254735576715"
+				title="Información detallada de: Encuesta Industrial Anual de Productos ">Encuesta Industrial Anual de Productos</a>
+                </td>
+			<td headers="field1_0620263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0620261">26</td>			
+			<td headers="field1_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177027&idp=1254735976596"
+				title="Información detallada de: Índice de precios del trabajo ">Índice de precios del trabajo</a>
+                </td>
+			<td headers="field1_0620263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0620261">30</td>			
+			<td headers="field1_0620262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176780&idp=1254735573175"
+				title="Información detallada de: Estadística de defunciones según la causa de muerte ">Estadística de defunciones según la causa de muerte</a>
+                </td>
+			<td headers="field1_0620263">Resultados provisionales 2025</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Junio 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0620261" scope="col">Día</th>
+		<th id="field3_0620262" scope="col">Operación Estadística</th>
+		<th id="field3_0620263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0620261">5</td>			
+			<td headers="field3_0620262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0620263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0620261">19</td>			
+			<td headers="field3_0620262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0620263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Otros Junio 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field4_0620261" scope="col">Día</th>
+		<th id="field4_0620262" scope="col">Operación Estadística</th>
+		<th id="field4_0620263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field4_0620261">5</td>			
+			<td headers="field4_0620262">
+			<a 
+				href="https://ine.es/infografias/medioambiente/panel_ind_medioambiente.htm"
+				title="Información detallada de: Panel de Indicadores Ambientales ">Panel de Indicadores Ambientales</a>
+                </td>
+			<td headers="field4_0620263">Año 2024</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div id="jul" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Julio 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0720261" scope="col">Día</th>
+		<th id="field2_0720262" scope="col">Operación Estadística</th>
+		<th id="field2_0720263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0720261">1</td>			
+			<td headers="field2_0720262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">2</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">2</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">3</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">10</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">10</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">13</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">14</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">14</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736163552&idp=1254735576550"
+				title="Información detallada de: Indicadores de Confianza Empresarial ">Indicadores de Confianza Empresarial</a>
+                </td>
+			<td headers="field2_0720263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">15</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0720263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">15</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0720263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">15</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0720263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">17</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">17</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">20</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">20</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">20</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">21</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">22</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">22</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0720263">Mayo 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">22</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0720263">Semana 27 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">24</td>			
+			<td headers="field2_0720262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0720263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">24</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0720263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">28</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176918&idp=1254735976595"
+				title="Información detallada de: Encuesta de Población Activa ">Encuesta de Población Activa</a>
+                </td>
+			<td headers="field2_0720263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">28</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176907&idp=1254735976595"
+				title="Información detallada de: Estadística de Flujos de la Población Activa ">Estadística de Flujos de la Población Activa</a>
+                </td>
+			<td headers="field2_0720263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">28</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0720263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">29</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0720263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">30</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Trimestral de España ">Contabilidad Nacional Trimestral de España</a>
+                </td>
+			<td headers="field2_0720263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">30</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0720263">Avance. Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">30</td>			
+			<td headers="field2_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0720263">Avance. Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0720261">31</td>			
+			<td headers="field2_0720262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0720263">Junio 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Julio 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_0720261" scope="col">Día</th>
+		<th id="field1_0720262" scope="col">Operación Estadística</th>
+		<th id="field1_0720263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736060920&idp=1254735976596"
+				title="Información detallada de: Encuesta Anual de Coste Laboral ">Encuesta Anual de Coste Laboral</a>
+                </td>
+			<td headers="field1_0720263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176793&idp=1254735573206"
+				title="Información detallada de: Estadística de Condenados: Adultos ">Estadística de Condenados: Adultos</a>
+                </td>
+			<td headers="field1_0720263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176795&idp=1254735573206"
+				title="Información detallada de: Estadística de Condenados: Menores ">Estadística de Condenados: Menores</a>
+                </td>
+			<td headers="field1_0720263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177069&idp=1254735976621"
+				title="Información detallada de: Estadística de Discapacidad y Mercado Laboral: Vida Laboral ">Estadística de Discapacidad y Mercado Laboral: Vida Laboral</a>
+                </td>
+			<td headers="field1_0720263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176798&idp=1254735573206"
+				title="Información detallada de: Estadística de nulidades, separaciones y divorcios ">Estadística de nulidades, separaciones y divorcios</a>
+                </td>
+			<td headers="field1_0720263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177040&idp=1254735576820"
+				title="Información detallada de: Estadística sobre Transporte Ferroviario. Anuales ">Estadística sobre Transporte Ferroviario. Anuales</a>
+                </td>
+			<td headers="field1_0720263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176834&idp=1254735976602"
+				title="Información detallada de: Estadísticas sobre el Suministro y Saneamiento del Agua ">Estadísticas sobre el Suministro y Saneamiento del Agua</a>
+                </td>
+			<td headers="field1_0720263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176846&idp=1254735976612"
+				title="Información detallada de: Estadísticas sobre las actividades de protección medioambiental ">Estadísticas sobre las actividades de protección medioambiental</a>
+                </td>
+			<td headers="field1_0720263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736176979&idp=1254735576669"
+				title="Información detallada de: Indicadores de Alta Tecnología ">Indicadores de Alta Tecnología</a>
+                </td>
+			<td headers="field1_0720263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0720261"></td>			
+			<td headers="field1_0720262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176742&idp=1254735576692"
+				title="Información detallada de: Indicadores del Sector de Tecnologías de la Información y las Comunicaciones (TIC) ">Indicadores del Sector de Tecnologías de la Información y las Comunicaciones (TIC)</a>
+                </td>
+			<td headers="field1_0720263">Año 2024</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Julio 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0720261" scope="col">Día</th>
+		<th id="field3_0720262" scope="col">Operación Estadística</th>
+		<th id="field3_0720263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0720261">3</td>			
+			<td headers="field3_0720262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0720263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0720261">24</td>			
+			<td headers="field3_0720262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0720263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0720261">31</td>			
+			<td headers="field3_0720262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0720263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div id="ago" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Agosto 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0820261" scope="col">Día</th>
+		<th id="field2_0820262" scope="col">Operación Estadística</th>
+		<th id="field2_0820263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0820261">3</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">3</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">6</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177095&idp=1254735572981"
+				title="Información detallada de: Estadística Continua de Población ">Estadística Continua de Población</a>
+                </td>
+			<td headers="field2_0820263">2026-07-01</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">6</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">7</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">7</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">12</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">13</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0820263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">13</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">13</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0820263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">13</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0820263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">14</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">14</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">17</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">18</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">19</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">19</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">19</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0820263">Semana 31 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">20</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">21</td>			
+			<td headers="field2_0820262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0820263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">25</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0820263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">26</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0820263">Junio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">28</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0820263">Avance. Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">28</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0820263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">28</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0820263">Avance. Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">28</td>			
+			<td headers="field2_0820262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0820263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0820261">31</td>			
+			<td headers="field2_0820262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0820263">Julio 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Agosto 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0820261" scope="col">Día</th>
+		<th id="field3_0820262" scope="col">Operación Estadística</th>
+		<th id="field3_0820263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0820261">21</td>			
+			<td headers="field3_0820262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0820263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div id="sep" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Septiembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_0920261" scope="col">Día</th>
+		<th id="field2_0920262" scope="col">Operación Estadística</th>
+		<th id="field2_0920263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_0920261">1</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">1</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">3</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177040&idp=1254735576820"
+				title="Información detallada de: Estadística sobre Transporte Ferroviario ">Estadística sobre Transporte Ferroviario</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">4</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176995&idp=1254735576799"
+				title="Información detallada de: Encuesta Coyuntural sobre Stocks y Existencias-Trimestral ">Encuesta Coyuntural sobre Stocks y Existencias-Trimestral</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">4</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176995&idp=1254735576799"
+				title="Información detallada de: Encuesta Coyuntural sobre Stocks y Existencias. Ponderaciones ">Encuesta Coyuntural sobre Stocks y Existencias. Ponderaciones</a>
+                </td>
+			<td headers="field2_0920263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">7</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736152838&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Vivienda ">Índice de Precios de Vivienda</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">8</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736053992&idp=1254735976596"
+				title="Información detallada de: Índice de Coste Laboral Armonizado ">Índice de Coste Laboral Armonizado</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">10</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">10</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">10</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">14</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">15</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0920263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">15</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778"
+				title="Información detallada de: Índice de Precios del Sector Servicios ">Índice de Precios del Sector Servicios</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">15</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778"
+				title="Información detallada de: Índice de Precios del Sector Servicios. Medias anuales ">Índice de Precios del Sector Servicios. Medias anuales</a>
+                </td>
+			<td headers="field2_0920263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">15</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_0920263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">15</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0920263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">16</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176993&idp=1254735576606"
+				title="Información detallada de: Estadística sobre Ejecuciones Hipotecarias ">Estadística sobre Ejecuciones Hipotecarias</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">16</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176993&idp=1254735576606"
+				title="Información detallada de: Estadística sobre Ejecuciones Hipotecarias. Anual ">Estadística sobre Ejecuciones Hipotecarias. Anual</a>
+                </td>
+			<td headers="field2_0920263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">16</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">16</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">16</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_0920263">Semana 35 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">17</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736045053&idp=1254735976596"
+				title="Información detallada de: Encuesta Trimestral de Coste Laboral ">Encuesta Trimestral de Coste Laboral</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">18</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">21</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">21</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">22</td>			
+			<td headers="field2_0920262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_0920263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">23</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">23</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">24</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863"
+				title="Información detallada de: Encuesta de turismo de residentes ">Encuesta de turismo de residentes</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">24</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_0920263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">25</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Trimestral de España ">Contabilidad Nacional Trimestral de España</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">25</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">25</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad. Resultados anuales ">Estadística de Transmisiones de Derechos de la Propiedad. Resultados anuales</a>
+                </td>
+			<td headers="field2_0920263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">28</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas ">Hipotecas</a>
+                </td>
+			<td headers="field2_0920263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">28</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_0920263">Julio 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">29</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_0920263">Avance. Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">29</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_0920263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">29</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_0920263">Avance. Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">30</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736165305&idp=1254735576581"
+				title="Información detallada de: Cuentas Trimestrales no Financieras de los Sectores Institucionales ">Cuentas Trimestrales no Financieras de los Sectores Institucionales</a>
+                </td>
+			<td headers="field2_0920263">Trimestre 2/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_0920261">30</td>			
+			<td headers="field2_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_0920263">Agosto 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Septiembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_0920261" scope="col">Día</th>
+		<th id="field1_0920262" scope="col">Operación Estadística</th>
+		<th id="field1_0920263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736167628&idp=1254735576581"
+				title="Información detallada de: Contabilidad Regional de España ">Contabilidad Regional de España</a>
+                </td>
+			<td headers="field1_0920263">Avance PIB. Serie 2000-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177056&idp=1254735576581"
+				title="Información detallada de: Contabilidad nacional anual de España: agregados por rama de actividad ">Contabilidad nacional anual de España: agregados por rama de actividad</a>
+                </td>
+			<td headers="field1_0920263">Serie 1995-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177057&idp=1254735576581"
+				title="Información detallada de: Contabilidad nacional anual de España: principales agregados ">Contabilidad nacional anual de España: principales agregados</a>
+                </td>
+			<td headers="field1_0920263">Serie 1995-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177059&idp=1254735576581"
+				title="Información detallada de: Contabilidad nacional anual de España: tablas de Origen y Destino ">Contabilidad nacional anual de España: tablas de Origen y Destino</a>
+                </td>
+			<td headers="field1_0920263">Año 2023</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177054&idp=1254735576581"
+				title="Información detallada de: Cuentas anuales no Financieras de los Sectores Institucionales. ">Cuentas anuales no Financieras de los Sectores Institucionales.</a>
+                </td>
+			<td headers="field1_0920263">Serie 1999-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177006&idp=1254735573002"
+				title="Información detallada de: Encuesta de Fecundidad ">Encuesta de Fecundidad</a>
+                </td>
+			<td headers="field1_0920263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176911&idp=1254735976621"
+				title="Información detallada de: Estadística de Discapacidad y Mercado Laboral: Salarios ">Estadística de Discapacidad y Mercado Laboral: Salarios</a>
+                </td>
+			<td headers="field1_0920263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736161127&idp=1254735576550"
+				title="Información detallada de: Estadística de Empresas según su pertenencia a grupos ">Estadística de Empresas según su pertenencia a grupos</a>
+                </td>
+			<td headers="field1_0920263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736162975&idp=1254735576550"
+				title="Información detallada de: Estadística de filiales de empresas españolas en el exterior ">Estadística de filiales de empresas españolas en el exterior</a>
+                </td>
+			<td headers="field1_0920263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_0920261"></td>			
+			<td headers="field1_0920262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177056&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Anual de España. Agregados por rama de actividad. Balances no financieros por rama de actividad ">Contabilidad Nacional Anual de España. Agregados por rama de actividad. Balances no financieros por rama de actividad</a>
+                </td>
+			<td headers="field1_0920263">Serie 2000-2024</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Septiembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_0920261" scope="col">Día</th>
+		<th id="field3_0920262" scope="col">Operación Estadística</th>
+		<th id="field3_0920263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_0920261">4</td>			
+			<td headers="field3_0920262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0920263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_0920261">25</td>			
+			<td headers="field3_0920262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_0920263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div id="oct" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Octubre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_1020261" scope="col">Día</th>
+		<th id="field2_1020262" scope="col">Operación Estadística</th>
+		<th id="field2_1020263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_1020261">1</td>			
+			<td headers="field2_1020262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">2</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">2</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">6</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">9</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">13</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">14</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_1020263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">14</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">14</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_1020263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">14</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_1020263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">16</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">16</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">19</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">19</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">20</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736163552&idp=1254735576550"
+				title="Información detallada de: Indicadores de Confianza Empresarial ">Indicadores de Confianza Empresarial</a>
+                </td>
+			<td headers="field2_1020263">Trimestre 4/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">20</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">21</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">21</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">21</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_1020263">Semana 40 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">23</td>			
+			<td headers="field2_1020262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_1020263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">26</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">26</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_1020263">Agosto 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">26</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_1020263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">27</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176918&idp=1254735976595"
+				title="Información detallada de: Encuesta de Población Activa ">Encuesta de Población Activa</a>
+                </td>
+			<td headers="field2_1020263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">27</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176907&idp=1254735976595"
+				title="Información detallada de: Estadística de Flujos de la Población Activa ">Estadística de Flujos de la Población Activa</a>
+                </td>
+			<td headers="field2_1020263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">29</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_1020263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">30</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Trimestral de España ">Contabilidad Nacional Trimestral de España</a>
+                </td>
+			<td headers="field2_1020263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">30</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_1020263">Avance. Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">30</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_1020263">Avance. Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1020261">30</td>			
+			<td headers="field2_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_1020263">Septiembre 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Octubre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_1020261" scope="col">Día</th>
+		<th id="field1_1020262" scope="col">Operación Estadística</th>
+		<th id="field1_1020263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_1020261"></td>			
+			<td headers="field1_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177114&idp=1254735573175"
+				title="Información detallada de: Encuesta de Salud de España ">Encuesta de Salud de España</a>
+                </td>
+			<td headers="field1_1020263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1020261"></td>			
+			<td headers="field1_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177088&idp=1254735976608"
+				title="Información detallada de: Atlas de distribución de renta de los hogares ">Atlas de distribución de renta de los hogares</a>
+                </td>
+			<td headers="field1_1020263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1020261"></td>			
+			<td headers="field1_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177059&idp=1254735576581"
+				title="Información detallada de: Contabilidad nacional anual de España: tablas de Origen y Destino ">Contabilidad nacional anual de España: tablas de Origen y Destino</a>
+                </td>
+			<td headers="field1_1020263">Datos provisionales 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1020261"></td>			
+			<td headers="field1_1020262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176743&idp=1254735576692"
+				title="Información detallada de: Encuesta sobre el Uso de Tecnologías de la Información y las Comunicaciones y del Comercio Electrónico en las Empresas ">Encuesta sobre el Uso de Tecnologías de la Información y las Comunicaciones y del Comercio Electrónico en las Empresas</a>
+                </td>
+			<td headers="field1_1020263">2025-2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1020261"></td>			
+			<td headers="field1_1020262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736176957&idp=1254735976608"
+				title="Información detallada de: Indicadores Urbanos ">Indicadores Urbanos</a>
+                </td>
+			<td headers="field1_1020263">Edición 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1020261"></td>			
+			<td headers="field1_1020262">
+			<a 
+				href="https://www.ine.es/dynt3/ICV/index.html"
+				title="Información detallada de: Indicadores de Calidad de Vida. Anual ">Indicadores de Calidad de Vida. Anual</a>
+                </td>
+			<td headers="field1_1020263">Edición 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Octubre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_1020261" scope="col">Día</th>
+		<th id="field3_1020262" scope="col">Operación Estadística</th>
+		<th id="field3_1020263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_1020261">2</td>			
+			<td headers="field3_1020262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_1020263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_1020261">23</td>			
+			<td headers="field3_1020262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_1020263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div id="nov" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Noviembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_1120261" scope="col">Día</th>
+		<th id="field2_1120262" scope="col">Operación Estadística</th>
+		<th id="field2_1120263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_1120261">3</td>			
+			<td headers="field2_1120262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">4</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">4</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">6</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">12</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177095&idp=1254735572981"
+				title="Información detallada de: Estadística Continua de Población ">Estadística Continua de Población</a>
+                </td>
+			<td headers="field2_1120263">2026-10-01</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">12</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">12</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">13</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_1120263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">13</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">13</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_1120263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">13</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_1120263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">17</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">18</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">18</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">18</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_1120263">Semana 44 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">19</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">20</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">20</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">23</td>			
+			<td headers="field2_1120262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_1120263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">24</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">24</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_1120263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">24</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">25</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_1120263">Septiembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">27</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_1120263">Avance. Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">27</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_1120263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">27</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_1120263">Avance. Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">30</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177040&idp=1254735576820"
+				title="Información detallada de: Estadística sobre Transporte Ferroviario ">Estadística sobre Transporte Ferroviario</a>
+                </td>
+			<td headers="field2_1120263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1120261">30</td>			
+			<td headers="field2_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_1120263">Octubre 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Noviembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_1120261" scope="col">Día</th>
+		<th id="field1_1120262" scope="col">Operación Estadística</th>
+		<th id="field1_1120263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176992&idp=1254735572981"
+				title="Información detallada de: Censos Anuales de Población. Ocupación y actividad. ">Censos Anuales de Población. Ocupación y actividad.</a>
+                </td>
+			<td headers="field1_1120263">01/01/2024,  01/01/2025 y 01/01/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176943&idp=1254735976603"
+				title="Información detallada de: Cuentas Medioambientales. Cuentas de flujos de materiales ">Cuentas Medioambientales. Cuentas de flujos de materiales</a>
+                </td>
+			<td headers="field1_1120263">serie 2008-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176941&idp=1254735976603"
+				title="Información detallada de: Cuentas Medioambientales: Cuenta de Emisiones a la Atmósfera ">Cuentas Medioambientales: Cuenta de Emisiones a la Atmósfera</a>
+                </td>
+			<td headers="field1_1120263">serie 2008-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176942&idp=1254735976603"
+				title="Información detallada de: Cuentas Medioambientales: Cuenta de Impuestos Ambientales ">Cuentas Medioambientales: Cuenta de Impuestos Ambientales</a>
+                </td>
+			<td headers="field1_1120263">serie 2008-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177062&idp=1254735976603"
+				title="Información detallada de: Cuentas Medioambientales: Cuenta de los Residuos ">Cuentas Medioambientales: Cuenta de los Residuos</a>
+                </td>
+			<td headers="field1_1120263">serie 2015-2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177046&idp=1254735976603"
+				title="Información detallada de: Cuentas medioambientales: Cuenta de flujos físicos de la energía ">Cuentas medioambientales: Cuenta de flujos físicos de la energía</a>
+                </td>
+			<td headers="field1_1120263">serie 2015-2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736161927&idp=1254735576550"
+				title="Información detallada de: Demografía Armonizada de Empresas ">Demografía Armonizada de Empresas</a>
+                </td>
+			<td headers="field1_1120263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736176918&menu=resultados&idp=1254735976595#!tabs-1254736195128"
+				title="Información detallada de: Encuesta de población activa. Decil de salarios del empleo principal ">Encuesta de población activa. Decil de salarios del empleo principal</a>
+                </td>
+			<td headers="field1_1120263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176741&idp=1254735976608"
+				title="Información detallada de: Encuesta sobre Equipamiento y Uso de Tecnologías de Información y Comunicación de los Hogares (TIC-H) ">Encuesta sobre Equipamiento y Uso de Tecnologías de Información y Comunicación de los Hogares (TIC-H)</a>
+                </td>
+			<td headers="field1_1120263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177098&idp=1254735573002"
+				title="Información detallada de: Estadística de Migraciones y Cambios de Residencia ">Estadística de Migraciones y Cambios de Residencia</a>
+                </td>
+			<td headers="field1_1120263">2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176754&idp=1254735576669"
+				title="Información detallada de: Estadística sobre actividades en I+D ">Estadística sobre actividades en I+D</a>
+                </td>
+			<td headers="field1_1120263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176844&idp=1254735976612"
+				title="Información detallada de: Estadísticas sobre Recogida y Tratamiento de Residuos ">Estadísticas sobre Recogida y Tratamiento de Residuos</a>
+                </td>
+			<td headers="field1_1120263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176841&idp=1254735976612"
+				title="Información detallada de: Estadísticas sobre generación de residuos ">Estadísticas sobre generación de residuos</a>
+                </td>
+			<td headers="field1_1120263">Año 2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a class="toggle-button light "  href="javascript:void(0)">Movimiento Natural de Población (Matrimonios, Nacimientos y Defunciones)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176999&idp=1254735573002" 
+    								title="Información detallada de: MNP Estadística de Matrimonios ">MNP Estadística de Matrimonios</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177007&idp=1254735573002" 
+    								title="Información detallada de: MNP Estadística de Nacimientos ">MNP Estadística de Nacimientos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177008&idp=1254735573002" 
+    								title="Información detallada de: MNP Estadística de Defunciones ">MNP Estadística de Defunciones</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field1_1120263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1120261"></td>			
+			<td headers="field1_1120262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177004&idp=1254735573002"
+				title="Información detallada de: Tablas de mortalidad ">Tablas de mortalidad</a>
+                </td>
+			<td headers="field1_1120263">Año 2025</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Noviembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_1120261" scope="col">Día</th>
+		<th id="field3_1120262" scope="col">Operación Estadística</th>
+		<th id="field3_1120263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_1120261">6</td>			
+			<td headers="field3_1120262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_1120263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_1120261">20</td>			
+			<td headers="field3_1120262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_1120263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div id="dic" class="datapub">
+				<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas coyunturales Diciembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field2_1220261" scope="col">Día</th>
+		<th id="field2_1220262" scope="col">Operación Estadística</th>
+		<th id="field2_1220263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field2_1220261">1</td>			
+			<td headers="field2_1220262">
+			<a class="toggle-button light "  href="javascript:void(0)">Encuesta de ocupación en alojamientos turísticos extrahoteleros</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176964&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Albergues ">Encuesta de Ocupación en Albergues</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Alojamientos de Turismo Rural ">Encuesta de Ocupación en Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Apartamentos Turísticos ">Encuesta de Ocupación en Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación en Campings ">Encuesta de Ocupación en Campings</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176963&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Alojamientos de Turismo Rural ">Índice de Precios de Alojamientos de Turismo Rural</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176962&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Apartamentos Turísticos ">Índice de Precios de Apartamentos Turísticos</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176961&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios de Camping ">Índice de Precios de Camping</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">2</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177002&idp=1254735576863"
+				title="Información detallada de: Encuesta de Gasto Turístico Mensual ">Encuesta de Gasto Turístico Mensual</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">2</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176996&idp=1254735576863"
+				title="Información detallada de: Movimientos Turísticos en Fronteras ">Movimientos Turísticos en Fronteras</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">3</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176995&idp=1254735576799"
+				title="Información detallada de: Encuesta Coyuntural sobre Stocks y Existencias-Trimestral ">Encuesta Coyuntural sobre Stocks y Existencias-Trimestral</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">4</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176993&idp=1254735576606"
+				title="Información detallada de: Estadística sobre Ejecuciones Hipotecarias ">Estadística sobre Ejecuciones Hipotecarias</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">4</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736152838&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Vivienda ">Índice de Precios de Vivienda</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">4</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736145519&idp=1254735576715"
+				title="Información detallada de: Índice de Producción Industrial ">Índice de Producción Industrial</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">9</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736053992&idp=1254735976596"
+				title="Información detallada de: Índice de Coste Laboral Armonizado ">Índice de Coste Laboral Armonizado</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">11</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176906&idp=1254735576820"
+				title="Información detallada de: Estadística de Transporte de Viajeros ">Estadística de Transporte de Viajeros</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">11</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177026&idp=1254735576550"
+				title="Información detallada de: Sociedades Mercantiles Mensual ">Sociedades Mercantiles Mensual</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">14</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177119&idp=1254735576757"
+				title="Información detallada de: Índice de Producción de la Construcción ">Índice de Producción de la Construcción</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">15</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_1220263">Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">15</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778"
+				title="Información detallada de: Índice de Precios del Sector Servicios ">Índice de Precios del Sector Servicios</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">15</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176864&idp=1254735576778"
+				title="Información detallada de: Índice de Precios del Sector Servicios. Medias anuales ">Índice de Precios del Sector Servicios. Medias anuales</a>
+                </td>
+			<td headers="field2_1220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">15</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177110&idp=1254735976607"
+				title="Información detallada de: Índice de Referencia de Arrendamientos de Vivienda ">Índice de Referencia de Arrendamientos de Vivienda</a>
+                </td>
+			<td headers="field2_1220263">Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">15</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_1220263">Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">16</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736171438&idp=1254735576606"
+				title="Información detallada de: Estadística de Transmisiones de Derechos de la Propiedad ">Estadística de Transmisiones de Derechos de la Propiedad</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">17</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736045053&idp=1254735976596"
+				title="Información detallada de: Encuesta Trimestral de Coste Laboral ">Encuesta Trimestral de Coste Laboral</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">17</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176863&idp=1254735576778"
+				title="Información detallada de: Indicadores de actividad del sector servicios ">Indicadores de actividad del sector servicios</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">17</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148782&idp=1254735576715"
+				title="Información detallada de: Índice de Cifras de Negocios en la Industria ">Índice de Cifras de Negocios en la Industria</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">18</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736170236&idp=1254735576606"
+				title="Información detallada de: Hipotecas Mensual ">Hipotecas Mensual</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">18</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176958&idp=1254735576550"
+				title="Información detallada de: Índice de Cifra de Negocios Empresarial ">Índice de Cifra de Negocios Empresarial</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">18</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177109&idp=1254735976607"
+				title="Información detallada de: Índice de Garantía de la Competitividad ">Índice de Garantía de la Competitividad</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">21</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176990&idp=1254735576863"
+				title="Información detallada de: Encuesta de turismo de residentes ">Encuesta de turismo de residentes</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">21</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="https://ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177099&idp=1254735576778"
+				title="Información detallada de: Índice de Producción del Sector Servicios ">Índice de Producción del Sector Servicios</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">22</td>			
+			<td headers="field2_1220262">
+			<a class="toggle-button light "  href="javascript:void(0)">Coyuntura Turística Hotelera (EOH/IPH/IRSH)</a>
+				<ul class="lstUrl toggle-container light">
+				<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Encuesta de Ocupación Hotelera ">Encuesta de Ocupación Hotelera</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Indicadores de Rentabilidad del Sector Hotelero ">Indicadores de Rentabilidad del Sector Hotelero</a>						
+    					</li>	    						    					        		
+	        			<li> 
+    						<a href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177015&idp=1254735576863" 
+    								title="Información detallada de: Índice de Precios Hoteleros ">Índice de Precios Hoteleros</a>						
+    					</li>	    						    					        		
+	        			</ul>
+             </td>
+			<td headers="field2_1220263">Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">23</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736164439&idp=1254735576581"
+				title="Información detallada de: Contabilidad Nacional Trimestral de España ">Contabilidad Nacional Trimestral de España</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">23</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177079&idp=1254735573002"
+				title="Información detallada de: Estimación Mensual de Nacimientos ">Estimación Mensual de Nacimientos</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">23</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones mensuales ">Estimación del número de defunciones mensuales</a>
+                </td>
+			<td headers="field2_1220263">Octubre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">23</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177074&idp=1254735573002"
+				title="Información detallada de: Estimación del número de defunciones semanales ">Estimación del número de defunciones semanales</a>
+                </td>
+			<td headers="field2_1220263">Semana 49 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">23</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736147699&idp=1254735576715"
+				title="Información detallada de: Índice de Precios Industriales ">Índice de Precios Industriales</a>
+                </td>
+			<td headers="field2_1220263">Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">29</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736148943&idp=1254735576715"
+				title="Información detallada de: Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales ">Índices de Precios de Exportación (IPRIX) y de Importación (IPRIM) de Productos Industriales</a>
+                </td>
+			<td headers="field2_1220263">Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">30</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736165305&idp=1254735576581"
+				title="Información detallada de: Cuentas Trimestrales no Financieras de los Sectores Institucionales ">Cuentas Trimestrales no Financieras de los Sectores Institucionales</a>
+                </td>
+			<td headers="field2_1220263">Trimestre 3/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">30</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176802&idp=1254735976607"
+				title="Información detallada de: Índice de Precios de Consumo ">Índice de Precios de Consumo</a>
+                </td>
+			<td headers="field2_1220263">Avance. Diciembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">30</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176900&idp=1254735576799"
+				title="Información detallada de: Índices de Comercio al por menor ">Índices de Comercio al por menor</a>
+                </td>
+			<td headers="field2_1220263">Noviembre 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field2_1220261">30</td>			
+			<td headers="field2_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176803&idp=1254735976607"
+				title="Información detallada de: Índices de Precios de Consumo Armonizado ">Índices de Precios de Consumo Armonizado</a>
+                </td>
+			<td headers="field2_1220263">Avance. Diciembre 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas estructurales Diciembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field1_1220261" scope="col">Día</th>
+		<th id="field1_1220262" scope="col">Operación Estadística</th>
+		<th id="field1_1220263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177011&idp=1254734710990"
+				title="Información detallada de: Cifras oficiales de población de los municipios españoles: revisión del Padrón municipal ">Cifras oficiales de población de los municipios españoles: revisión del Padrón municipal</a>
+                </td>
+			<td headers="field1_1220263">Año 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736167628&idp=1254735576581"
+				title="Información detallada de: Contabilidad Regional de España ">Contabilidad Regional de España</a>
+                </td>
+			<td headers="field1_1220263">Serie 2000-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177058&idp=1254735576581"
+				title="Información detallada de: Contabilidad nacional anual de España: tablas Input-Output ">Contabilidad nacional anual de España: tablas Input-Output</a>
+                </td>
+			<td headers="field1_1220263">Año 2023</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736169169&idp=1254735576863"
+				title="Información detallada de: Cuenta Satélite del Turismo de España ">Cuenta Satélite del Turismo de España</a>
+                </td>
+			<td headers="field1_1220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/es/operacion.htm?c=Estadistica_C&cid=1254736177118&idp=1254735976603"
+				title="Información detallada de: Cuentas Medioambientales: Cuenta de Subvenciones Medioambientales y Otras Transferencias Similares ">Cuentas Medioambientales: Cuenta de Subvenciones Medioambientales y Otras Transferencias Similares</a>
+                </td>
+			<td headers="field1_1220263">serie 2020-2024</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177054&idp=1254735576581"
+				title="Información detallada de: Cuentas anuales no Financieras de los Sectores Institucionales. ">Cuentas anuales no Financieras de los Sectores Institucionales.</a>
+                </td>
+			<td headers="field1_1220263">Serie 1995-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177048&idp=1254735976603"
+				title="Información detallada de: Cuentas medioambientales: Cuenta de gasto en protección medioambiental  ">Cuentas medioambientales: Cuenta de gasto en protección medioambiental </a>
+                </td>
+			<td headers="field1_1220263">serie 2014-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177053&idp=1254735976603"
+				title="Información detallada de: Cuentas medioambientales: bienes y servicios ambientales ">Cuentas medioambientales: bienes y servicios ambientales</a>
+                </td>
+			<td headers="field1_1220263">serie 2014-2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176815&idp=1254735976608"
+				title="Información detallada de: Encuesta de Empleo del Tiempo ">Encuesta de Empleo del Tiempo</a>
+                </td>
+			<td headers="field1_1220263">2024/2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177006&idp=1254735573002"
+				title="Información detallada de: Encuesta de Fecundidad ">Encuesta de Fecundidad</a>
+                </td>
+			<td headers="field1_1220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736056996&idp=1254735976597"
+				title="Información detallada de: Encuesta de Transición Educativa - Formativa e Inserción Laboral ">Encuesta de Transición Educativa - Formativa e Inserción Laboral</a>
+                </td>
+			<td headers="field1_1220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="https://www.ine.es/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736055502&idp=1254735976621"
+				title="Información detallada de: Estadística de Discapacidad y Mercado Laboral: Empleo ">Estadística de Discapacidad y Mercado Laboral: Empleo</a>
+                </td>
+			<td headers="field1_1220263">Año 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736176780&idp=1254735573175"
+				title="Información detallada de: Estadística de defunciones según la causa de muerte ">Estadística de defunciones según la causa de muerte</a>
+                </td>
+			<td headers="field1_1220263">Resultados definitivos 2025</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736160707&idp=1254735576550"
+				title="Información detallada de: Explotación Estadística del Directorio Central de Empresas ">Explotación Estadística del Directorio Central de Empresas</a>
+                </td>
+			<td headers="field1_1220263">01/01/2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field1_1220261"></td>			
+			<td headers="field1_1220262">
+			<a 
+				href="/dyngs/INEbase/operacion.htm?c=Estadistica_C&cid=1254736177063&idp=1254735576581"
+				title="Información detallada de: Tabla de Pensiones ">Tabla de Pensiones</a>
+                </td>
+			<td headers="field1_1220263">Año 2024</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+<div class="tipo">
+<table class="operaciones">
+	<caption>
+	Estadísticas Experimentales Diciembre 2026</caption>
+	<thead> 
+	<tr>
+		<th id="field3_1220261" scope="col">Día</th>
+		<th id="field3_1220262" scope="col">Operación Estadística</th>
+		<th id="field3_1220263" scope="col">Periodo de referencia</th>			
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="dia" headers="field3_1220261">4</td>			
+			<td headers="field3_1220262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_1220263"> 2026</td>
+			</tr>
+	<tr>
+			<td class="dia" headers="field3_1220261">18</td>			
+			<td headers="field3_1220262">
+			<a 
+				href="https://www.ine.es/experimental/cdmge/"
+				title="Información detallada de: Experimental: Índice Diario de Comercio al por Menor ">Experimental: Índice Diario de Comercio al por Menor</a>
+                </td>
+			<td headers="field3_1220263"> 2026</td>
+			</tr>
+	</tbody>
+</table>
+</div>
+</div>
+			
+			<div class="empty-message">
+				<p>Lo sentimos. No se ha encontrado ninguna coincidencia con la búsqueda solicitada en el calendario de</p>
+			</div>
+		</div>
+	</section>
+	<section class="registroModif">
+	<p class="clear onceb sinesp">		
+		<a href="regmodificaciones.htm?anyo=2026&position=center&height=80%&amp;width=90%" class="thickbox btn ii-group" role="button" title="Registro de modificaciones" target="thickBoxINEfrm">
+			<i class="ii ii-regCalendar ii-normal"></i>
+			<span >Registro de modificaciones</span>
+		</a>		
+	</p>
+	</section>
+	<section class="banner">
+	    <a href='/daco/daco41/calendario-coyunturales-2026-A1.pdf' title='Versión imprimible Calendario estadísticas coyunturales'><img src="/menus/plantillas/raizweb/calendario/img/CalendarioPrint_2026.png" alt="Versión imprimible Calendario estadísticas coyunturales"></a>
+	</section>
+	<div class="notas"><p class="clear"><sup>(1)</sup> El último viernes de cada mes (t) se anunciará el día de publicación de las estadísticas estructurales programadas para el mes (t+2)</p></div><p class="NIPO">NIPO: 222-25-001-2</p>
+	</main>
+<footer><div id="pie" class="d2">	<div class="homePie" >
+		<ul>
+			<li><a href="/infoine/">
+				<i class="ii ii-mail"></i> <strong>Contacto</strong></a>
+			</li>
+			<li><a href="/indiceweb.htm">Mapa web</a></li>
+			<li>
+				<a href="/dyngs/AYU/index.htm?cid=125">
+					Aviso legal
+				</a>
+			</li>
+			<li><a href="/dyngs/AYU/index.htm?cid=127">Accesibilidad</a></li>
+			<li><a href="/prensa/seccion_prensa.htm">Prensa</a></li>			<li class="margen_sup20imp"><a href="/dyngs/MYP/index.htm?cid=1">Clasificaciones y est&#225;ndares</a></li>
+			<li><a href="/dyngs/MYP/index.htm?cid=10">Nuevos proyectos</a></li>
+		</ul>
+	</div>
+	<div class="homePie">
+		<ul>
+			<li><a href="/dyngs/INE/index.htm?cid=498">El INE</a></li>
+			<li><a href="/dyngs/INE/index.htm?cid=401">Transparencia</a></li>
+			<li><a href="/dyngs/INE/index.htm?cid=581">Organizaci&#243;n Estad&#237;stica en Espa&#241;a</a></li>
+			<li><a href="/dyngs/MYP/es/index.htm?cid=35">Calidad</a></li>
+			<li><a href="/dyngs/INE/index.htm?cid=542">Sistema Estad&#237;stico Europeo</a></li>
+		</ul>
+	</div>	<div class="homePie">
+		<ul>
+			<li><a href="/dyngs/FYE/index.htm?cid=1791">Formaci&#243;n y empleo</a></li>
+			<li><a href="/dyngs/FYE/es/index.htm?cid=1802">Pr&#225;cticas universitarias</a></li>
+			<li><a href="/dyngs/FYE/es/index.htm?cid=1802">Becas</a></li>
+			<li><a href="/dyngs/FYE/index.htm?cid=166">Oposiciones</a></li>
+			<li><a href="/explica/explica.htm" target="_blank"  rel="noopener">Explica</a></li>
+		</ul>
+	</div>	<div class="homePie">
+		<ul>
+			<li><a href="/dyngs/SER/index.htm?cid=1550">Atenci&#243;n al p&#250;blico</a></li>
+			<li><a href="/dyngs/DAB/es/index.htm?cid=1722">Datos abiertos</a></li>
+			<li><a href="/dyngs/PUB/index.htm?cid=1440" aria-label="Catalogo de Publicaciones">Publicaciones</a></li>
+			<li><a href="/dyngs/SER/index.htm?cid=1391">Carta de servicios</a></li>
+		</ul>
+	</div>	<div class="homePie" >
+		<ul>
+			<li>S&#237;guenos</li>
+			<li><a class="ii ii-twitter-x" href="https://twitter.com/es_ine" target="_blank" rel="noopener" title="Abre ventana nueva"><span class="tit">X</span></a></li>
+			<li><a class="ii ii-youtube" href="https://www.youtube.com/INEDifusion" target="_blank"  rel="noopener" title="Abre ventana nueva"><span class="tit">Youtube</span></a></li>
+			<li><a class="ii ii-instagram" href="https://www.instagram.com/es_ine_/" target="_blank" rel="noopener" title="Abre ventana nueva"><span class="tit">Instagram</span></a></li>
+			<li><a class="ii ii-linkedin" href="https://www.linkedin.com/company/ine-es" target="_blank" rel="noopener" title="Abre ventana nueva"><span class="tit">LinkedIn</span></a></li>
+			<li><a class="ii ii-feed" href="/dyngs/AYU/index.htm?cid=1303" target="_blank" rel="noopener" title="Abre ventana nueva"><span class="tit">Canal RSS</span></a></li>
+			<li><a class="ii ii-github" href="https://github.com/es-ine" target="_blank" rel="noopener" title="Abre ventana nueva"><span class="tit">GitHub</span></a></li>
+		</ul>
+	</div>	<div class="homePie copyright">
+		<p>
+		<span>	&copy; 2026 <a href="https://www.ine.es/" rel="author cc:attributionURL dct:creator" property="cc:attributionName">INE. Instituto Nacional de Estad&#237;stica</a>
+			<a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;" title ="Este sitio web y su contenido est&#225;n bajo licencia CC BY-SA 4.0">
+				<i class="ii ii-cc ii-normal"></i>
+				<i class="ii ii-by ii-normal"></i>
+			</a>
+		</span>
+		<span>
+			Avda. Manoteras, 52 - 28050 - Madrid - Espa&#241;a Tlf: (+34) 91 583 91 00
+		</span>
+		</p>
+	</div>
+	</div>
+		<!-- boton subir -->
+		
+		<button class="ir-arriba" aria-label="Bot&#243;n para volver arriba" title="Volver arriba">
+			<i class="ii ii-caret-up"></i>
+		</button>
+		
+		<!-- fin boton subir -->
+	</footer>
+	
+		
+			
+						
+			
+		</div>
+				<!-- Codigo de seguimiento de Google Analytics  -->
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script  src="https://www.googletagmanager.com/gtag/js?id=UA-19028967-1"></script>
+<script >
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());  gtag('config', 'UA-19028967-1');
+</script><!-- Fin Google Analytics  -->
+		<script src='/menus/_b/js/politicaCookies.js' ></script>
+		</body>
+</html>

--- a/tests/test_ine_calendar_api_scaffold.py
+++ b/tests/test_ine_calendar_api_scaffold.py
@@ -75,6 +75,22 @@ def test_schedule_parser_extracts_cpi_and_gdp_advance_rows() -> None:
     assert entries[3].event_time_utc == "2026-04-30T07:00:00+00:00"
 
 
+def test_schedule_parser_handles_button_section_headers() -> None:
+    entries = parse_calendar_html(
+        _fixture_text("ine_calendar", "calendar_2026_live.html"),
+    )
+    cpi = [e for e in entries if e.series_id == "INE_CPI_ADVANCE_YOY"]
+    gdp = [e for e in entries if e.series_id == "INE_GDP_ADVANCE_QOQ"]
+    assert len(cpi) == 12
+    assert len(gdp) == 4
+    assert {e.reference_date for e in cpi} == {
+        f"2026-{m:02d}-01" for m in range(1, 13)
+    }
+    assert {e.reference_date for e in gdp} == {
+        "2025-12-31", "2026-03-31", "2026-06-30", "2026-09-30",
+    }
+
+
 def test_schedule_filter_keeps_requested_series_only() -> None:
     entries = parse_calendar_html(
         _fixture_text("ine_calendar", "calendar_2026.html"),


### PR DESCRIPTION
## Summary
- INE moved publication-section headers into `<button class="toggle-button nocircle tit">…</button>` containers; the parser's tag whitelist excluded `<button>`, so section detection silently failed and `parse_calendar_html` raised `INE calendar sections not found` on the first production fire of `calendar-schedule-refresh.timer`.
- Added `<button>` to the `find_all` whitelist. Any `<button>` carrying class `tit` is now treated as a publication boundary — recognized sections (CPI, GDP) flip `current`, every other toggle-button (HICP, hipotecas, EPA, …) resets `current` to `None` so its rows don't leak into our buckets.
- Pinned the live 2026 calendar HTML (467 KB) as `tests/fixtures/ine_calendar/calendar_2026_live.html` and added a regression test asserting 12 CPI advance + 4 GDP advance entries with the expected reference dates.

## Why
ESRI/INE is allowed to restructure their public calendar; the previous `<h*>` / `<li>` heuristic was too tight. Treating `<button>` as a section delimiter mirrors the new DOM and survives the next added publication category (none of which use the IPC/CPI exact text).

## Codex review
Round 1 clean — Codex ran the parser against both fixtures and confirmed expected CPI/GDP rows; no findings.

## Test plan
- [x] `pytest tests/test_ine_calendar_api_scaffold.py` — 15 passed (was 14, +1 live regression test).
- [x] `pytest tests/ -k calendar` — 799 passed.

Closes #34