### PR TITLE
[VPS launch] Add read-only service mode

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -426,6 +426,13 @@ defeats the whole aggregation-layer premise.
 
 - **HTTP API** (`macro-data-api`) — the contract. Routes are a thin mapping
   over `LocalMacroDataService` ops; schema is the `contracts.py` DTOs.
+  Runtime construction uses `build_read_only_macro_data_service`: SQLite
+  opens live WAL paths with `mode=ro` when WAL sidecars exist and
+  checkpointed snapshots with `mode=ro&immutable=1`, schema/seed bootstrap
+  writes are disabled, and `/health` reads existing capability/checkpoint
+  rows through a reader health backend. Startup validates `concept_map`,
+  `release_schedule`, `source_capability`, `subjects`, and
+  `subject_aliases` contain rows.
   `POST /v1/ops/<op>` is locked to a read-only allowlist
   (`PUBLIC_READ_OPS` in `macro_data/server.py`, issue #104):
   `resolve_indicator`, `resolve_indicator_history`, `list_items`,

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,11 @@
-from .macro_data import LocalMacroDataService, build_local_macro_data_service
+from .macro_data import (
+    LocalMacroDataService,
+    build_local_macro_data_service,
+    build_read_only_macro_data_service,
+)
 
-__all__ = ["LocalMacroDataService", "build_local_macro_data_service"]
+__all__ = [
+    "LocalMacroDataService",
+    "build_local_macro_data_service",
+    "build_read_only_macro_data_service",
+]

--- a/src/ingestion/source_capabilities.py
+++ b/src/ingestion/source_capabilities.py
@@ -90,11 +90,18 @@ class SourceCapabilityManager:
         *,
         orchestrator: Any | None = None,
         adapters: dict[str, SourceCapabilityAdapter] | None = None,
+        seed_registry: bool = True,
     ) -> None:
         self._store = store
         self._orchestrator = orchestrator
-        self._adapters = adapters or self._build_default_adapters(orchestrator)
-        self.seed_registry()
+        self._adapters = (
+            adapters
+            if adapters is not None
+            else self._build_default_adapters(orchestrator)
+        )
+        self._seed_registry = seed_registry
+        if self._seed_registry:
+            self.seed_registry()
 
     def seed_registry(self) -> None:
         for adapter in self._adapters.values():
@@ -105,7 +112,8 @@ class SourceCapabilityManager:
 
     # ── Public capability + entity API ─────────────────────────────────
     def list_capabilities(self, *, include_internal: bool = True) -> list[dict[str, Any]]:
-        self.seed_registry()
+        if self._seed_registry:
+            self.seed_registry()
         items = self._store.list_source_capabilities()
         if include_internal:
             return items

--- a/src/ingestion/sources.py
+++ b/src/ingestion/sources.py
@@ -315,6 +315,7 @@ class IngestionOrchestrator:
         self._default_refresh_order: list[str] = []
         self._last_run_reports: dict[str, IngestionRunReport] = {}
         self._register_default_sources()
+        self._ensure_capability_manager()
 
     def _ensure_obs_seed(self) -> None:
         """Seed observation sources/families once, then build lookup cache."""

--- a/src/macro_data/__init__.py
+++ b/src/macro_data/__init__.py
@@ -6,7 +6,7 @@ from .client import (
     build_local_macro_data_client,
     coerce_macro_data_client,
 )
-from .factory import build_local_macro_data_service
+from .factory import build_local_macro_data_service, build_read_only_macro_data_service
 from .service import LocalMacroDataService
 
 __all__ = [
@@ -17,5 +17,6 @@ __all__ = [
     "MacroDataHttpConfig",
     "build_local_macro_data_client",
     "build_local_macro_data_service",
+    "build_read_only_macro_data_service",
     "coerce_macro_data_client",
 ]

--- a/src/macro_data/factory.py
+++ b/src/macro_data/factory.py
@@ -11,6 +11,46 @@ from .service import LocalMacroDataService
 
 logger = logging.getLogger(__name__)
 
+_REQUIRED_READER_BOOTSTRAP_TABLES: tuple[str, ...] = (
+    "concept_map",
+    "release_schedule",
+    "source_capability",
+    "subjects",
+    "subject_aliases",
+)
+
+
+class _ReadOnlyHealthBackend:
+    def __init__(self, store: SQLiteEngineStore) -> None:
+        self._store = store
+        self._manager: Any | None = None
+
+    def get_source_health_dashboard(self, *, include_internal: bool = False) -> dict[str, Any]:
+        if self._manager is None:
+            from ingestion.source_capabilities import SourceCapabilityManager
+            self._manager = SourceCapabilityManager(
+                self._store,
+                adapters={},
+                seed_registry=False,
+            )
+        return self._manager.get_customer_health(include_internal=include_internal)
+
+
+def _validate_read_only_bootstrap(store: SQLiteEngineStore) -> None:
+    empty_tables: list[str] = []
+    with store._connection(commit=False) as connection:
+        for table in _REQUIRED_READER_BOOTSTRAP_TABLES:
+            row = connection.execute(f"SELECT COUNT(*) AS cnt FROM {table}").fetchone()
+            count = int(row["cnt"]) if row is not None else 0
+            if count == 0:
+                empty_tables.append(table)
+    if empty_tables:
+        tables = ", ".join(empty_tables)
+        raise RuntimeError(
+            "read-only macro-data DB is missing reader bootstrap rows: "
+            f"{tables}. Run the writable bootstrap before starting macro-data-api."
+        )
+
 
 def _build_clickhouse_market_store() -> Any | None:
     """Build a ``ClickHouseMarketStore`` from env vars.
@@ -49,4 +89,13 @@ def build_local_macro_data_service(db_path: Path | None = None) -> LocalMacroDat
         store=store,
         market_store=market_store,
         ingestion=IngestionOrchestrator(store),
+    )
+
+
+def build_read_only_macro_data_service(db_path: Path | None = None) -> LocalMacroDataService:
+    store = SQLiteEngineStore(db_path=db_path, read_only=True)
+    _validate_read_only_bootstrap(store)
+    return LocalMacroDataService(
+        store=store,
+        health=_ReadOnlyHealthBackend(store),
     )

--- a/src/macro_data/server.py
+++ b/src/macro_data/server.py
@@ -296,9 +296,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
-    from macro_data.factory import build_local_macro_data_service
+    from macro_data.factory import build_read_only_macro_data_service
 
-    service = build_local_macro_data_service(db_path=Path(args.db_path) if args.db_path else None)
+    service = build_read_only_macro_data_service(db_path=Path(args.db_path) if args.db_path else None)
     serve(
         host=args.host,
         port=args.port,

--- a/src/macro_data/service/_documents.py
+++ b/src/macro_data/service/_documents.py
@@ -133,11 +133,12 @@ class DocumentsOpsMixin(LocalMacroDataServiceBase):
         """List the subject vocabulary. Seeds the yaml on first call so
         the response is always complete on a fresh DB."""
         del arguments
-        try:
-            from storage.subjects import sync_from_yaml
-            sync_from_yaml(self._store)
-        except (AttributeError, TypeError, FileNotFoundError):
-            pass  # best-effort; yaml may be unavailable in test environments
+        if not self._store_is_read_only():
+            try:
+                from storage.subjects import sync_from_yaml
+                sync_from_yaml(self._store)
+            except (AttributeError, TypeError, FileNotFoundError):
+                pass  # best-effort; yaml may be unavailable in test environments
         return {"subjects": self._store.list_subjects()}
 
     def _op_backfill_document_indexes(self, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/src/macro_data/service/_ops_health.py
+++ b/src/macro_data/service/_ops_health.py
@@ -54,10 +54,11 @@ class OpsHealthMixin(LocalMacroDataServiceBase):
         return {"total": len(items), "sources": items}
 
     def _op_get_source_health_dashboard(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        if self._ingestion is None:
+        health = self._health or self._ingestion
+        if health is None:
             return {"error": "source health unavailable", "sources": []}
         include_internal = bool(arguments.get("include_internal", False))
-        return self._ingestion.get_source_health_dashboard(include_internal=include_internal)
+        return health.get_source_health_dashboard(include_internal=include_internal)
 
     def _op_get_health(self, arguments: dict[str, Any]) -> dict[str, Any]:
         if self._ingestion is None:

--- a/src/macro_data/service/_timeseries.py
+++ b/src/macro_data/service/_timeseries.py
@@ -144,7 +144,8 @@ class TimeseriesOpsMixin(LocalMacroDataServiceBase):
         concept_id = (arguments.get("concept_id") or "").strip()
         if not concept_id:
             return {"error": "concept_id is required"}
-        self._store.seed_concept_map()
+        if not self._store_is_read_only():
+            self._store.seed_concept_map()
         date = (arguments.get("date") or "").strip() or None
         as_of = (arguments.get("as_of") or "").strip() or None
         obs = self._store.resolve_indicator(concept_id, date=date, as_of=as_of)
@@ -157,7 +158,8 @@ class TimeseriesOpsMixin(LocalMacroDataServiceBase):
         concept_id = (arguments.get("concept_id") or "").strip()
         if not concept_id:
             return {"error": "concept_id is required"}
-        self._store.seed_concept_map()
+        if not self._store_is_read_only():
+            self._store.seed_concept_map()
         limit = int(arguments.get("limit", 12))
         as_of = (arguments.get("as_of") or "").strip() or None
         results = self._store.resolve_indicator_history(
@@ -175,7 +177,8 @@ class TimeseriesOpsMixin(LocalMacroDataServiceBase):
         due_only = bool(arguments.get("due_only", False))
         limit = int(arguments.get("limit", 100))
 
-        self._store.seed_release_schedules()
+        if not self._store_is_read_only():
+            self._store.seed_release_schedules()
 
         if concept_id:
             rec = self._store.get_release_schedule(concept_id)

--- a/src/macro_data/service/base.py
+++ b/src/macro_data/service/base.py
@@ -72,10 +72,12 @@ class LocalMacroDataServiceBase:
         store: Any,
         market_store: Any | None = None,
         ingestion: Any | None = None,
+        health: Any | None = None,
     ) -> None:
         self._store = store
         self._market_store = market_store
         self._ingestion = ingestion
+        self._health = health
         self._ontology_seeded = False
         self._subject_vocabulary_seeded = False
 
@@ -85,8 +87,14 @@ class LocalMacroDataServiceBase:
             raise KeyError(f"unknown macro-data operation: {operation}")
         return handler(arguments or {})
 
+    def _store_is_read_only(self) -> bool:
+        return bool(getattr(self._store, "read_only", False))
+
     def _ensure_structural_ontology(self) -> None:
         if self._ontology_seeded:
+            return
+        if self._store_is_read_only():
+            self._ontology_seeded = True
             return
         seed = getattr(self._store, "seed_structural_ontology", None)
         if callable(seed):
@@ -102,6 +110,9 @@ class LocalMacroDataServiceBase:
         so we load the yaml vocabulary + default concept map on demand
         — both helpers are idempotent so repeat calls are cheap."""
         if self._subject_vocabulary_seeded:
+            return
+        if self._store_is_read_only():
+            self._subject_vocabulary_seeded = True
             return
         try:
             from storage.subjects import sync_from_yaml

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -32,6 +32,7 @@ import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
+from urllib.parse import quote
 
 from storage.models import (
     CalendarEventVintageRecord,
@@ -87,15 +88,32 @@ class SQLiteEngineStore(
     _NewsQueriesMixin,
     _SentimentQueriesMixin,
 ):
-    def __init__(self, db_path: Path | None = None) -> None:
+    def __init__(self, db_path: Path | None = None, *, read_only: bool = False) -> None:
         self.db_path = db_path or default_engine_db_path()
+        self.read_only = read_only
+        if self.read_only:
+            return
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.init_schema()
 
     def get_connection(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(str(self.db_path))
+        if self.read_only:
+            resolved_path = self.db_path.resolve()
+            uri_path = quote(resolved_path.as_posix(), safe="/")
+            if resolved_path.with_name(f"{resolved_path.name}-wal").exists():
+                # WAL-aware reads preserve committed frames from a live writer.
+                uri = f"file:{uri_path}?mode=ro"
+            else:
+                # Checkpointed snapshots avoid SQLite WAL sidecar creation.
+                uri = f"file:{uri_path}?mode=ro&immutable=1"
+            connection = sqlite3.connect(uri, uri=True)
+        else:
+            connection = sqlite3.connect(str(self.db_path))
         connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA journal_mode=WAL")
+        if self.read_only:
+            connection.execute("PRAGMA query_only=ON")
+        else:
+            connection.execute("PRAGMA journal_mode=WAL")
         connection.execute("PRAGMA foreign_keys=ON")
         return connection
 
@@ -114,5 +132,7 @@ class SQLiteEngineStore(
             connection.close()
 
     def init_schema(self) -> None:
+        if self.read_only:
+            return
         with self._connection(commit=True) as connection:
             apply_schema(connection)

--- a/tests/test_read_only_service.py
+++ b/tests/test_read_only_service.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from macro_data import factory
+from macro_data.factory import (
+    build_local_macro_data_service,
+    build_read_only_macro_data_service,
+)
+from macro_data import server
+from storage.sqlite import (
+    IndicatorObservationRecord,
+    IndicatorVintageRecord,
+    SQLiteEngineStore,
+)
+from storage.subjects import sync_from_yaml
+
+
+def _seed_reader_fixture(db_path: Path) -> None:
+    store = SQLiteEngineStore(db_path=db_path)
+    store.seed_concept_map()
+    store.seed_release_schedules()
+    sync_from_yaml(store)
+    store.upsert_indicator_observation(
+        IndicatorObservationRecord(
+            series_id="CPIAUCSL",
+            source="fred",
+            date="2026-01-01",
+            value=321.4,
+        )
+    )
+    store.upsert_indicator_vintage(
+        IndicatorVintageRecord(
+            series_id="CPIAUCSL",
+            source="fred",
+            observation_date="2026-01-01",
+            vintage_date="2026-02-12",
+            value=321.4,
+            vintage_quality="native_pit",
+        )
+    )
+    store.upsert_source_capability({
+        "source_id": "fred",
+        "display_name": "FRED",
+        "source_type": "data_aggregator",
+        "entity_type": "series",
+        "supports_discovery": True,
+        "supports_latest_sync": True,
+        "is_default_scheduled": True,
+    })
+
+
+def test_read_only_store_blocks_physical_writes(tmp_path: Path) -> None:
+    db_path = tmp_path / "engine.db"
+    _seed_reader_fixture(db_path)
+
+    store = SQLiteEngineStore(db_path=db_path, read_only=True)
+    assert store.read_only is True
+    assert store.list_subjects()
+
+    with pytest.raises(sqlite3.OperationalError):
+        with store._connection(commit=True) as connection:
+            connection.execute(
+                "INSERT INTO subjects (subject_id, display_name) VALUES (?, ?)",
+                ("test.subject", "Test Subject"),
+            )
+
+
+def test_read_only_factory_starts_from_wal_snapshot_in_read_only_directory(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "engine.db"
+    _seed_reader_fixture(db_path)
+    for suffix in ("-wal", "-shm"):
+        db_path.with_name(f"{db_path.name}{suffix}").unlink(missing_ok=True)
+
+    original_mode = tmp_path.stat().st_mode
+    os.chmod(tmp_path, 0o555)
+    try:
+        service = build_read_only_macro_data_service(db_path=db_path)
+        resolved = service.invoke(
+            "resolve_indicator",
+            {"concept_id": "CPI_US", "date": "2026-01-01"},
+        )
+    finally:
+        os.chmod(tmp_path, original_mode)
+
+    assert resolved["resolved"]["value"] == 321.4
+    assert not db_path.with_name(f"{db_path.name}-wal").exists()
+    assert not db_path.with_name(f"{db_path.name}-shm").exists()
+
+
+def test_read_only_store_reads_committed_wal_frames(tmp_path: Path) -> None:
+    db_path = tmp_path / "engine.db"
+    store = SQLiteEngineStore(db_path=db_path)
+
+    writer = store.get_connection()
+    try:
+        writer.execute("CREATE TABLE wal_probe (value INTEGER NOT NULL)")
+        writer.execute("INSERT INTO wal_probe (value) VALUES (7)")
+        writer.commit()
+        assert db_path.with_name(f"{db_path.name}-wal").exists()
+
+        reader = SQLiteEngineStore(db_path=db_path, read_only=True)
+        with reader._connection(commit=False) as connection:
+            row = connection.execute("SELECT value FROM wal_probe").fetchone()
+    finally:
+        writer.close()
+
+    assert row["value"] == 7
+
+
+def test_read_only_store_detects_wal_next_to_resolved_db_path(
+    tmp_path: Path,
+) -> None:
+    real_dir = tmp_path / "real"
+    link_dir = tmp_path / "link"
+    real_dir.mkdir()
+    link_dir.mkdir()
+    real_db_path = real_dir / "engine.db"
+    link_db_path = link_dir / "engine.db"
+    link_db_path.symlink_to(real_db_path)
+    store = SQLiteEngineStore(db_path=link_db_path)
+
+    writer = store.get_connection()
+    try:
+        writer.execute("CREATE TABLE symlink_wal_probe (value INTEGER NOT NULL)")
+        writer.execute("INSERT INTO symlink_wal_probe (value) VALUES (11)")
+        writer.commit()
+        assert real_db_path.with_name(f"{real_db_path.name}-wal").exists()
+
+        reader = SQLiteEngineStore(db_path=link_db_path, read_only=True)
+        with reader._connection(commit=False) as connection:
+            row = connection.execute(
+                "SELECT value FROM symlink_wal_probe",
+            ).fetchone()
+    finally:
+        writer.close()
+
+    assert row["value"] == 11
+
+
+def test_read_only_service_uses_preseeded_data_without_bootstrap_writes(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "engine.db"
+    _seed_reader_fixture(db_path)
+
+    service = build_read_only_macro_data_service(db_path=db_path)
+    assert service._ingestion is None
+    assert service._health is not None
+    assert service._store.read_only is True
+
+    health = service.invoke("get_source_health_dashboard", {})
+    assert health["sources"][0]["source_id"] == "fred"
+    assert health["sources"][0]["status"] == "healthy"
+
+    resolved = service.invoke(
+        "resolve_indicator",
+        {"concept_id": "CPI_US", "date": "2026-01-01"},
+    )
+    assert resolved["resolved"]["value"] == 321.4
+
+    schedule = service.invoke("get_release_schedule", {"concept_id": "CPI_US"})
+    assert schedule["schedules"][0]["concept_id"] == "CPI_US"
+
+    items = service.invoke(
+        "list_items",
+        {"subject": "econ.cpi", "family": "economic_data"},
+    )
+    assert any(item["series_id"] == "CPIAUCSL" for item in items["items"])
+
+
+def test_writable_factory_keeps_orchestrator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(factory, "_build_clickhouse_market_store", lambda: None)
+
+    service = build_local_macro_data_service(db_path=tmp_path / "engine.db")
+
+    assert service._store.read_only is False
+    assert service._ingestion is not None
+    assert service._store.get_source_capability("fred") is not None
+
+
+def test_read_only_factory_requires_bootstrap_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "engine.db"
+    SQLiteEngineStore(db_path=db_path)
+
+    with pytest.raises(RuntimeError, match="reader bootstrap rows"):
+        build_read_only_macro_data_service(db_path=db_path)
+
+
+def test_server_main_uses_read_only_factory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, Any] = {}
+    sentinel_service = object()
+
+    def fake_build_read_only_macro_data_service(
+        db_path: Path | None = None,
+    ) -> object:
+        calls["db_path"] = db_path
+        return sentinel_service
+
+    def fake_serve(**kwargs: Any) -> None:
+        calls["serve"] = kwargs
+
+    monkeypatch.setattr(
+        factory,
+        "build_read_only_macro_data_service",
+        fake_build_read_only_macro_data_service,
+    )
+    monkeypatch.setattr(server, "serve", fake_serve)
+
+    db_path = tmp_path / "engine.db"
+    result = server.main([
+        "--host", "127.0.0.1",
+        "--port", "0",
+        "--db-path", str(db_path),
+    ])
+
+    assert result == 0
+    assert calls["db_path"] == db_path
+    assert calls["serve"]["service"] is sentinel_service


### PR DESCRIPTION
## Shipped
- Adds a reader-mode SQLite store and `build_read_only_macro_data_service` for `macro-data-api`.
- Uses WAL-aware `mode=ro` reads for live sidecars and immutable `mode=ro&immutable=1` reads for checkpointed snapshots.
- Keeps request-time bootstrap writes out of read-only service paths and preserves `/health` through a reader health backend.
- Seeds source capability rows during writable orchestrator setup and validates reader bootstrap tables at startup.
- Covers physical write rejection, read-only directory startup, live WAL frames, symlinked DB WAL detection, health, API factory selection, and writable factory behavior.

## Verification
- `PYTHONPATH=src pytest tests/test_read_only_service.py`
- `PYTHONPATH=src pytest tests/test_read_only_service.py tests/test_public_ops_allowlist.py tests/test_calendar_http_route.py tests/test_source_capabilities.py tests/test_ingestion_orchestrator.py`
- `git diff --check`

Closes #105