### PR TITLE
feat(parity): #38 P1 — suppress sweep-lag false positives via vintage-timing classification

### DIFF
--- a/scripts/parity_daily.py
+++ b/scripts/parity_daily.py
@@ -147,9 +147,11 @@ def main(argv: list[str] | None = None) -> int:
     state_path = args.state_path or default_state_path(engine_db.parent.parent)
     infra_streak_path = engine_db.parent / "logs" / INFRA_STREAK_FILE
 
+    parity_run_time = dt.datetime.now(dt.timezone.utc)
     summary: dict = {
         "target_date": target.isoformat(),
-        "started_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "started_at": parity_run_time.isoformat(),
+        "parity_run_time": parity_run_time.isoformat(),
         "dry_run": args.dry_run,
         "skip_fetch": args.skip_fetch,
     }
@@ -182,9 +184,20 @@ def main(argv: list[str] | None = None) -> int:
             summary["te_pull"] = "skipped"
 
         with store.get_connection() as conn:
-            reports = compare_daily(conn, target_date=target)
-        summary["agencies_with_anomalies"] = [r.agency_id for r in reports]
+            reports = compare_daily(
+                conn, target_date=target, now_utc=parity_run_time,
+            )
+        summary["agencies_with_anomalies"] = [
+            r.agency_id for r in reports if not r.clean
+        ]
         summary["total_anomalies"] = sum(r.total_anomalies for r in reports)
+        summary["lag_after_parity_count"] = sum(
+            r.total_lag_after_parity for r in reports
+        )
+        summary["lag_after_parity_by_agency"] = {
+            r.agency_id: r.total_lag_after_parity
+            for r in reports if r.lag_after_parity
+        }
 
         action_log = file_reports(
             reports=reports,
@@ -195,6 +208,7 @@ def main(argv: list[str] | None = None) -> int:
         summary["created_issues"] = [a for a, _ in action_log.created]
         summary["commented_issues"] = [a for a, _ in action_log.commented]
         summary["closed_issues"] = [a for a, _ in action_log.closed]
+        summary["lag_only_agencies"] = [a for a, _ in action_log.lag_only]
 
         # Reset infra strike counter on success.
         _save_infra_streak(infra_streak_path, 0)

--- a/src/ingestion/calendar/parity_daily.py
+++ b/src/ingestion/calendar/parity_daily.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation
 
 from ._official_shared import canonicalize_indicator
@@ -68,6 +68,32 @@ class ValueMismatch:
     note: str
 
 
+@dataclass(frozen=True)
+class LagAfterParity:
+    """First-release vintage exists but landed after the parity run.
+
+    Informational only — the value-side sweep was lagging the parity
+    cron, not a real drift. The filer skips these (no issue, no comment,
+    no clean-streak change) and the structured log records the count.
+
+    ``agency_actual`` is captured even though no drift is filed: it lets
+    the operator confirm from the structured log whether the late write
+    eventually matched TE. A late mismatch is logged but intentionally
+    not filed (per the issue spec) — the operator can re-run the
+    comparator with a later ``--now-utc`` if they want it to file.
+    """
+
+    country: str
+    canonical: str
+    reference_date: str | None
+    te_event_id: str
+    agency_event_id: str
+    agency_provider: str
+    te_actual: str
+    agency_actual: str | None
+    first_observed_at: str
+
+
 @dataclass
 class AgencyReport:
     agency_id: str
@@ -75,6 +101,7 @@ class AgencyReport:
     target_date: str
     missing: list[MissingRelease] = field(default_factory=list)
     mismatches: list[ValueMismatch] = field(default_factory=list)
+    lag_after_parity: list[LagAfterParity] = field(default_factory=list)
 
     @property
     def clean(self) -> bool:
@@ -83,6 +110,15 @@ class AgencyReport:
     @property
     def total_anomalies(self) -> int:
         return len(self.missing) + len(self.mismatches)
+
+    @property
+    def total_lag_after_parity(self) -> int:
+        return len(self.lag_after_parity)
+
+    @property
+    def empty(self) -> bool:
+        """True when no missing, mismatches, *or* lag rows are present."""
+        return self.clean and not self.lag_after_parity
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +187,24 @@ def _first_release_vintage(
     ).fetchone()
 
 
+def _parse_observed_at(observed_at: str | None) -> datetime | None:
+    """Parse a vintage ``observed_at`` ISO string to an aware UTC datetime.
+
+    Naive inputs are assumed UTC — vintage writers normalise to UTC before
+    inserting, so a missing offset is the legacy-row case rather than a
+    local-time leak.
+    """
+    if not observed_at:
+        return None
+    try:
+        parsed = datetime.fromisoformat(observed_at)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def _bucket_key(reference_date: str | None) -> str | None:
     """Reduce reference_date to a YYYY-MM bucket so TE and agency rows
     that disagree on the day-component (TE uses end-of-month, BLS uses
@@ -169,16 +223,28 @@ def _bucket_key(reference_date: str | None) -> str | None:
 
 
 def compare_daily(
-    connection: sqlite3.Connection, *, target_date: date,
+    connection: sqlite3.Connection,
+    *,
+    target_date: date,
+    now_utc: datetime | None = None,
 ) -> list[AgencyReport]:
     """Run the full per-agency parity sweep for ``target_date``.
 
-    Empty ``[]`` when every agency is clean. Reports with anomalies are
-    included; clean agencies are dropped (the filer's clean-streak
-    bookkeeping is its own concern).
+    ``now_utc`` is the parity run wall-clock used to classify lagged
+    sweep writes (issue #38). When the earliest first-release vintage
+    for a candidate anomaly was ``observed_at > now_utc``, the row is
+    bucketed under ``lag_after_parity`` instead of ``mismatches`` and
+    the filer skips it. Defaults to ``datetime.now(UTC)``.
+
+    Empty ``[]`` when every agency has no missing/mismatch/lag rows.
+    Reports with anomalies *or* lag-only entries are returned so the
+    structured log can record both.
     """
     iso = target_date.isoformat()
     next_iso = date.fromordinal(target_date.toordinal() + 1).isoformat()
+    parity_run_time = (now_utc or datetime.now(timezone.utc)).astimezone(
+        timezone.utc,
+    )
 
     te_rows = connection.execute(
         """
@@ -197,8 +263,9 @@ def compare_daily(
         report = _compare_agency(
             connection, agency=agency, te_rows=te_rows,
             target_iso=iso, next_iso=next_iso,
+            parity_run_time=parity_run_time,
         )
-        if not report.clean:
+        if not report.empty:
             reports.append(report)
     return reports
 
@@ -210,6 +277,7 @@ def _compare_agency(
     te_rows: list[sqlite3.Row],
     target_iso: str,
     next_iso: str,
+    parity_run_time: datetime,
 ) -> AgencyReport:
     report = AgencyReport(
         agency_id=agency.agency_id, label=agency.label, target_date=target_iso,
@@ -271,6 +339,24 @@ def _compare_agency(
             provider=agency_row["provider"],
             event_id=agency_row["provider_event_id"],
         )
+        if first_release is not None:
+            observed_at = _parse_observed_at(first_release["observed_at"])
+            if observed_at is not None and observed_at > parity_run_time:
+                # Sweep landed the value after the parity cron fired —
+                # the parity check would have flagged drift on the live
+                # DB even though the data eventually arrived. Record
+                # the timing forensics and skip filing.
+                report.lag_after_parity.append(LagAfterParity(
+                    country=country, canonical=canonical,
+                    reference_date=te_row["reference_date"],
+                    te_event_id=te_row["provider_event_id"],
+                    agency_event_id=agency_row["provider_event_id"],
+                    agency_provider=agency_row["provider"],
+                    te_actual=te_row["actual"],
+                    agency_actual=first_release["actual"],
+                    first_observed_at=first_release["observed_at"],
+                ))
+                continue
         agency_actual = first_release["actual"] if first_release else None
 
         te_decimal = _normalise(te_row["actual"], alignment)
@@ -332,6 +418,7 @@ def _looks_like_clean_factor(te: Decimal, agency: Decimal) -> bool:
 
 __all__ = [
     "AgencyReport",
+    "LagAfterParity",
     "MissingRelease",
     "ValueMismatch",
     "compare_daily",

--- a/src/ingestion/calendar/parity_filer.py
+++ b/src/ingestion/calendar/parity_filer.py
@@ -53,6 +53,7 @@ class FilerActionLog:
     closed: list[tuple[str, int]] = field(default_factory=list)
     skipped_no_anomaly: list[str] = field(default_factory=list)
     suppressed: list[str] = field(default_factory=list)  # operator-closed, no refile
+    lag_only: list[tuple[str, int]] = field(default_factory=list)  # (agency_id, lag_count)
 
 
 # ---------------------------------------------------------------------------
@@ -303,6 +304,17 @@ def file_reports(
                 agency_state["suppressed_by_operator"] = True
                 agency_state["suppressed_issue"] = remembered
             agency_state["open_issue"] = None
+
+        if report is not None and report.clean and report.lag_after_parity:
+            # Lag-only path: vintages landed after parity_run_time.
+            # Per #38 these are not real drift — skip filing entirely
+            # and leave the clean-streak counter untouched (neither
+            # bumped nor reset) so the agency neither auto-closes nor
+            # opens a fresh issue from a sweep timing artifact.
+            log.lag_only.append(
+                (agency.agency_id, len(report.lag_after_parity)),
+            )
+            continue
 
         if report is not None and not report.clean:
             # Anomaly path.

--- a/tests/test_parity_daily.py
+++ b/tests/test_parity_daily.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from ingestion.calendar.parity_daily import (
     AgencyReport,
+    LagAfterParity,
     MissingRelease,
     ValueMismatch,
     compare_daily,
@@ -307,6 +308,157 @@ def test_missing_first_release_records_parse_failed(
     mm = reports[0].mismatches[0]
     assert mm.parse_failed is True
     assert "vintage" in mm.note
+
+
+def test_vintage_after_parity_run_classified_as_lag(
+    store: SQLiteEngineStore,
+) -> None:
+    """First-release vintage observed_at > parity_run_time → LagAfterParity,
+    not ValueMismatch. Issue #38."""
+    _insert_event(
+        store, provider="tradingeconomics", provider_event_id="te-9",
+        country_code="US", title="Unemployment Rate",
+        reference_date="2026-03-31T00:00:00",
+        event_time_utc="2026-04-24T03:30:00+00:00",
+        actual="3.1",
+    )
+    _insert_event(
+        store, provider="bls", provider_event_id="bls-9",
+        country_code="US", title="Unemployment Rate",
+        reference_date="2026-03-01",
+        event_time_utc="2026-04-24T03:30:00+00:00",
+        actual=None,
+    )
+    # Sweep wrote the vintage at 07:15 UTC — after the 06:00 parity cron.
+    _insert_vintage(
+        store, provider="bls", event_id="bls-9",
+        observed_at="2026-04-24T07:15:00+00:00", actual="3.1",
+    )
+
+    parity_run = datetime(2026, 4, 24, 6, 0, tzinfo=timezone.utc)
+    with store.get_connection() as conn:
+        reports = compare_daily(
+            conn, target_date=date(2026, 4, 24), now_utc=parity_run,
+        )
+
+    assert len(reports) == 1
+    report = reports[0]
+    assert report.clean is True
+    assert report.empty is False
+    assert len(report.lag_after_parity) == 1
+    lag = report.lag_after_parity[0]
+    assert lag.agency_event_id == "bls-9"
+    assert lag.first_observed_at == "2026-04-24T07:15:00+00:00"
+    assert lag.te_actual == "3.1"
+
+
+def test_vintage_before_parity_run_falls_through_to_normal_logic(
+    store: SQLiteEngineStore,
+) -> None:
+    """observed_at <= parity_run_time → normal value comparison applies."""
+    _insert_event(
+        store, provider="tradingeconomics", provider_event_id="te-10",
+        country_code="US", title="Unemployment Rate",
+        reference_date="2026-03-31T00:00:00",
+        event_time_utc="2026-04-24T03:30:00+00:00",
+        actual="3.1",
+    )
+    _insert_event(
+        store, provider="bls", provider_event_id="bls-10",
+        country_code="US", title="Unemployment Rate",
+        reference_date="2026-03-01",
+        event_time_utc="2026-04-24T03:30:00+00:00",
+        actual="3.1",
+    )
+    _insert_vintage(
+        store, provider="bls", event_id="bls-10",
+        observed_at="2026-04-24T05:55:00+00:00", actual="3.2",
+    )
+
+    parity_run = datetime(2026, 4, 24, 6, 0, tzinfo=timezone.utc)
+    with store.get_connection() as conn:
+        reports = compare_daily(
+            conn, target_date=date(2026, 4, 24), now_utc=parity_run,
+        )
+
+    assert len(reports) == 1
+    assert reports[0].lag_after_parity == []
+    assert len(reports[0].mismatches) == 1
+
+
+def test_late_vintage_with_mismatched_value_still_classified_as_lag(
+    store: SQLiteEngineStore,
+) -> None:
+    """Per the issue spec the lag classification is timing-based, not
+    value-based: a late vintage that disagrees with TE is still bucketed
+    under lag (no drift filed) but its agency_actual is captured so the
+    structured log shows the disagreement for operator triage."""
+    _insert_event(
+        store, provider="tradingeconomics", provider_event_id="te-12",
+        country_code="US", title="Unemployment Rate",
+        reference_date="2026-03-31T00:00:00",
+        event_time_utc="2026-04-24T03:30:00+00:00",
+        actual="3.1",
+    )
+    _insert_event(
+        store, provider="bls", provider_event_id="bls-12",
+        country_code="US", title="Unemployment Rate",
+        reference_date="2026-03-01",
+        event_time_utc="2026-04-24T03:30:00+00:00",
+        actual=None,
+    )
+    _insert_vintage(
+        store, provider="bls", event_id="bls-12",
+        observed_at="2026-04-24T07:15:00+00:00", actual="3.4",
+    )
+
+    parity_run = datetime(2026, 4, 24, 6, 0, tzinfo=timezone.utc)
+    with store.get_connection() as conn:
+        reports = compare_daily(
+            conn, target_date=date(2026, 4, 24), now_utc=parity_run,
+        )
+    assert len(reports) == 1
+    report = reports[0]
+    assert report.mismatches == []
+    assert len(report.lag_after_parity) == 1
+    lag = report.lag_after_parity[0]
+    assert lag.te_actual == "3.1"
+    assert lag.agency_actual == "3.4"
+
+
+def test_lag_only_report_returned_with_clean_true(
+    store: SQLiteEngineStore,
+) -> None:
+    """A report whose only entries are lag_after_parity is still
+    returned (so the structured log can record the count) but
+    ``clean`` is True so the filer skips drift handling."""
+    _insert_event(
+        store, provider="tradingeconomics", provider_event_id="te-11",
+        country_code="US", title="Unemployment Rate",
+        reference_date="2026-03-31T00:00:00",
+        event_time_utc="2026-04-24T03:30:00+00:00",
+        actual="3.1",
+    )
+    _insert_event(
+        store, provider="bls", provider_event_id="bls-11",
+        country_code="US", title="Unemployment Rate",
+        reference_date="2026-03-01",
+        event_time_utc="2026-04-24T03:30:00+00:00",
+        actual=None,
+    )
+    _insert_vintage(
+        store, provider="bls", event_id="bls-11",
+        observed_at="2026-04-24T07:15:00+00:00", actual="3.1",
+    )
+
+    parity_run = datetime(2026, 4, 24, 6, 0, tzinfo=timezone.utc)
+    with store.get_connection() as conn:
+        reports = compare_daily(
+            conn, target_date=date(2026, 4, 24), now_utc=parity_run,
+        )
+    assert len(reports) == 1
+    assert reports[0].clean is True
+    assert reports[0].total_lag_after_parity == 1
 
 
 def test_unowned_country_indicator_ignored(store: SQLiteEngineStore) -> None:

--- a/tests/test_parity_filer.py
+++ b/tests/test_parity_filer.py
@@ -14,6 +14,7 @@ import pytest
 
 from ingestion.calendar.parity_daily import (
     AgencyReport,
+    LagAfterParity,
     MissingRelease,
     ValueMismatch,
 )
@@ -253,6 +254,72 @@ def test_dry_run_real_runner_emits_no_subprocess(tmp_path: Path) -> None:
     assert log.created == [
         ("BLS", "Parity drift — US Bureau of Labor Statistics (2026-04-24)"),
     ]
+
+
+def _bls_report_with_lag_only(target: str = "2026-04-24") -> AgencyReport:
+    report = AgencyReport(
+        agency_id="BLS", label="US Bureau of Labor Statistics",
+        target_date=target,
+    )
+    report.lag_after_parity.append(LagAfterParity(
+        country="US", canonical="UNEMPLOYMENT_RATE",
+        reference_date="2026-03-01",
+        te_event_id="te-9", agency_event_id="bls-9",
+        agency_provider="bls",
+        te_actual="3.1",
+        agency_actual="3.1",
+        first_observed_at="2026-04-24T07:15:00+00:00",
+    ))
+    return report
+
+
+def test_lag_only_report_skips_filing_and_streak(tmp_path: Path) -> None:
+    """A lag-only report must not file, comment, or change the streak."""
+    runner = FakeRunner()
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({
+        "BLS": {"clean_streak": 4, "open_issue": None},
+    }))
+
+    log = file_reports(
+        reports=[_bls_report_with_lag_only()],
+        target_date=date(2026, 4, 24),
+        runner=runner,
+        state_path=state,
+    )
+
+    assert runner.creates == []
+    assert runner.comments == []
+    assert runner.closes == []
+    assert log.lag_only == [("BLS", 1)]
+    persisted = json.loads(state.read_text())
+    # Streak unchanged: lag is neutral, neither bump nor reset.
+    assert persisted["BLS"]["clean_streak"] == 4
+
+
+def test_lag_only_report_does_not_close_open_issue(tmp_path: Path) -> None:
+    """A lag-only report on an agency with an open drift issue must
+    leave the issue alone — neither comment nor close."""
+    runner = FakeRunner()
+    runner.open_by_label[runner._key("BLS")] = 88
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({
+        "BLS": {"clean_streak": 6, "open_issue": 88},
+    }))
+
+    log = file_reports(
+        reports=[_bls_report_with_lag_only()],
+        target_date=date(2026, 4, 24),
+        runner=runner,
+        state_path=state,
+    )
+
+    assert runner.comments == []
+    assert runner.closes == []
+    assert log.lag_only == [("BLS", 1)]
+    persisted = json.loads(state.read_text())
+    assert persisted["BLS"]["clean_streak"] == 6
+    assert persisted["BLS"]["open_issue"] == 88
 
 
 def test_infra_failure_creates_or_comments(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Comparator threads ``now_utc`` through ``compare_daily``; when an earliest first-release vintage is ``observed_at > parity_run_time``, the row goes into a new ``LagAfterParity`` bucket instead of ``ValueMismatch``.
- ``parity_filer.file_reports`` skips lag-only reports — no create / no comment / no clean-streak change — and records them in the new ``FilerActionLog.lag_only``.
- ``scripts/parity_daily.py`` captures ``parity_run_time`` once and surfaces ``lag_after_parity_count`` + ``lag_after_parity_by_agency`` + ``lag_only_agencies`` in the structured log.

Closes #38

## Test plan
- [x] ``pytest tests/test_parity_daily.py tests/test_parity_filer.py`` — 23 pass
- [x] ``pytest tests/test_calendar_parity.py tests/test_te_daily_parity.py`` — 24 pass (no regression)
- [ ] Production verification deferred: requires real engine.db; operator can confirm against next post-#31 false positive in the parity log.