### PR TITLE
fix(calendar): destatis + stat-bureau-jp credentials & zip unwrap

### DIFF
--- a/src/ingestion/calendar/destatis_api/client.py
+++ b/src/ingestion/calendar/destatis_api/client.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
+import zipfile
 from dataclasses import dataclass, field
 from typing import Mapping
 
@@ -38,9 +40,11 @@ class DestatisGenesisClient:
     @classmethod
     def from_env(cls) -> "DestatisGenesisClient":
         """Build a client from environment credentials with guest fallback."""
+        from env import get_env_value
+
         return cls(
-            username=os.getenv(DESTATIS_USERNAME_ENV, "GAST"),
-            password=os.getenv(DESTATIS_PASSWORD_ENV, "GAST"),
+            username=get_env_value(DESTATIS_USERNAME_ENV) or "GAST",
+            password=get_env_value(DESTATIS_PASSWORD_ENV) or "GAST",
         )
 
     def tablefile(
@@ -83,7 +87,21 @@ class DestatisGenesisClient:
             timeout=self.timeout,
         )
         response.raise_for_status()
-        text = response.content.decode(response.encoding or "utf-8-sig")
+        body = response.content
+        # Genesis-Online's tablefile endpoint returns a zip archive
+        # regardless of the ``compress=false`` request param (verified
+        # 2026-04-26). Detect the PK\x03\x04 magic and unwrap the
+        # contained CSV; fall through to direct decode for legacy bare
+        # CSV responses (older test fixtures still use that shape).
+        if body[:4] == b"PK\x03\x04":
+            with zipfile.ZipFile(io.BytesIO(body)) as zf:
+                inner = next((n for n in zf.namelist() if n.endswith(".csv")), None)
+                if inner is None:
+                    raise DestatisGenesisError(
+                        f"Destatis zip response had no CSV: {zf.namelist()}"
+                    )
+                body = zf.read(inner)
+        text = body.decode(response.encoding or "utf-8-sig")
         return self._extract_response_text(text)
 
     @staticmethod

--- a/src/ingestion/calendar/stat_bureau_api/estat.py
+++ b/src/ingestion/calendar/stat_bureau_api/estat.py
@@ -54,7 +54,9 @@ def _reference_label(reference: date) -> str:
 
 
 def _resolve_app_id(app_id: str | None) -> str:
-    resolved = (app_id or os.getenv("ESTAT_APP_ID") or "").strip()
+    from env import get_env_value
+
+    resolved = (app_id or get_env_value("ESTAT_APP_ID")).strip()
     if not resolved:
         raise RuntimeError("ESTAT_APP_ID not set")
     return resolved

--- a/tests/test_destatis_calendar_api_scaffold.py
+++ b/tests/test_destatis_calendar_api_scaffold.py
@@ -337,6 +337,38 @@ def test_genesis_client_extracts_json_wrapped_table_content() -> None:
     assert client.tablefile("61111-0004").startswith("Zeit;Merkmal;Wert")
 
 
+def test_genesis_client_unwraps_zip_response() -> None:
+    """Genesis tablefile now returns a ZIP archive containing the CSV.
+
+    Verified against the live API on 2026-04-26: the endpoint always
+    answers ``application/zip`` regardless of the ``compress=false``
+    request param. The client must detect the PK\\x03\\x04 magic and
+    extract the inner ``.csv`` file before decoding.
+    """
+    import io
+    import zipfile
+
+    csv_payload = b"Zeit;Merkmal;Wert\n2026-04;x;2,1\n"
+    zip_buf = io.BytesIO()
+    with zipfile.ZipFile(zip_buf, "w") as zf:
+        zf.writestr("61111-0001_1234_en_flat.csv", csv_payload)
+    zip_bytes = zip_buf.getvalue()
+
+    class _Response:
+        content = zip_bytes
+        encoding = None
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class _Session:
+        def post(self, url, *, data, headers, timeout):  # noqa: ANN001
+            return _Response()
+
+    client = DestatisGenesisClient(session=_Session())  # type: ignore[arg-type]
+    assert client.tablefile("61111-0001").startswith("Zeit;Merkmal;Wert")
+
+
 def test_service_dry_runs_return_plan(store: SQLiteEngineStore) -> None:
     svc = LocalMacroDataService(store=store)
     fetch_result = svc.invoke("calendar_econ_fetch_destatis", {"dry_run": True})


### PR DESCRIPTION
## Summary
- Both connectors now read credentials via \`env.get_env_value()\` so the repo \`.env\` file is actually consulted (previous direct \`os.getenv\` bypassed it).
- Destatis GENESIS \`tablefile\` endpoint now returns \`application/zip\` regardless of \`compress=false\` (verified live 2026-04-26). Detect PK magic and extract inner CSV before decoding.

## Test plan
- [x] \`pytest tests/test_destatis_calendar_api_scaffold.py tests/test_stat_bureau_calendar_api_scaffold.py\` — 28 pass (including new \`test_genesis_client_unwraps_zip_response\`).
- [x] Live verify: \`stat-bureau-jp-values\` upserts 7 events; \`destatis\` returns \`ok=True\`.