### PR TITLE
feat(data-quality): #102 — concept-validation + digest auto-filer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,6 +242,7 @@ Issue #36 — Wayback evidence-archive URL per vintage row:
 - `release_schedule` (rules) + `release_status` (per-release tracking). Date-math resolvers in `ingestion/release_schedule.py` compute `next_expected` per concept.
 - State machine: `PENDING → WAITING → FETCHED → CONFIRMED / STALE / FAILED`. Retry ladder 1m / 5m / 15m / 1h / 4h.
 - Three alert types: `DELAY` (missed expected release by 30m), `FAILED` (retries exhausted), `MISMATCH` (cross-source divergence over threshold).
+- **Data-quality auto-filer (issue #102):** `src/ingestion/quality/data_quality_filer.py` is the macro-data sibling to the calendar-side `parity_filer`. It rolls concept-validation hard failures, shadow-digest coverage drops, and persisted-log secret leaks into one `data-quality` GitHub issue (label distinct from `parity-drift`), comments on the open issue while findings persist, and auto-closes after `CLEAN_STREAK_TO_CLOSE` consecutive clean runs. State lives at `.macro-data/data_quality_state.json`. `scripts/data_quality_daily.py` is the entry-point — runs `validate_all_concepts`, computes `compute_digest`, scans the tail of `shadow.log` / `daily_digest.jsonl` for any unredacted `api_key=…`, and appends a structured JSON line to `.macro-data/logs/data_quality.log`. Bare `macro-data-service validate` (no `--source`) now delegates to concept validation and exits 1 on failures; `validate --source X` exits 1 with a `--json`-safe `ok=false` payload when zero checks ran. `ingestion/_shared/redaction.py` (`redact_secrets` + `SecretRedactingFilter`) is the shared scrubber both this filer and `shadow_runner` use to keep provider keys out of logs, digest payloads, issue bodies, and traceback text.
 
 ### 7. Source capabilities + catalog sync
 
@@ -317,7 +318,8 @@ src/
     validation/             Data quality + cross-source checks
     sdmx/                   Unified SDMX engine (base client, parsing, providers/)
     timeseries/, news/, documents/, trends/, market/, calendar/, sentiment/  One dir per domain
-    _shared/                http_transport, url_canon, selector versioning
+    quality/                data_quality_filer — macro data-quality auto-filer (issue #102)
+    _shared/                http_transport, url_canon, selector versioning, redaction
   macro_data/
     service/                LocalMacroDataService — the one interface downstream reads
       base.py               __init__, invoke router, _ensure_* one-shot seeders

--- a/scripts/data_quality_daily.py
+++ b/scripts/data_quality_daily.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Daily macro data-quality auto-filer entry-point (issue #102 P3).
+
+Mirrors :mod:`scripts.parity_daily` for the data-quality lane:
+
+1. Run concept-level validation across the engine DB.
+2. Compute the shadow digest snapshot.
+3. Roll those signals up into a :class:`DataQualityReport`.
+4. File / comment / close the single ``data-quality`` GitHub issue via
+   :func:`ingestion.quality.data_quality_filer.file_data_quality_report`.
+5. Append a structured log line to ``.macro-data/logs/data_quality.log``.
+
+Exit codes:
+
+- 0 on success (clean run, finding run, or dry-run).
+- 1 on validation / digest failure that prevents the run from
+  reaching the filer.
+- 2 on argument errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import sys
+import traceback
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ingestion._shared.redaction import redact_secrets  # noqa: E402
+from ingestion.calendar.parity_filer import GhRunner  # noqa: E402
+from ingestion.quality.data_quality_filer import (  # noqa: E402
+    DataQualityFinding,
+    DataQualityReport,
+    coverage_drop_from_digest,
+    default_state_path,
+    file_data_quality_report,
+    findings_from_concept_reports,
+    secret_leak_from_text,
+)
+from ingestion.validation import ValidationEngine, ValidationStore  # noqa: E402
+from storage import SQLiteEngineStore, default_engine_db_path  # noqa: E402
+
+LOG_FILENAME = "data_quality.log"
+
+logger = logging.getLogger("data_quality_daily")
+
+
+def _today_utc(now: dt.datetime | None = None) -> dt.date:
+    base = now or dt.datetime.now(dt.timezone.utc)
+    return base.date()
+
+
+def _append_log(log_path: Path, payload: dict) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as fh:
+        fh.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _scan_log_for_secrets(log_path: Path) -> DataQualityFinding | None:
+    """Scan the tail of a persisted log for unredacted secrets."""
+    if not log_path.is_file():
+        return None
+    try:
+        # Only look at the last ~256 KB — older log lines pre-date the
+        # redaction guard and would create permanent noise.
+        with log_path.open("rb") as fh:
+            fh.seek(0, 2)
+            size = fh.tell()
+            offset = max(0, size - 256 * 1024)
+            fh.seek(offset)
+            sample = fh.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+    return secret_leak_from_text(sample, source_label=log_path.name)
+
+
+def _build_report(
+    *,
+    target_date: dt.date,
+    engine_db: Path,
+) -> tuple[DataQualityReport, dict]:
+    """Run validation + digest, assemble findings, return report+summary."""
+    summary: dict = {"target_date": target_date.isoformat()}
+
+    db_path = str(engine_db)
+    store = SQLiteEngineStore(db_path=engine_db)
+    store.seed_concept_map()
+    validation_store = ValidationStore(db_path)
+    engine = ValidationEngine(validation_store)
+    reports = engine.validate_all_concepts(store)
+    summary["concept_reports"] = len(reports)
+    summary["concept_failures"] = sum(1 for r in reports if not r.passed)
+
+    # Lazy import to avoid heavy paths during unit tests of the filer.
+    from shadow_runner import compute_digest
+
+    digest = compute_digest(db_path)
+    digest = {"timestamp": dt.datetime.now(dt.timezone.utc).isoformat(), **digest}
+
+    findings: list[DataQualityFinding] = []
+    if not reports:
+        # An empty concept_map means every concept-level guard was a
+        # no-op. Without a finding here the run would auto-close the
+        # data-quality issue based on a vacuous "clean" comparator.
+        findings.append(
+            DataQualityFinding(
+                kind="zero_validation_reports",
+                severity="error",
+                detail=(
+                    "validate_all_concepts returned 0 reports; "
+                    "concept_map is empty or unseeded"
+                ),
+            ),
+        )
+    findings.extend(findings_from_concept_reports(reports))
+    drop = coverage_drop_from_digest(digest)
+    if drop is not None:
+        findings.append(drop)
+
+    log_dir = engine_db.parent / "logs"
+    for log_name in ("shadow.log", "daily_digest.jsonl"):
+        leak = _scan_log_for_secrets(log_dir / log_name)
+        if leak is not None:
+            findings.append(leak)
+
+    report = DataQualityReport(
+        target_date=target_date,
+        findings=findings,
+        digest_summary={
+            k: digest.get(k)
+            for k in (
+                "timestamp", "cycle", "concepts_covered", "concepts_total",
+                "coverage_pct", "confirmed_24h", "error_sources",
+            )
+            if digest.get(k) is not None
+        },
+    )
+    summary["findings"] = [f.to_dict() for f in findings]
+    summary["clean"] = report.clean
+    return report, summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--date",
+        type=lambda s: dt.date.fromisoformat(s),
+        default=None,
+        help="Run date label (default: today UTC).",
+    )
+    parser.add_argument(
+        "--db-path", type=Path, default=None,
+        help="engine.db override (default: .macro-data/engine.db).",
+    )
+    parser.add_argument(
+        "--state-path", type=Path, default=None,
+        help="Filer state path override.",
+    )
+    parser.add_argument(
+        "--log-path", type=Path, default=None,
+        help="Log file path override.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Run validation + digest but stub out gh side effects.",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Log to stderr at DEBUG.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    target = args.date or _today_utc()
+    engine_db = args.db_path or default_engine_db_path()
+    log_path = args.log_path or (engine_db.parent / "logs" / LOG_FILENAME)
+    state_path = args.state_path or default_state_path(engine_db.parent.parent)
+
+    started = dt.datetime.now(dt.timezone.utc)
+    summary: dict = {
+        "started_at": started.isoformat(),
+        "target_date": target.isoformat(),
+        "dry_run": args.dry_run,
+    }
+
+    runner = GhRunner(dry_run=args.dry_run)
+
+    try:
+        report, build_summary = _build_report(
+            target_date=target, engine_db=engine_db,
+        )
+        summary.update(build_summary)
+
+        action = file_data_quality_report(
+            report=report, runner=runner, state_path=state_path,
+        )
+        summary["created"] = [n for n, _ in action.created]
+        summary["commented"] = list(action.commented)
+        summary["closed"] = list(action.closed)
+        summary["skipped_clean"] = action.skipped_clean
+        summary["status"] = "ok"
+        summary["finished_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
+        _append_log(log_path, summary)
+        return 0
+
+    except Exception as exc:
+        summary["status"] = "error"
+        summary["error"] = redact_secrets(repr(exc))
+        summary["traceback"] = redact_secrets(traceback.format_exc())
+        summary["finished_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
+        _append_log(log_path, summary)
+        logger.exception("data_quality_daily run failed")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shadow_runner.py
+++ b/shadow_runner.py
@@ -15,6 +15,10 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from ingestion._shared.redaction import SecretRedactingFilter, redact_secrets  # noqa: E402
+
 # ── Logging setup ──────────────────────────────────────────────────────────
 
 LOG_DIR = Path(__file__).parent / ".macro-data" / "logs"
@@ -50,10 +54,12 @@ def setup_logging() -> None:
     ch.setFormatter(fmt)
     root.addHandler(ch)
 
-    # File — rotates daily via name, append mode
+    # File — rotates daily via name, append mode. The redacting filter
+    # scrubs api_key=… style secrets before they hit disk.
     fh = logging.FileHandler(LOG_FILE, mode="a", encoding="utf-8")
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(fmt)
+    fh.addFilter(SecretRedactingFilter())
     root.addHandler(fh)
 
 
@@ -161,17 +167,40 @@ def compute_digest(db_path: str) -> dict:
     }
 
 
+def _redact_digest_payload(digest: dict) -> dict:
+    """Redact provider secrets from any error strings inside the digest.
+
+    We only walk the well-known string fields that carry upstream error
+    text (per-source ``error`` and the digest-level ``error`` from the
+    runner). Any future free-text field added here should be added to
+    this list rather than dumped raw.
+    """
+    redacted = dict(digest)
+    sources = redacted.get("source_results")
+    if isinstance(sources, dict):
+        redacted["source_results"] = {
+            name: {**entry, "error": redact_secrets(entry.get("error", ""))}
+            if isinstance(entry, dict)
+            else entry
+            for name, entry in sources.items()
+        }
+    if isinstance(redacted.get("error"), str):
+        redacted["error"] = redact_secrets(redacted["error"])
+    return redacted
+
+
 def write_digest(digest: dict) -> None:
     """Append digest to JSONL file for time-series tracking."""
+    safe_digest = _redact_digest_payload(digest)
     with open(DIGEST_FILE, "a", encoding="utf-8") as f:
-        f.write(json.dumps(digest, ensure_ascii=False) + "\n")
+        f.write(json.dumps(safe_digest, ensure_ascii=False) + "\n")
     logger.info(
         "DIGEST: coverage=%d/%d (%.0f%%), confirmed_24h=%d, total_obs=%d",
-        digest["concepts_covered"],
-        digest["concepts_total"],
-        digest["coverage_pct"],
-        digest.get("confirmed_24h", 0),
-        digest["total_obs"],
+        safe_digest["concepts_covered"],
+        safe_digest["concepts_total"],
+        safe_digest["coverage_pct"],
+        safe_digest.get("confirmed_24h", 0),
+        safe_digest["total_obs"],
     )
 
 

--- a/src/ingestion/_shared/__init__.py
+++ b/src/ingestion/_shared/__init__.py
@@ -4,3 +4,7 @@ from ingestion._shared.http_transport import *  # noqa: F401,F403
 from ingestion._shared.url_canon import *  # noqa: F401,F403
 from ingestion._shared.common import *  # noqa: F401,F403
 from ingestion._shared.selector_versioning import *  # noqa: F401,F403
+from ingestion._shared.redaction import (  # noqa: F401
+    SecretRedactingFilter,
+    redact_secrets,
+)

--- a/src/ingestion/_shared/redaction.py
+++ b/src/ingestion/_shared/redaction.py
@@ -1,0 +1,102 @@
+"""Secret-redaction helpers (issue #102).
+
+Provider error messages — typically wrapped urllib3 / requests exceptions —
+include the full request URL in their text. When that URL carries an
+``api_key=…`` or similar token in the query string, the secret leaks into
+``shadow.log`` and ``daily_digest.jsonl`` the moment we serialize the error.
+
+:func:`redact_secrets` strips the value of every known secret query
+parameter, replacing it with ``***``. The match is anchored on the
+parameter name to avoid mangling unrelated text.
+
+:class:`SecretRedactingFilter` is a logging filter wrapping the same call
+so the file handler scrubs records regardless of which call site
+formatted them.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import traceback
+
+# Parameter names whose values must never reach disk. The list is
+# deliberately specific: matching ``key=`` would clobber unrelated values
+# like ``key=stored`` in human-readable log lines.
+_SECRET_PARAM_NAMES = (
+    "api_key",
+    "apikey",
+    "api_token",
+    "access_token",
+    "auth_token",
+    "authtoken",
+    "authentication",
+    "token",
+    "password",
+    "passwd",
+    "client_secret",
+)
+
+_SECRET_QUERY_RE = re.compile(
+    r"(?i)\b(" + "|".join(_SECRET_PARAM_NAMES) + r")=([^&\s\"'<>\\]+)",
+)
+
+_BEARER_RE = re.compile(r"(?i)(bearer\s+)([A-Za-z0-9\-_\.=]+)")
+
+_REDACTED = "***"
+
+
+def redact_secrets(text: str | None) -> str:
+    """Replace secret values inside ``text`` with ``***``.
+
+    Returns ``""`` for ``None`` to keep callers tolerant of missing
+    error fields. Idempotent — already-redacted strings pass through
+    unchanged because ``***`` does not match the value alphabet.
+    """
+    if not text:
+        return text or ""
+    redacted = _SECRET_QUERY_RE.sub(lambda m: f"{m.group(1)}={_REDACTED}", text)
+    redacted = _BEARER_RE.sub(lambda m: f"{m.group(1)}{_REDACTED}", redacted)
+    return redacted
+
+
+class SecretRedactingFilter(logging.Filter):
+    """Logging filter that scrubs secrets from formatted records.
+
+    Attach to any handler whose output may persist (file handlers,
+    syslog, etc.). The filter rewrites ``record.msg`` and clears the
+    cached ``record.args`` so that downstream formatting stays in sync.
+
+    ``record.exc_info`` and ``record.stack_info`` are rendered and
+    redacted here — the standard ``logging.Formatter`` appends them
+    *after* the filter chain runs, so if we don't pre-render them, an
+    ``exc_info=True`` log call will leak provider URLs verbatim into
+    the traceback section of the file output.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            rendered = record.getMessage()
+        except Exception:
+            rendered = None
+        if rendered is not None:
+            cleaned = redact_secrets(rendered)
+            if cleaned != rendered:
+                record.msg = cleaned
+                record.args = None
+
+        if record.exc_info:
+            etype, value, tb = record.exc_info
+            text = "".join(traceback.format_exception(etype, value, tb))
+            record.exc_text = redact_secrets(text)
+            record.exc_info = None
+        elif record.exc_text:
+            record.exc_text = redact_secrets(record.exc_text)
+
+        if record.stack_info:
+            record.stack_info = redact_secrets(record.stack_info)
+
+        return True
+
+
+__all__ = ["redact_secrets", "SecretRedactingFilter"]

--- a/src/ingestion/quality/__init__.py
+++ b/src/ingestion/quality/__init__.py
@@ -1,0 +1,21 @@
+"""Data-quality auto-filing surface (issue #102)."""
+
+from ingestion.quality.data_quality_filer import (
+    DATA_QUALITY_LABEL,
+    DataQualityFinding,
+    DataQualityReport,
+    coverage_drop_from_digest,
+    file_data_quality_report,
+    findings_from_concept_reports,
+    secret_leak_from_text,
+)
+
+__all__ = [
+    "DATA_QUALITY_LABEL",
+    "DataQualityFinding",
+    "DataQualityReport",
+    "coverage_drop_from_digest",
+    "file_data_quality_report",
+    "findings_from_concept_reports",
+    "secret_leak_from_text",
+]

--- a/src/ingestion/quality/data_quality_filer.py
+++ b/src/ingestion/quality/data_quality_filer.py
@@ -1,0 +1,477 @@
+"""Macro data-quality auto-filer (issue #102).
+
+The TE calendar parity tripwire (``ingestion/calendar/parity_filer.py``)
+only acts on calendar-style ``AgencyReport`` anomalies. Everything else
+that signals upstream rot — concept-validation hard failures, shadow
+digest coverage drops, ``validate`` runs that produced zero checks,
+provider keys leaking into persisted logs — has no single sink today.
+
+This module fills that gap with a separate filer keyed on the
+``data-quality`` label so the two pipelines never collide:
+
+* One open ``data-quality`` issue at a time.
+* Daily comments append the latest run when an issue is already open.
+* :data:`CLEAN_STREAK_TO_CLOSE` consecutive clean runs auto-close.
+* Issue / comment bodies are redacted via
+  :func:`ingestion._shared.redaction.redact_secrets` before they hit
+  GitHub, mirroring the on-disk log guarantee from P1.
+
+The :class:`GhRunner` from ``parity_filer`` is reused as-is (the only
+parity-specific surface there is the agency_id label, which we replace
+with ``"data-quality"``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from ingestion._shared.redaction import redact_secrets
+from ingestion.calendar.parity_filer import (
+    GhRunner,
+    _label_args,
+    _parse_issue_url,
+)
+
+logger = logging.getLogger(__name__)
+
+DATA_QUALITY_LABEL = "data-quality"
+CLEAN_STREAK_TO_CLOSE = 7
+DEFAULT_REPRO_COMMANDS = (
+    "PYTHONPATH=src python3 -m macro_data.cli validate "
+    "--db-path .macro-data/engine.db --json",
+    "PYTHONPATH=src python3 -c "
+    "\"from shadow_runner import compute_digest; import json; "
+    "print(json.dumps(compute_digest('.macro-data/engine.db'), indent=2))\"",
+)
+
+
+# ---------------------------------------------------------------------------
+# Findings + report
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DataQualityFinding:
+    """One concrete macro data-quality failure detected on a run.
+
+    ``kind`` identifies the trigger family (matches the four signals
+    listed in the issue thread). ``severity`` keeps the same vocabulary
+    as :class:`ingestion.validation._types.ValidationSeverity` so the
+    filer's clean / error gating mirrors the underlying check.
+    """
+
+    kind: str
+    detail: str
+    severity: str = "error"
+    concept_id: str = ""
+    series_id: str = ""
+    source: str = ""
+    run_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "severity": self.severity,
+            "detail": self.detail,
+            "concept_id": self.concept_id,
+            "series_id": self.series_id,
+            "source": self.source,
+            "run_id": self.run_id,
+        }
+
+
+_BLOCKING_SEVERITIES = ("error", "critical")
+
+
+@dataclass
+class DataQualityReport:
+    """Aggregate of findings from one filer cycle."""
+
+    target_date: date
+    findings: list[DataQualityFinding] = field(default_factory=list)
+    digest_summary: dict[str, Any] = field(default_factory=dict)
+    repro_commands: tuple[str, ...] = DEFAULT_REPRO_COMMANDS
+
+    @property
+    def clean(self) -> bool:
+        return not any(f.severity in _BLOCKING_SEVERITIES for f in self.findings)
+
+    @property
+    def error_findings(self) -> list[DataQualityFinding]:
+        return [f for f in self.findings if f.severity in _BLOCKING_SEVERITIES]
+
+    @property
+    def warning_findings(self) -> list[DataQualityFinding]:
+        return [f for f in self.findings if f.severity == "warning"]
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+# ---------------------------------------------------------------------------
+
+
+def findings_from_concept_reports(reports: Iterable[Any]) -> list[DataQualityFinding]:
+    """Map concept-level :class:`ValidationReport`s to findings.
+
+    Pulls every error- or critical-severity check from each report and
+    one finding per failed check. Reports that pass cleanly contribute
+    nothing.
+    """
+    out: list[DataQualityFinding] = []
+    for report in reports:
+        if getattr(report, "passed", True) and not _has_warning_checks(report):
+            continue
+        run_id = getattr(report, "run_id", "")
+        for check in getattr(report, "checks", ()):  # CheckResult
+            if check.passed:
+                continue
+            severity = (
+                check.severity.value
+                if hasattr(check.severity, "value")
+                else str(check.severity)
+            )
+            if severity not in ("error", "critical", "warning"):
+                continue
+            kind = (
+                "concept_warning"
+                if severity == "warning"
+                else "concept_failure"
+            )
+            out.append(
+                DataQualityFinding(
+                    kind=kind,
+                    severity="warning" if severity == "warning" else "error",
+                    detail=redact_secrets(check.message),
+                    concept_id=check.source,
+                    series_id=getattr(check, "series_id", "") or "",
+                    run_id=run_id,
+                ),
+            )
+    return out
+
+
+def _has_warning_checks(report: Any) -> bool:
+    for check in getattr(report, "checks", ()):
+        severity = (
+            check.severity.value
+            if hasattr(check.severity, "value")
+            else str(check.severity)
+        )
+        if severity == "warning" and not check.passed:
+            return True
+    return False
+
+
+def coverage_drop_from_digest(digest: dict[str, Any]) -> DataQualityFinding | None:
+    """Emit a finding when shadow digest reports incomplete coverage.
+
+    The threshold is strict: any ``concepts_covered < concepts_total``
+    or any non-empty ``error_sources`` flips this to a finding. We
+    don't try to be clever about transient gaps — that's what the
+    clean-streak counter on the filer is for.
+    """
+    covered = int(digest.get("concepts_covered", 0))
+    total = int(digest.get("concepts_total", 0))
+    error_sources = list(digest.get("error_sources", []) or [])
+    if total > 0 and covered >= total and not error_sources:
+        return None
+    parts: list[str] = []
+    if total > 0 and covered < total:
+        parts.append(f"coverage {covered}/{total}")
+    if error_sources:
+        # Pre-redact in case any source name carries a stray query string.
+        parts.append(
+            "error_sources=["
+            + ", ".join(redact_secrets(s) for s in error_sources)
+            + "]"
+        )
+    if not parts:
+        return None
+    return DataQualityFinding(
+        kind="coverage_drop",
+        severity="error",
+        detail="shadow digest: " + "; ".join(parts),
+    )
+
+
+def secret_leak_from_text(text: str, *, source_label: str = "") -> DataQualityFinding | None:
+    """Emit a finding when ``text`` still contains a known secret.
+
+    Use when scanning persisted logs to confirm the redaction guard
+    held. ``source_label`` gets included verbatim in the detail so the
+    operator knows which file to inspect.
+    """
+    if not text:
+        return None
+    redacted = redact_secrets(text)
+    if redacted == text:
+        return None
+    label = source_label or "log"
+    return DataQualityFinding(
+        kind="secret_leak",
+        severity="error",
+        detail=f"{label}: provider secret detected (redacted in this issue)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Body formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_findings_table(findings: Sequence[DataQualityFinding], title: str) -> list[str]:
+    if not findings:
+        return []
+    lines: list[str] = []
+    lines.append(f"## {title}")
+    lines.append("")
+    lines.append("| Kind | Concept | Series | Detail | Run ID |")
+    lines.append("|------|---------|--------|--------|--------|")
+    for f in findings:
+        lines.append(
+            f"| {f.kind} | {f.concept_id or '—'} | {f.series_id or '—'} "
+            f"| {redact_secrets(f.detail)} | `{f.run_id or '—'}` |",
+        )
+    lines.append("")
+    return lines
+
+
+def _format_digest_section(digest: dict[str, Any]) -> list[str]:
+    if not digest:
+        return []
+    lines: list[str] = ["## Shadow digest"]
+    lines.append("")
+    if "concepts_covered" in digest and "concepts_total" in digest:
+        coverage_pct = digest.get("coverage_pct")
+        coverage_str = (
+            f"{digest['concepts_covered']}/{digest['concepts_total']}"
+            + (f" ({coverage_pct}%)" if coverage_pct is not None else "")
+        )
+        lines.append(f"- Coverage: {coverage_str}")
+    if "confirmed_24h" in digest:
+        lines.append(f"- Confirmed (24h): {digest['confirmed_24h']}")
+    error_sources = digest.get("error_sources")
+    if error_sources:
+        lines.append(
+            "- Error sources: "
+            + ", ".join(f"`{redact_secrets(s)}`" for s in error_sources),
+        )
+    if "cycle" in digest:
+        lines.append(f"- Cycle: {digest['cycle']}")
+    if "timestamp" in digest:
+        lines.append(f"- Timestamp: `{digest['timestamp']}`")
+    lines.append("")
+    return lines
+
+
+def _format_repro_section(commands: Sequence[str]) -> list[str]:
+    if not commands:
+        return []
+    lines = ["## Repro", "", "```"]
+    lines.extend(redact_secrets(cmd) for cmd in commands)
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def _format_report_body(report: DataQualityReport) -> str:
+    lines: list[str] = []
+    iso = report.target_date.isoformat()
+    lines.append(f"# Macro data-quality — {iso}")
+    lines.append("")
+    lines.append(
+        f"Findings: **{len(report.error_findings)} errors**, "
+        f"**{len(report.warning_findings)} warnings**",
+    )
+    lines.append("")
+    lines.extend(_format_findings_table(report.error_findings, "Errors"))
+    lines.extend(_format_findings_table(report.warning_findings, "Warnings"))
+    lines.extend(_format_digest_section(report.digest_summary))
+    lines.extend(_format_repro_section(report.repro_commands))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _format_comment_body(report: DataQualityReport) -> str:
+    iso = report.target_date.isoformat()
+    body = _format_report_body(report)
+    # Strip the H1 header from the issue body so the comment leads with
+    # a date stamp instead of a duplicate title.
+    _, _, rest = body.partition("\n")
+    return f"### Daily data-quality run — `{iso}`\n\n{rest}"
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+
+def default_state_path(root: Path | None = None) -> Path:
+    base = root or Path.cwd()
+    return base / ".macro-data" / "data_quality_state.json"
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        logger.warning("data_quality_state.json unreadable at %s; starting fresh", path)
+        return {}
+
+
+def _save_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, sort_keys=True, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# GhRunner extensions
+# ---------------------------------------------------------------------------
+
+
+def _list_open_data_quality_issue(runner: GhRunner) -> int | None:
+    """List the single open ``data-quality`` issue, regardless of whether
+    other label filters were applied.
+
+    ``GhRunner.list_open_issue(agency_id=...)`` is parity-specific (it
+    appends ``parity-drift`` + ``agency:<id>``). We need a different
+    label tuple, so we route through the same private ``_run`` so dry-
+    run handling stays consistent.
+    """
+    out = runner._run(  # type: ignore[attr-defined]
+        "issue", "list",
+        "--label", DATA_QUALITY_LABEL,
+        "--state", "open",
+        "--json", "number",
+        "--limit", "5",
+    )
+    if not out:
+        return None
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    if not data:
+        return None
+    return max(int(entry["number"]) for entry in data if "number" in entry)
+
+
+def _create_data_quality_issue(
+    runner: GhRunner, *, title: str, body: str,
+) -> int | None:
+    out = runner._run(  # type: ignore[attr-defined]
+        "issue", "create",
+        "--title", title,
+        "--body", body,
+        *_label_args([DATA_QUALITY_LABEL]),
+    )
+    return _parse_issue_url(out)
+
+
+# ---------------------------------------------------------------------------
+# Action log
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DataQualityFilerAction:
+    """Mirror of ``parity_filer.FilerActionLog`` for the data-quality path."""
+
+    created: list[tuple[int, str]] = field(default_factory=list)  # (number, title)
+    commented: list[int] = field(default_factory=list)
+    closed: list[int] = field(default_factory=list)
+    skipped_clean: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def file_data_quality_report(
+    *,
+    report: DataQualityReport,
+    runner: GhRunner,
+    state_path: Path | None = None,
+) -> DataQualityFilerAction:
+    """Reconcile ``report`` against the open ``data-quality`` issue.
+
+    Behavior matches the parity filer's lifecycle invariants:
+
+    * Findings + open issue → comment + reset clean streak.
+    * Findings + no open issue → create + reset clean streak.
+    * Clean run + open issue → bump streak; close on
+      :data:`CLEAN_STREAK_TO_CLOSE`.
+    * Clean run + no open issue → bump streak only.
+    """
+    iso = report.target_date.isoformat()
+    state_path = state_path or default_state_path()
+    state = _load_state(state_path)
+    action = DataQualityFilerAction()
+
+    live_issue = _list_open_data_quality_issue(runner)
+    state.setdefault("clean_streak", 0)
+
+    if not report.clean:
+        state["clean_streak"] = 0
+        state["last_failure_date"] = iso
+        if live_issue is not None:
+            runner.comment_issue(
+                number=live_issue, body=_format_comment_body(report),
+            )
+            action.commented.append(live_issue)
+            state["open_issue"] = live_issue
+            _save_state(state_path, state)
+            return action
+        title = f"Macro data-quality — {iso}"
+        body = _format_report_body(report)
+        created = _create_data_quality_issue(runner, title=title, body=body)
+        if created is not None:
+            action.created.append((created, title))
+            state["open_issue"] = created
+        _save_state(state_path, state)
+        return action
+
+    # Clean run.
+    streak = int(state.get("clean_streak", 0)) + 1
+    state["clean_streak"] = streak
+    state["last_clean_date"] = iso
+    action.skipped_clean = True
+
+    if live_issue is None:
+        _save_state(state_path, state)
+        return action
+    if streak >= CLEAN_STREAK_TO_CLOSE:
+        runner.close_issue(
+            number=int(live_issue),
+            comment=(
+                f"Auto-closing: {streak} consecutive clean macro data-"
+                f"quality runs through {iso}."
+            ),
+        )
+        action.closed.append(int(live_issue))
+        state["open_issue"] = None
+        state["clean_streak"] = 0
+    _save_state(state_path, state)
+    return action
+
+
+__all__ = [
+    "CLEAN_STREAK_TO_CLOSE",
+    "DATA_QUALITY_LABEL",
+    "DEFAULT_REPRO_COMMANDS",
+    "DataQualityFilerAction",
+    "DataQualityFinding",
+    "DataQualityReport",
+    "coverage_drop_from_digest",
+    "default_state_path",
+    "file_data_quality_report",
+    "findings_from_concept_reports",
+    "secret_leak_from_text",
+]

--- a/src/macro_data/cli.py
+++ b/src/macro_data/cli.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import asdict
 import json
+import sys
+from dataclasses import asdict
 from pathlib import Path
 
 from ingestion.sdmx.providers.oecd import OECDClient
@@ -447,6 +448,7 @@ def _run_schedule_command(args: argparse.Namespace) -> int:
 
 def _run_validate(args: argparse.Namespace) -> int:
     from ingestion.validation import ValidationEngine, ValidationStore
+    from storage import SQLiteEngineStore
 
     db_path = args.db_path or ".macro-data/engine.db"
     validation_store = ValidationStore(db_path)
@@ -482,12 +484,63 @@ def _run_validate(args: argparse.Namespace) -> int:
         return 0
 
     engine = ValidationEngine(validation_store)
-    report = engine.validate_full(args.source or "all")
+
+    # When no --source is given the legacy ``validate_full("all")`` path
+    # produces zero checks (every layer needs raw/stored inputs we don't
+    # have here) and reports PASS, which masks real data-quality
+    # failures. Delegate to concept-level validation so the CLI
+    # surfaces FEDWATCH_US / VIX_US / CPI_EU style issues instead.
+    if args.source is None:
+        store = SQLiteEngineStore(db_path=Path(db_path))
+        store.seed_concept_map()
+        reports = engine.validate_all_concepts(store)
+        if args.json_output:
+            payload = {
+                "reports": [r.to_dict() for r in reports],
+                "report_count": len(reports),
+                "failed_count": sum(1 for r in reports if not r.passed),
+                "ok": bool(reports) and all(r.passed for r in reports),
+            }
+            if not reports:
+                payload["error"] = "validate ran 0 concept reports; concept_map may be empty."
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+        else:
+            for r in reports:
+                print(r.format_text())
+                print()
+            if not reports:
+                print(
+                    "ERROR: validate ran 0 concept reports; "
+                    "concept_map may be empty.",
+                    file=sys.stderr,
+                )
+        if not reports:
+            return 1
+        failed = sum(1 for r in reports if not r.passed)
+        return 1 if failed > 0 else 0
+
+    report = engine.validate_full(args.source)
 
     if args.json_output:
-        print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
+        payload = report.to_dict()
+        if not report.checks:
+            payload["ok"] = False
+            payload["error"] = (
+                f"validate produced 0 checks for source='{args.source}'. "
+                "Run `validate-concept --all` or supply raw/stored inputs."
+            )
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
         print(report.format_text())
+        if not report.checks:
+            print(
+                f"ERROR: validate produced 0 checks for source='{args.source}'. "
+                "Run `validate-concept --all` or supply raw/stored inputs.",
+                file=sys.stderr,
+            )
+
+    if not report.checks:
+        return 1
     return 0 if report.passed else 1
 
 
@@ -659,6 +712,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "health":
         return _run_health(args)
 
+    # Validation (no service needed; building the factory before
+    # dispatching here would force every test to stub out the live
+    # SQLiteEngineStore and the ingestion client constructors).
+    if args.command == "validate":
+        return _run_validate(args)
+
     # Release schedule (no service needed for --show/--due/--status/--run)
     if args.command == "schedule":
         if args.show or args.due or args.status or args.run:
@@ -746,8 +805,6 @@ def main(argv: list[str] | None = None) -> int:
         return _run_oecd_refresh_catalog(args)
     if args.command == "rag":
         return _run_rag(args)
-    if args.command == "validate":
-        return _run_validate(args)
     parser.error("unknown command")
     return 2
 

--- a/tests/test_data_quality_daily.py
+++ b/tests/test_data_quality_daily.py
@@ -1,0 +1,101 @@
+"""Tests for the data_quality_daily script (issue #102 P3).
+
+Stubs out the live SQLite store, validation engine, and shadow_runner
+digest so the script's findings-assembly logic is exercised in
+isolation.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+if str(REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import data_quality_daily as script  # noqa: E402
+
+
+def _patched_build(tmp_path: Path, *, reports, digest):
+    """Yield context managers that intercept the heavy dependencies."""
+    seeded_store = type("FakeStore", (), {"seed_concept_map": lambda self: None})()
+    fake_engine = type(
+        "FakeEngine",
+        (),
+        {"validate_all_concepts": staticmethod(lambda store: reports)},
+    )()
+    fake_validation_store = object()
+
+    cm = patch.multiple(
+        script,
+        SQLiteEngineStore=lambda **kwargs: seeded_store,
+        ValidationStore=lambda *args, **kwargs: fake_validation_store,
+        ValidationEngine=lambda *args, **kwargs: fake_engine,
+    )
+    return cm, digest
+
+
+def test_build_report_flags_empty_validation_reports(tmp_path: Path) -> None:
+    """Issue #102 P3 codex round 1: an empty concept_map must not pass
+    the filer's clean gate. The script must surface a blocking finding."""
+
+    digest = {
+        "concepts_covered": 0, "concepts_total": 0,
+        "coverage_pct": 0, "confirmed_24h": 0, "error_sources": [],
+    }
+    cm, _ = _patched_build(tmp_path, reports=[], digest=digest)
+    fake_log_dir = tmp_path / "logs"
+    fake_log_dir.mkdir()
+
+    with cm:
+        with patch("shadow_runner.compute_digest", return_value=digest), \
+             patch.object(script, "_scan_log_for_secrets", return_value=None):
+            report, summary = script._build_report(
+                target_date=dt.date(2026, 5, 1),
+                engine_db=tmp_path / "engine.db",
+            )
+
+    assert summary["concept_reports"] == 0
+    assert any(
+        f.kind == "zero_validation_reports" and f.severity == "error"
+        for f in report.findings
+    )
+    assert not report.clean
+
+
+def test_build_report_clean_when_all_pass(tmp_path: Path) -> None:
+    from ingestion.validation._types import ValidationReport
+
+    passing = ValidationReport(
+        source="concept:CPI_US",
+        run_id="r1",
+        timestamp="2026-05-01T00:00:00+00:00",
+        checks=(),
+    )
+    digest = {
+        "concepts_covered": 88, "concepts_total": 88, "coverage_pct": 100.0,
+        "confirmed_24h": 88, "error_sources": [],
+    }
+    cm, _ = _patched_build(tmp_path, reports=[passing], digest=digest)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    with cm:
+        with patch("shadow_runner.compute_digest", return_value=digest), \
+             patch.object(script, "_scan_log_for_secrets", return_value=None):
+            report, summary = script._build_report(
+                target_date=dt.date(2026, 5, 1),
+                engine_db=tmp_path / "engine.db",
+            )
+
+    assert summary["concept_failures"] == 0
+    assert report.clean
+    assert report.findings == []

--- a/tests/test_data_quality_filer.py
+++ b/tests/test_data_quality_filer.py
@@ -1,0 +1,363 @@
+"""Tests for the macro data-quality auto-filer (issue #102 P3)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from ingestion.calendar.parity_filer import GhRunner
+from ingestion.quality.data_quality_filer import (
+    CLEAN_STREAK_TO_CLOSE,
+    DATA_QUALITY_LABEL,
+    DataQualityFinding,
+    DataQualityReport,
+    coverage_drop_from_digest,
+    file_data_quality_report,
+    findings_from_concept_reports,
+    secret_leak_from_text,
+)
+from ingestion.validation._types import (
+    CheckResult,
+    ValidationLayer,
+    ValidationReport,
+    ValidationSeverity,
+)
+
+
+class FakeRunner(GhRunner):
+    """In-memory ``gh`` runner that records intent, never spawns subprocesses."""
+
+    def __init__(self) -> None:
+        super().__init__(dry_run=False)
+        self.next_issue_number = 5000
+        self._open_numbers: list[int] = []
+        self.creates: list[dict] = []
+        self.comments: list[dict] = []
+        self.closes: list[dict] = []
+
+    def _run(self, *args: str) -> str:  # type: ignore[override]
+        if args[:2] == ("issue", "list"):
+            return json.dumps([{"number": n} for n in self._open_numbers])
+        if args[:2] == ("issue", "create"):
+            number = self.next_issue_number
+            self.next_issue_number += 1
+            title = args[args.index("--title") + 1]
+            body = args[args.index("--body") + 1]
+            self.creates.append({"number": number, "title": title, "body": body})
+            self._open_numbers.append(number)
+            return f"https://github.com/example/repo/issues/{number}\n"
+        if args[:2] == ("issue", "comment"):
+            number = int(args[2])
+            body = args[args.index("--body") + 1]
+            self.comments.append({"number": number, "body": body})
+            return ""
+        if args[:2] == ("issue", "close"):
+            number = int(args[2])
+            comment = args[args.index("--comment") + 1] if "--comment" in args else None
+            self.closes.append({"number": number, "comment": comment})
+            if number in self._open_numbers:
+                self._open_numbers.remove(number)
+            return ""
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Detector helpers
+# ---------------------------------------------------------------------------
+
+
+def _failing_concept_report() -> ValidationReport:
+    failing = CheckResult(
+        check_name="concept_source_coverage",
+        layer=ValidationLayer.CONCEPT,
+        passed=False,
+        severity=ValidationSeverity.ERROR,
+        message="FEDWATCH_US: 0/1 sources have data",
+        source="FEDWATCH_US",
+        timestamp="2026-05-01T00:00:00+00:00",
+    )
+    info = CheckResult(
+        check_name="concept_exists",
+        layer=ValidationLayer.CONCEPT,
+        passed=True,
+        severity=ValidationSeverity.INFO,
+        message="ok",
+        source="FEDWATCH_US",
+        timestamp="2026-05-01T00:00:00+00:00",
+    )
+    return ValidationReport(
+        source="concept:FEDWATCH_US",
+        run_id="rep-001",
+        timestamp="2026-05-01T00:00:00+00:00",
+        checks=(info, failing),
+    )
+
+
+def _passing_concept_report() -> ValidationReport:
+    return ValidationReport(
+        source="concept:CPI_US",
+        run_id="rep-002",
+        timestamp="2026-05-01T00:00:00+00:00",
+        checks=(),
+    )
+
+
+def test_findings_from_concept_reports_collects_errors() -> None:
+    findings = findings_from_concept_reports([_failing_concept_report(), _passing_concept_report()])
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.kind == "concept_failure"
+    assert f.severity == "error"
+    assert f.concept_id == "FEDWATCH_US"
+    assert f.run_id == "rep-001"
+    assert "FEDWATCH_US" in f.detail
+
+
+def test_findings_from_concept_reports_includes_warnings() -> None:
+    warning = CheckResult(
+        check_name="cross_source_level",
+        layer=ValidationLayer.CROSS_SOURCE,
+        passed=False,
+        severity=ValidationSeverity.WARNING,
+        message="CPI_EU level mismatch 98%",
+        source="CPI_EU",
+        timestamp="2026-05-01T00:00:00+00:00",
+    )
+    report = ValidationReport(
+        source="concept:CPI_EU",
+        run_id="rep-003",
+        timestamp="2026-05-01T00:00:00+00:00",
+        checks=(warning,),
+    )
+    findings = findings_from_concept_reports([report])
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert findings[0].kind == "concept_warning"
+
+
+def test_coverage_drop_emits_finding_when_partial() -> None:
+    digest = {"concepts_covered": 86, "concepts_total": 88, "error_sources": ["fred_daily"]}
+    finding = coverage_drop_from_digest(digest)
+    assert finding is not None
+    assert finding.kind == "coverage_drop"
+    assert "86/88" in finding.detail
+    assert "fred_daily" in finding.detail
+
+
+def test_coverage_drop_returns_none_when_clean() -> None:
+    digest = {"concepts_covered": 88, "concepts_total": 88, "error_sources": []}
+    assert coverage_drop_from_digest(digest) is None
+
+
+def test_secret_leak_from_text_detects_api_key() -> None:
+    text = "GET /fred?api_key=DEADBEEF&series=T5YIE"
+    finding = secret_leak_from_text(text, source_label="shadow.log")
+    assert finding is not None
+    assert "shadow.log" in finding.detail
+    assert "DEADBEEF" not in finding.detail
+
+
+def test_secret_leak_from_text_clean_returns_none() -> None:
+    assert secret_leak_from_text("nothing sensitive here") is None
+
+
+# ---------------------------------------------------------------------------
+# Filer driver
+# ---------------------------------------------------------------------------
+
+
+def _findings_report(*findings: DataQualityFinding) -> DataQualityReport:
+    return DataQualityReport(
+        target_date=date(2026, 5, 1),
+        findings=list(findings),
+        digest_summary={"concepts_covered": 86, "concepts_total": 88},
+    )
+
+
+def _failure_finding() -> DataQualityFinding:
+    return DataQualityFinding(
+        kind="concept_failure",
+        severity="error",
+        detail="FEDWATCH_US: 0/1 sources have data",
+        concept_id="FEDWATCH_US",
+        run_id="rep-001",
+    )
+
+
+def test_filer_creates_issue_on_first_failure(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    state_path = tmp_path / "state.json"
+
+    action = file_data_quality_report(
+        report=_findings_report(_failure_finding()),
+        runner=runner,
+        state_path=state_path,
+    )
+
+    assert len(action.created) == 1
+    number, title = action.created[0]
+    assert "Macro data-quality" in title
+    assert "2026-05-01" in title
+    body = runner.creates[0]["body"]
+    assert "FEDWATCH_US" in body
+    assert "86/88" in body
+    state = json.loads(state_path.read_text())
+    assert state["open_issue"] == number
+    assert state["clean_streak"] == 0
+
+
+def test_filer_comments_when_open_issue_exists(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    state_path = tmp_path / "state.json"
+    runner._open_numbers.append(7777)
+
+    action = file_data_quality_report(
+        report=_findings_report(_failure_finding()),
+        runner=runner,
+        state_path=state_path,
+    )
+
+    assert action.commented == [7777]
+    assert not runner.creates
+    assert "Daily data-quality run" in runner.comments[0]["body"]
+    assert "FEDWATCH_US" in runner.comments[0]["body"]
+
+
+def test_filer_clean_run_bumps_streak_until_close(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    state_path = tmp_path / "state.json"
+
+    # Day 0 — create issue.
+    file_data_quality_report(
+        report=_findings_report(_failure_finding()),
+        runner=runner,
+        state_path=state_path,
+    )
+    assert runner.creates
+    open_number = runner.creates[0]["number"]
+
+    # Days 1..(N-1) clean — bump streak only.
+    for day in range(1, CLEAN_STREAK_TO_CLOSE):
+        clean_report = DataQualityReport(target_date=date(2026, 5, 1 + day))
+        action = file_data_quality_report(
+            report=clean_report,
+            runner=runner,
+            state_path=state_path,
+        )
+        assert action.skipped_clean
+        assert not action.closed
+
+    # Final clean run hits threshold and closes.
+    final_action = file_data_quality_report(
+        report=DataQualityReport(target_date=date(2026, 5, 1 + CLEAN_STREAK_TO_CLOSE)),
+        runner=runner,
+        state_path=state_path,
+    )
+    assert final_action.closed == [open_number]
+    state = json.loads(state_path.read_text())
+    assert state["open_issue"] is None
+    assert state["clean_streak"] == 0
+
+
+def test_filer_redacts_secrets_in_body(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    state_path = tmp_path / "state.json"
+
+    poisoned_finding = DataQualityFinding(
+        kind="concept_failure",
+        severity="error",
+        detail="error fetching url=https://api.example.com/x?api_key=DEADBEEF&z=1",
+        concept_id="FEDWATCH_US",
+        run_id="rep-leak",
+    )
+    digest = {
+        "concepts_covered": 86,
+        "concepts_total": 88,
+        "error_sources": ["fred_daily?api_key=DEADBEEF"],
+    }
+    report = DataQualityReport(
+        target_date=date(2026, 5, 1),
+        findings=[poisoned_finding],
+        digest_summary=digest,
+    )
+
+    file_data_quality_report(report=report, runner=runner, state_path=state_path)
+
+    body = runner.creates[0]["body"]
+    assert "DEADBEEF" not in body
+    assert "api_key=***" in body
+
+
+def test_critical_severity_blocks_clean_classification() -> None:
+    """A finding tagged ``critical`` (the documented vocabulary) must
+    keep the report from looking clean. Without this guard the filer's
+    auto-close path would advance through critical regressions."""
+
+    critical_finding = DataQualityFinding(
+        kind="zero_validation_reports",
+        severity="critical",
+        detail="validate_all_concepts returned 0 reports",
+    )
+    report = DataQualityReport(
+        target_date=date(2026, 5, 1),
+        findings=[critical_finding],
+    )
+    assert not report.clean
+    assert critical_finding in report.error_findings
+
+
+def test_critical_finding_creates_issue(tmp_path: Path) -> None:
+    """End-to-end: a critical finding must drive a real ``gh issue create``."""
+
+    runner = FakeRunner()
+    state_path = tmp_path / "state.json"
+
+    critical_finding = DataQualityFinding(
+        kind="zero_validation_reports",
+        severity="critical",
+        detail="validate_all_concepts returned 0 reports",
+    )
+    report = DataQualityReport(
+        target_date=date(2026, 5, 1),
+        findings=[critical_finding],
+    )
+    action = file_data_quality_report(
+        report=report, runner=runner, state_path=state_path,
+    )
+    assert len(action.created) == 1
+
+
+def test_filer_re_failure_after_close_creates_fresh_issue(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    state_path = tmp_path / "state.json"
+
+    file_data_quality_report(
+        report=_findings_report(_failure_finding()),
+        runner=runner,
+        state_path=state_path,
+    )
+    first_number = runner.creates[0]["number"]
+
+    # Drive clean streak to threshold.
+    for day in range(1, CLEAN_STREAK_TO_CLOSE + 1):
+        file_data_quality_report(
+            report=DataQualityReport(target_date=date(2026, 5, 1 + day)),
+            runner=runner,
+            state_path=state_path,
+        )
+    assert runner.closes and runner.closes[0]["number"] == first_number
+
+    # New failure after close.
+    action = file_data_quality_report(
+        report=DataQualityReport(
+            target_date=date(2026, 5, 20),
+            findings=[_failure_finding()],
+        ),
+        runner=runner,
+        state_path=state_path,
+    )
+    assert len(action.created) == 1
+    assert action.created[0][0] != first_number

--- a/tests/test_macro_data_cli.py
+++ b/tests/test_macro_data_cli.py
@@ -252,6 +252,131 @@ class MacroDataCLITest(unittest.TestCase):
         self.assertEqual(db_path.name, "engine.db")
         self.assertEqual(db_path.parent.name, ".macro-data")
 
+    def test_validate_no_source_delegates_to_concept_validation(self) -> None:
+        """Issue #102 P2: bare ``validate`` must run concept reports rather
+        than the legacy zero-check ``validate_full('all')`` path."""
+
+        from ingestion.validation._types import (
+            CheckResult,
+            ValidationLayer,
+            ValidationReport,
+            ValidationSeverity,
+        )
+
+        failing_check = CheckResult(
+            check_name="concept_source_coverage",
+            layer=ValidationLayer.CONCEPT,
+            passed=False,
+            severity=ValidationSeverity.ERROR,
+            message="FEDWATCH_US: 0/1 sources have data",
+            source="FEDWATCH_US",
+            timestamp="2026-05-01T00:00:00+00:00",
+        )
+        report = ValidationReport(
+            source="concept:FEDWATCH_US",
+            run_id="abc",
+            timestamp="2026-05-01T00:00:00+00:00",
+            checks=(failing_check,),
+        )
+
+        engine = Mock()
+        engine.validate_all_concepts.return_value = [report]
+
+        store = Mock()
+        store.seed_concept_map.return_value = None
+
+        output = io.StringIO()
+        with patch("ingestion.validation.ValidationEngine", return_value=engine), \
+             patch("ingestion.validation.ValidationStore"), \
+             patch("storage.SQLiteEngineStore", return_value=store):
+            with redirect_stdout(output):
+                rc = main(["validate"])
+
+        self.assertEqual(rc, 1)
+        engine.validate_all_concepts.assert_called_once()
+        engine.validate_full.assert_not_called()
+        text = output.getvalue()
+        self.assertIn("FEDWATCH_US", text)
+
+    def test_validate_no_source_passes_when_all_concepts_pass(self) -> None:
+        from ingestion.validation._types import ValidationReport
+
+        passing = ValidationReport(
+            source="concept:CPI_US",
+            run_id="r1",
+            timestamp="2026-05-01T00:00:00+00:00",
+            checks=(),
+        )
+
+        engine = Mock()
+        engine.validate_all_concepts.return_value = [passing]
+
+        store = Mock()
+
+        with patch("ingestion.validation.ValidationEngine", return_value=engine), \
+             patch("ingestion.validation.ValidationStore"), \
+             patch("storage.SQLiteEngineStore", return_value=store):
+            with redirect_stdout(io.StringIO()):
+                rc = main(["validate"])
+
+        self.assertEqual(rc, 0)
+
+    def test_validate_with_source_zero_checks_returns_error(self) -> None:
+        """Issue #102 P2: ``validate --source X`` that produces zero checks
+        must exit non-zero, not silently report PASS."""
+
+        from ingestion.validation._types import ValidationReport
+
+        empty_report = ValidationReport(
+            source="fred",
+            run_id="r1",
+            timestamp="2026-05-01T00:00:00+00:00",
+            checks=(),
+        )
+
+        engine = Mock()
+        engine.validate_full.return_value = empty_report
+
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+        with patch("ingestion.validation.ValidationEngine", return_value=engine), \
+             patch("ingestion.validation.ValidationStore"):
+            with redirect_stdout(stdout_buf), \
+                 patch("sys.stderr", stderr_buf):
+                rc = main(["validate", "--source", "fred"])
+
+        self.assertEqual(rc, 1)
+        # Human-readable failure message goes to stderr, not stdout.
+        self.assertIn("0 checks", stderr_buf.getvalue())
+
+    def test_validate_with_source_zero_checks_json_keeps_payload_parseable(self) -> None:
+        """Issue #102 P2: ``--json`` output must remain valid JSON even
+        when zero checks ran. The failure signal goes into the payload
+        as ``ok=false`` + ``error`` rather than as a trailing text line."""
+
+        from ingestion.validation._types import ValidationReport
+
+        empty_report = ValidationReport(
+            source="fred",
+            run_id="r1",
+            timestamp="2026-05-01T00:00:00+00:00",
+            checks=(),
+        )
+
+        engine = Mock()
+        engine.validate_full.return_value = empty_report
+
+        stdout_buf = io.StringIO()
+        with patch("ingestion.validation.ValidationEngine", return_value=engine), \
+             patch("ingestion.validation.ValidationStore"):
+            with redirect_stdout(stdout_buf):
+                rc = main(["validate", "--source", "fred", "--json"])
+
+        self.assertEqual(rc, 1)
+        payload = json.loads(stdout_buf.getvalue())
+        self.assertFalse(payload["ok"])
+        self.assertIn("0 checks", payload["error"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_secret_redaction.py
+++ b/tests/test_secret_redaction.py
@@ -1,0 +1,117 @@
+"""Tests for the secret-redaction helper (issue #102 P1)."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+from ingestion._shared.redaction import SecretRedactingFilter, redact_secrets
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (
+            "https://api.stlouisfed.org/fred/series/observations?series_id=T5YIE"
+            "&api_key=00000000000000000000000000000000&file_type=json",
+            "https://api.stlouisfed.org/fred/series/observations?series_id=T5YIE"
+            "&api_key=***&file_type=json",
+        ),
+        (
+            "GET /v2/data?api_token=ABCDEF12345&format=json",
+            "GET /v2/data?api_token=***&format=json",
+        ),
+        (
+            "ConnectionError: token=xyz123 host=api.example.com",
+            "ConnectionError: token=*** host=api.example.com",
+        ),
+        ("Authorization: Bearer abc.def-XYZ=", "Authorization: Bearer ***"),
+        ("APIKey=Foo&other=Bar", "APIKey=***&other=Bar"),
+        ("no secret in this string", "no secret in this string"),
+    ],
+)
+def test_redacts_known_secret_params(raw: str, expected: str) -> None:
+    assert redact_secrets(raw) == expected
+
+
+def test_redact_is_idempotent() -> None:
+    once = redact_secrets("api_key=DEADBEEF&x=1")
+    twice = redact_secrets(once)
+    assert once == twice == "api_key=***&x=1"
+
+
+def test_redact_handles_none_and_empty() -> None:
+    assert redact_secrets(None) == ""
+    assert redact_secrets("") == ""
+
+
+def test_redact_preserves_unrelated_keyvalue_pairs() -> None:
+    # ``key=`` alone must not match — only the named secret params.
+    text = "key=42 stored=128 series_id=ABC"
+    assert redact_secrets(text) == text
+
+
+def test_filter_scrubs_log_records() -> None:
+    log = logging.getLogger("redaction-test")
+    log.setLevel(logging.DEBUG)
+    log.handlers.clear()
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.addFilter(SecretRedactingFilter())
+    log.addHandler(handler)
+
+    log.warning(
+        "fred_daily ERROR: %s",
+        "HTTPSConnectionPool: /fred?api_key=DEADBEEF&series=T5YIE",
+    )
+
+    output = buf.getvalue().strip()
+    assert "DEADBEEF" not in output
+    assert "api_key=***" in output
+
+
+def test_filter_passthrough_when_no_secret() -> None:
+    log = logging.getLogger("redaction-test-clean")
+    log.setLevel(logging.DEBUG)
+    log.handlers.clear()
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.addFilter(SecretRedactingFilter())
+    log.addHandler(handler)
+
+    log.info("cycle 5 done in 12.3s")
+    assert buf.getvalue().strip() == "cycle 5 done in 12.3s"
+
+
+def test_filter_scrubs_exception_traceback() -> None:
+    """A logger called with ``exc_info=True`` would otherwise leak the
+    provider URL embedded in the exception text — the formatter appends
+    the traceback after the filter chain. The filter must pre-render
+    and redact so the persisted log is clean."""
+
+    log = logging.getLogger("redaction-test-traceback")
+    log.setLevel(logging.DEBUG)
+    log.handlers.clear()
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.addFilter(SecretRedactingFilter())
+    log.addHandler(handler)
+
+    try:
+        raise RuntimeError(
+            "HTTPSConnectionPool: /fred?api_key=DEADBEEF&series=T5YIE"
+        )
+    except RuntimeError:
+        log.error("ingestion failed", exc_info=True)
+
+    output = buf.getvalue()
+    assert "DEADBEEF" not in output
+    assert "api_key=***" in output
+    # Traceback header should still be present so debuggability is
+    # preserved.
+    assert "Traceback" in output

--- a/tests/test_shadow_runner_redaction.py
+++ b/tests/test_shadow_runner_redaction.py
@@ -1,0 +1,69 @@
+"""Shadow-runner redaction tests (issue #102 P1).
+
+We don't run the full shadow loop here — just exercise the digest
+serialization helper to confirm provider secrets are stripped before the
+JSONL append.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import shadow_runner
+
+
+def test_redact_digest_payload_strips_per_source_secrets() -> None:
+    digest = {
+        "concepts_covered": 1, "concepts_total": 1, "coverage_pct": 100.0,
+        "total_obs": 0,
+        "source_results": {
+            "fred_daily": {
+                "stored": 0,
+                "error": (
+                    "HTTPSConnectionPool: /fred?series_id=T5YIE"
+                    "&api_key=DEADBEEF&file_type=json"
+                ),
+                "ms": 0,
+            },
+            "bls": {"stored": 5, "error": "", "ms": 12},
+        },
+    }
+
+    cleaned = shadow_runner._redact_digest_payload(digest)
+
+    assert "DEADBEEF" not in json.dumps(cleaned)
+    assert cleaned["source_results"]["fred_daily"]["error"].count("api_key=***") == 1
+    # Untouched per-source entries pass through.
+    assert cleaned["source_results"]["bls"]["error"] == ""
+    assert cleaned["source_results"]["bls"]["stored"] == 5
+    # Original digest is not mutated in place.
+    assert "DEADBEEF" in digest["source_results"]["fred_daily"]["error"]
+
+
+def test_write_digest_redacts_before_append(tmp_path, monkeypatch) -> None:
+    digest_file = tmp_path / "daily_digest.jsonl"
+    monkeypatch.setattr(shadow_runner, "DIGEST_FILE", digest_file)
+
+    shadow_runner.write_digest({
+        "concepts_covered": 1, "concepts_total": 1, "coverage_pct": 100.0,
+        "total_obs": 7,
+        "confirmed_24h": 1,
+        "source_results": {
+            "fred_daily": {
+                "stored": 0,
+                "error": "boom token=SECRETTOKEN x=1",
+                "ms": 0,
+            },
+        },
+    })
+
+    persisted = digest_file.read_text().strip()
+    assert "SECRETTOKEN" not in persisted
+    payload = json.loads(persisted)
+    assert payload["source_results"]["fred_daily"]["error"] == "boom token=*** x=1"


### PR DESCRIPTION
Closes #102.

## Summary

Three commits make macro data-quality drift visible through GitHub issues, mirroring the calendar-side TE parity tripwire that already files `parity-drift` issues. Without this work, FEDWATCH_US / VIX_US zero-data, CPI_EU cross-source level mismatches, and provider keys persisting into `shadow.log` / `daily_digest.jsonl` would all sit in the database silently.

- **P1 — secret redaction (e6b3bdc).** `ingestion._shared.redaction` strips `api_key=…`, `Bearer …`, and other named secret query params from log lines, traceback text, and digest payloads. `SecretRedactingFilter` covers `record.exc_info` so `logger.error(..., exc_info=True)` calls don't leak.
- **P2 — `validate` exit semantics (db4698b).** Bare `macro-data-service validate` now delegates to `validate_all_concepts` and exits non-zero on failures. `validate --source X` exits 1 with a `--json`-safe `ok=false` payload when zero checks ran.
- **P3 — data-quality auto-filer (32116c6).** `src/ingestion/quality/data_quality_filer.py` files / comments / closes one `data-quality` issue based on concept-validation hard failures, shadow-digest coverage drops, and persisted-secret detection. `scripts/data_quality_daily.py` is the entry point. Issue/comment bodies are redacted; both `error` and `critical` severities block clean classification.

## Test plan

- [x] `pytest tests/test_secret_redaction.py tests/test_shadow_runner_redaction.py tests/test_macro_data_cli.py tests/test_data_quality_filer.py tests/test_data_quality_daily.py tests/test_parity_filer.py tests/test_parity_daily.py` — all 68 pass.
- [x] `PYTHONPATH=src python3 -m macro_data.cli validate --db-path .macro-data/engine.db --json` returns 88 reports, exits 1, surfaces FEDWATCH_US / VIX_US failures.
- [x] `PYTHONPATH=src python3 scripts/data_quality_daily.py --dry-run --db-path .macro-data/engine.db` assembles 5-error / 29-warning report and would file the `data-quality` issue.
- [x] Codex review run on each slice; round-2 findings (P1 traceback redaction, P2 `--json` contract + test isolation) and round-1 findings on P3 (`critical` severity bypass, empty-validation pass) all accepted and fixed before commit.

## Out of scope

The two data-shape acceptance criteria (FEDWATCH_US / VIX_US backfill, CPI_EU rate-vs-level reconciliation) stay open per the issue's "minimum slice" framing — the visibility guard P3 ships now makes them visible as a tracked `data-quality` issue rather than masking them. Follow-up issues if the user wants the data-shape fixes.