### PR TITLE
fix(sdmx): #46 — tolerate empty response bodies

### DIFF
--- a/src/ingestion/timeseries/sdmx/_base_client.py
+++ b/src/ingestion/timeseries/sdmx/_base_client.py
@@ -109,6 +109,28 @@ class SDMXClient:
             ) from exc
         return response
 
+    def _response_json(
+        self, response: requests.Response, *, context: str = "",
+    ) -> dict[str, Any]:
+        """Decode ``response.json()``, tolerating empty bodies / 204.
+
+        ECB (and likely other SDMX 2.1 providers) returns HTTP 200 with a
+        zero-byte body when the requested dataflow/series matches no
+        observations. The default ``response.json()`` raises on byte 0,
+        which trips the connector's failure breaker for what is really a
+        "no data" signal. Returning ``{}`` lets downstream parsers emit
+        zero observations — the same shape they produce for a populated
+        dataset with no matching rows.
+        """
+        if response.status_code == 204 or not response.content:
+            suffix = f" ({context})" if context else ""
+            logger.info(
+                "%s returned empty body for %s%s — treating as zero observations",
+                self.config.provider_name, response.url, suffix,
+            )
+            return {}
+        return response.json()
+
     # ── Hook: date normalization ──────────────────────────────────────
 
     def _normalize_date(self, raw: str) -> str:
@@ -142,7 +164,9 @@ class SDMXClient:
     ) -> list[SDMXObservation]:
         """Default: SDMX-JSON. Override for CSV (BIS) or other formats."""
         return parse_sdmx_json_observations(
-            response.json(),
+            self._response_json(
+                response, context=f"{dataflow}/{series_id or '*'}",
+            ),
             series_id=series_id,
             dataflow=dataflow,
             limit=limit,
@@ -186,7 +210,15 @@ class SDMXClient:
 
         url = self._build_dataflow_list_url()
         response = self._get(url, headers={"Accept": "application/json"})
-        data = response.json()
+        # A catalog endpoint returning an empty body is an outage, not a
+        # "no data" signal — raising here keeps `refresh_catalog()` and
+        # config generators from silently reporting a zero-flow success.
+        if response.status_code == 204 or not response.content:
+            raise self._api_error_cls(
+                f"{self.config.provider_name} returned empty body for "
+                f"dataflow catalog at {url}"
+            )
+        data = self._response_json(response, context="dataflow catalog")
 
         dataflows: list[SDMXDataflow] = []
         for df_node in data.get("data", {}).get("dataflows", []):
@@ -246,7 +278,9 @@ class SDMXClient:
         url = self._build_structure_url(dataflow_id, df_version)
         params: dict[str, str] = {"references": "all"}
         response = self._get(url, params, headers={"Accept": "application/json"})
-        data = response.json()
+        data = self._response_json(
+            response, context=f"DSD {dataflow_id}/{df_version}",
+        )
 
         structures = data.get("data", {}).get("dataStructures", [])
         if not structures:
@@ -401,6 +435,10 @@ class SDMXClient:
         """Probe a dataflow with limit=1 to estimate total size."""
         total_series = 0
         time_periods = 1
+        # An explicit zero-observation response from upstream means the
+        # dataflow truly has no data — return 0 instead of falling back to
+        # the codelist-product, which would advertise a fake nonzero size.
+        probe_was_empty = False
 
         try:
             url = self._build_estimate_url(dataflow_id, **kwargs)
@@ -409,7 +447,11 @@ class SDMXClient:
                 "lastNObservations": "1",
             }
             response = self._get(url, params)
-            data = response.json()
+            if response.status_code == 204 or not response.content:
+                probe_was_empty = True
+            data = self._response_json(
+                response, context=f"estimate {dataflow_id}",
+            )
             datasets = data.get("dataSets", [])
             if datasets:
                 all_series = datasets[0].get("series", {})
@@ -417,7 +459,7 @@ class SDMXClient:
         except (SDMXAPIError, SDMXRateLimitError):
             pass
 
-        if total_series == 0:
+        if total_series == 0 and not probe_was_empty:
             try:
                 structure = self.get_datastructure(dataflow_id, version, **kwargs)
                 total_series = 1

--- a/tests/test_sdmx_empty_response.py
+++ b/tests/test_sdmx_empty_response.py
@@ -1,0 +1,132 @@
+"""Issue #46 — SDMX base client tolerates empty response bodies.
+
+ECB returns HTTP 200 with a zero-byte body when a query matches no
+observations (live-probed 2026-04-26 with
+``EXR/D.USD.EUR.SP00.A?startPeriod=1900-01-01&endPeriod=1900-01-02``
+→ status=200, size=0). Before this fix, ``response.json()`` blew up
+at byte 0 and the connector tripped its failure breaker.
+
+These tests pin the regression at every call site that decodes JSON
+in the base client: ``_parse_data_response`` (the value-sweep path
+that surfaced the production failure), ``list_dataflows``,
+``get_datastructure``, and ``estimate_size``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import requests
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from ingestion.timeseries.sdmx._base_client import SDMXClient
+from ingestion.timeseries.sdmx._config import ECB_CONFIG
+from ingestion.timeseries.sdmx._errors import SDMXAPIError
+
+
+def _fake_response(
+    *, status_code: int = 200, content: bytes = b"", url: str = "http://x",
+) -> requests.Response:
+    r = requests.Response()
+    r.status_code = status_code
+    r._content = content
+    r.url = url
+    return r
+
+
+@pytest.fixture()
+def client() -> SDMXClient:
+    c = SDMXClient(ECB_CONFIG, timeout=5)
+    c.config = ECB_CONFIG  # ensure provider_name visible
+    return c
+
+
+def test_response_json_returns_empty_dict_on_zero_byte_body(client: SDMXClient) -> None:
+    response = _fake_response(content=b"")
+    assert client._response_json(response, context="EXR/.") == {}
+
+
+def test_response_json_returns_empty_dict_on_204(client: SDMXClient) -> None:
+    response = _fake_response(status_code=204, content=b"")
+    assert client._response_json(response) == {}
+
+
+def test_response_json_decodes_normal_body(client: SDMXClient) -> None:
+    response = _fake_response(content=b'{"data": {"dataflows": []}}')
+    assert client._response_json(response) == {"data": {"dataflows": []}}
+
+
+def test_get_data_yields_empty_observations_on_empty_body(client: SDMXClient) -> None:
+    """Production failure path: value sweep against an ECB series whose
+    upstream returned 200 with no body. Should produce zero observations,
+    not raise JSONDecodeError.
+    """
+    empty = _fake_response(content=b"")
+    with patch.object(client, "_get", return_value=empty):
+        observations = client.get_data(
+            "EXR", "D.USD.EUR.SP00.A", series_id="EXR", limit=1,
+        )
+    assert observations == []
+
+
+def test_list_dataflows_raises_on_empty_body(client: SDMXClient) -> None:
+    """A catalog endpoint returning an empty body is an outage, not a
+    "no data" signal — raising prevents `refresh_catalog()` from silently
+    reporting a zero-flow success on a transient catalog response."""
+    empty = _fake_response(content=b"")
+    with patch.object(client, "_get", return_value=empty):
+        with pytest.raises(SDMXAPIError, match="empty body"):
+            client.list_dataflows()
+
+
+def test_get_datastructure_raises_on_empty_body(client: SDMXClient) -> None:
+    """Empty body for a structure request still has to raise — there is
+    no DSD to return — but with the connector-friendly ``SDMXAPIError``
+    rather than a raw ``JSONDecodeError``."""
+    empty = _fake_response(content=b"")
+    with patch.object(client, "_get", return_value=empty):
+        with pytest.raises(SDMXAPIError):
+            client.get_datastructure("EXR", version="1.0")
+
+
+def test_estimate_size_yields_zero_on_empty_body(client: SDMXClient) -> None:
+    empty = _fake_response(content=b"")
+    with patch.object(client, "_get", return_value=empty), \
+         patch.object(client, "get_datastructure", side_effect=SDMXAPIError("x")):
+        estimate = client.estimate_size("EXR")
+    assert estimate.total_series == 0
+
+
+def test_estimate_size_skips_codelist_fallback_on_empty_probe(
+    client: SDMXClient,
+) -> None:
+    """An explicit zero-observation response must not fall back to the
+    codelist-product size — that would advertise a fake nonzero estimate
+    for a dataflow whose upstream truly returned no data.
+    """
+    empty = _fake_response(content=b"")
+    with patch.object(client, "_get", return_value=empty), \
+         patch.object(client, "get_datastructure") as ds_mock:
+        estimate = client.estimate_size("EXR")
+    assert estimate.total_series == 0
+    ds_mock.assert_not_called()
+
+
+def test_list_dataflows_does_not_cache_failed_catalog(client: SDMXClient) -> None:
+    """A transient empty-body response on the catalog endpoint raises and
+    must not be cached — the next caller must get a fresh attempt."""
+    empty = _fake_response(content=b"")
+    populated = _fake_response(
+        content=b'{"data": {"dataflows": [{"id": "EXR", "agencyID": "ECB"}]}}',
+    )
+    with patch.object(client, "_get", side_effect=[empty, populated]):
+        with pytest.raises(SDMXAPIError):
+            client.list_dataflows()
+        second = client.list_dataflows()
+    assert len(second) == 1
+    assert second[0].id == "EXR"


### PR DESCRIPTION
## Summary

- ECB returns HTTP 200 + 0 bytes for queries matching no observations; default `response.json()` blew up and tripped the connector's 3-fail breaker.
- New `SDMXClient._response_json` short-circuits to `{}` on 204 / empty content, with an INFO log naming provider/url/context.
- `_parse_data_response` and `estimate_size` yield zero observations / zero series; `estimate_size` skips the codelist-product fallback when the probe was truthfully empty.
- `list_dataflows` raises on an empty catalog body — that's an outage, not "no data".

Closes #46

## Test plan

- [x] `tests/test_sdmx_empty_response.py` — 9 mocked tests pin every call site (data, catalog, DSD, estimate) at both 200/zero-byte and 204.
- [x] Existing 74 sdmx/ecb mocked tests still pass.