### PR TITLE
Add data availability manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,12 +255,14 @@ Calendar and fundamentals use the same replay shape. `cal_econ_raw`, `cal_corp_r
 
 - `GET /health`      customer-facing source health matrix
 - `GET /healthz`     lightweight liveness probe
+- `GET /v1/manifest` data availability manifest for consumer routing
 - `POST /v1/ops/<operation>`
 
 Key operations:
 
 | Operation | Description |
 |---|---|
+| `get_data_manifest` | Dataset availability manifest with status, row counts, freshness, and quality status |
 | `resolve_indicator` | Highest-priority observation for a concept; accepts `as_of` for PIT vintage reads |
 | `resolve_indicator_history` | Resolved time series with best source per date; accepts `as_of` |
 | `get_release_schedule` | Release calendar for all/single concept |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,7 +82,7 @@ and respect the handoff invariants below.
 |---|---|---|---|
 | **Bronze** | `obs_raw`, `cal_econ_raw`, `cal_corp_raw`, `fundamentals_raw` (SQLite, macro line) | Raw HTTP payloads, audit + replay only | Append-only; idempotent on `(source, series_id, content_hash)` (or domain-equivalent key). Per-source canonicalization (`ingestion/timeseries/canonicalize.py`, calendar equivalents) drops query-time envelope echoes — `realtime_*` / `responseTime` / SDMX `header.prepared` / pagination links / Eurostat `updated` / EIA `request` — so the same observations hash to the same row across daily refreshes and `INSERT OR IGNORE` dedupes. Module-level `_parse_X(payload, …)` helpers re-project bronze through the same parser the live HTTP path uses; a parser fix replays from bronze with zero quota cost. Market corp actions are append-shaped in `market.dividends` / `market.splits`: content hashes preserve provider revisions and trigger bar refills. |
 | **Silver** | `indicator_vintages`, `cal_econ_event`, `document` (+ `document_blob` / `document_extra`), `news_articles`, `fundamentals_company` / `_financials` / `_highlights` / `_estimates` (SQLite); `market.bars_1d` / `dividends` / `splits` / `instruments` (ClickHouse, issue #118) | Parsed, schema-conformant, point-in-time | Append-only at the vintage / event / article level; PIT-queryable via `as_of=YYYY-MM-DD` for the macro line. `vintage_quality` (`native_pit` / `synthetic_snapshot` / `single_observation`, per #114 P0) tags how the vintage was sourced. `obs_family_id` joins to the `obs_family` catalog so projections + concept resolution share one identity layer. Schema-conformant means: every silver column must be derivable by parsing the corresponding bronze payload — no live-only headers, no run-time enrichment. CH market silver uses ReplacingMergeTree to absorb retried ingests at merge time (bars dedupe on `(instrument_id, time)`; dividends / splits dedupe on `(instrument_id, ex_date / execution_date, content_hash)` so revisions still preserve the chain). |
-| **Gold** | `indicators` view, `resolve_indicator` / `resolve_indicator_history` / `list_items` / `get_document` / `get_release_schedule` / `get_release_status` ops, public-read HTTP surface | Latest projection + cross-source ranking, derived | Read-only views over silver. `indicators` is a SQL view over `indicator_vintages` (latest vintage per `(source, series_id, observation_date)` per #114 P1). `resolve_indicator` ranks sources by `concept_map.priority`; calendar fallback augments thin projections from `cal_econ_event.actual` (#114 P3, tagged `provenance='calendar'`). The `PUBLIC_READ_OPS` allowlist in `macro_data/server.py` bounds what downstream services can hit unauthenticated. |
+| **Gold** | `indicators` view, `resolve_indicator` / `resolve_indicator_history` / `list_items` / `get_document` / `get_release_schedule` / `get_release_status` / `get_data_manifest` ops, public-read HTTP surface | Latest projection + cross-source ranking, derived | Read-only views over silver. `indicators` is a SQL view over `indicator_vintages` (latest vintage per `(source, series_id, observation_date)` per #114 P1). `resolve_indicator` ranks sources by `concept_map.priority`; calendar fallback augments thin projections from `cal_econ_event.actual` (#114 P3, tagged `provenance='calendar'`). The `PUBLIC_READ_OPS` allowlist in `macro_data/server.py` bounds what downstream services can hit unauthenticated. |
 
 **Handoff invariants** (must hold for every new fetcher / storage table):
 
@@ -161,6 +161,9 @@ family fan-out) stay a service-level operation.
     (`market.bars_1m` / `_5m` / …) share the column type without
     cross-table casts. Storage cost trivial (+2 bytes × 200M ≈
     +400 MB raw, less after compression).
+    Manifest availability reads active part metadata (`system.parts`)
+    for row count, latest bar time, and ingest freshness, keeping
+    `/v1/manifest` bounded by active-part metadata size.
   - `market.dividends` — ReplacingMergeTree(`fetched_at`) on
     `(instrument_id, ex_date, content_hash)`. Putting `content_hash`
     in the sort key means a revised payout (different hash) lands
@@ -430,15 +433,17 @@ defeats the whole aggregation-layer premise.
   opens live WAL paths with `mode=ro` when WAL sidecars exist and
   checkpointed snapshots with `mode=ro&immutable=1`, schema/seed bootstrap
   writes are disabled, and `/health` reads existing capability/checkpoint
-  rows through a reader health backend. Startup validates `concept_map`,
+  rows through a reader health backend. The public service also attaches a
+  ClickHouse market store without schema initialization so `/v1/manifest`
+  reports market-bar availability from the market lane. Startup validates `concept_map`,
   `release_schedule`, `source_capability`, `subjects`, and
   `subject_aliases` contain rows.
   `POST /v1/ops/<op>` is locked to a read-only allowlist
   (`PUBLIC_READ_OPS` in `macro_data/server.py`, issue #104):
-  `resolve_indicator`, `resolve_indicator_history`, `list_items`,
-  `get_document`, `get_release_schedule`, `get_release_status`. Anything
+  `resolve_indicator`, `resolve_indicator_history`, `get_data_manifest`,
+  `list_items`, `get_document`, `get_release_schedule`, `get_release_status`. Anything
   else returns HTTP 403, even with a valid bearer token. Existing
-  `GET` routes (`/healthz`, `/health`, `/v1/calendar`,
+  `GET` routes (`/healthz`, `/health`, `/v1/manifest`, `/v1/calendar`,
   `/v1/calendar/revisions`, `/v1/fundamentals/{ticker}`) stay public.
   Admin / write ops (`refresh_*`, `run_schedule`, `fundamentals_fetch`,
   `sync_catalog_*`, …) reach the same in-process service through the CLI
@@ -490,6 +495,7 @@ src/
       _calendar.py          calendar econ + corp ops + event_to_dict
       _timeseries.py        indicator/catalog/concept/release/surprise/fed-comm ops
       _documents.py         document feed + cross-type list_items
+      _manifest.py          dataset availability manifest
       _news.py              news + article fetcher
       _market.py            market snapshot + live-markets fetcher
       _ops_health.py        refresh-all/run-schedule/source listing/health/alerts

--- a/src/macro_data/factory.py
+++ b/src/macro_data/factory.py
@@ -52,7 +52,7 @@ def _validate_read_only_bootstrap(store: SQLiteEngineStore) -> None:
         )
 
 
-def _build_clickhouse_market_store() -> Any | None:
+def _build_clickhouse_market_store(*, initialize_schema: bool = True) -> Any | None:
     """Build a ``ClickHouseMarketStore`` from env vars.
 
     Returns ``None`` when ``clickhouse_connect`` cannot reach the server
@@ -75,7 +75,8 @@ def _build_clickhouse_market_store() -> Any | None:
         return None
     try:
         client = clickhouse_client_from_env()
-        apply_clickhouse_schema(client)
+        if initialize_schema:
+            apply_clickhouse_schema(client)
     except Exception as exc:  # pragma: no cover - exercised by smoke test
         logger.warning("ClickHouse unavailable — market lane disabled: %s", exc)
         return None
@@ -95,7 +96,9 @@ def build_local_macro_data_service(db_path: Path | None = None) -> LocalMacroDat
 def build_read_only_macro_data_service(db_path: Path | None = None) -> LocalMacroDataService:
     store = SQLiteEngineStore(db_path=db_path, read_only=True)
     _validate_read_only_bootstrap(store)
+    market_store = _build_clickhouse_market_store(initialize_schema=False)
     return LocalMacroDataService(
         store=store,
+        market_store=market_store,
         health=_ReadOnlyHealthBackend(store),
     )

--- a/src/macro_data/server.py
+++ b/src/macro_data/server.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 PUBLIC_READ_OPS: frozenset[str] = frozenset({
     "resolve_indicator",
     "resolve_indicator_history",
+    "get_data_manifest",
     "list_items",
     "get_document",
     "get_release_schedule",
@@ -52,6 +53,16 @@ class MacroDataRequestHandler(BaseHTTPRequestHandler):
             except Exception as exc:
                 logger.exception("macro-data health request failed")
                 self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"status": "error", "error": str(exc)})
+                return
+            self._write_json(HTTPStatus.OK, payload)
+            return
+        if parsed.path == "/v1/manifest":
+            service = self.server.service  # type: ignore[attr-defined]
+            try:
+                payload = service.invoke("get_data_manifest", {})
+            except Exception as exc:
+                logger.exception("GET /v1/manifest failed")
+                self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
                 return
             self._write_json(HTTPStatus.OK, payload)
             return

--- a/src/macro_data/service/README.md
+++ b/src/macro_data/service/README.md
@@ -5,7 +5,7 @@ uses (HTTP server, CLI, tests, scripts). It owns no business logic — every
 public method routes through `invoke(operation, params)`, which dispatches
 to the matching `_op_<operation>` method via `getattr`.
 
-The class is composed from one base + six domain mixins. Tier 1.1 of
+The class is composed from one base + seven domain mixins. Tier 1.1 of
 issue #58 split a 5,566-line `service.py` into this package; method
 bodies are byte-equivalent to the pre-split version and the public
 import path (`from macro_data.service import LocalMacroDataService`) is
@@ -23,6 +23,7 @@ service/
   _timeseries.py — 23 ops for indicators, catalog, concepts,
                    release-schedule, release-status
   _documents.py  — 4 ops: list_items, get_document, subjects, backfill
+  _manifest.py   — 1 op: data availability manifest
   _news.py       — 5 ops: recent, search, live, article fetch
   _market.py     — 2 ops: snapshot, live_markets
   _ops_health.py — 8 ops: refresh_all, run_schedule, source listing,
@@ -43,6 +44,7 @@ the one matching method regardless.
    - Touches `obs_*` / `concept_*` / `release_schedule*` /
      `indicator_*` → `_timeseries.py`.
    - Touches `document` / `doc_*` / subjects / backfill → `_documents.py`.
+   - Touches cross-domain availability counts / freshness → `_manifest.py`.
    - Touches `news_*` / article fetch → `_news.py`.
    - Touches `market_prices` / live market quotes → `_market.py`.
    - Cross-cutting refresh / scheduler / health / alerts →

--- a/src/macro_data/service/__init__.py
+++ b/src/macro_data/service/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from ._calendar import CalendarOpsMixin
 from ._documents import DocumentsOpsMixin
+from ._manifest import ManifestOpsMixin
 from ._market import MarketOpsMixin
 from ._news import NewsOpsMixin
 from ._ops_health import OpsHealthMixin
@@ -17,6 +18,7 @@ class LocalMacroDataService(
     DocumentsOpsMixin,
     NewsOpsMixin,
     MarketOpsMixin,
+    ManifestOpsMixin,
     OpsHealthMixin,
     LocalMacroDataServiceBase,
 ):

--- a/src/macro_data/service/_manifest.py
+++ b/src/macro_data/service/_manifest.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .base import LocalMacroDataServiceBase
+
+
+class ManifestOpsMixin(LocalMacroDataServiceBase):
+    def _op_get_data_manifest(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        del arguments
+        market_stats = self._market_manifest_stats()
+        return self._store.get_data_manifest(market_bars=market_stats)
+
+    def _market_manifest_stats(self) -> dict[str, Any]:
+        if self._market_store is None:
+            return {
+                "row_count": 0,
+                "latest_timestamp": None,
+                "latest_ingested_at": None,
+                "notes": ["market store unavailable"],
+            }
+        get_stats = getattr(self._market_store, "get_manifest_stats", None)
+        if callable(get_stats):
+            try:
+                stats = get_stats()
+            except Exception as exc:
+                return {
+                    "row_count": 0,
+                    "latest_timestamp": None,
+                    "latest_ingested_at": None,
+                    "error": str(exc),
+                    "notes": ["market store unavailable"],
+                }
+            if isinstance(stats, dict):
+                return stats
+        snapshot = self._market_store.latest_market_snapshot()
+        latest = max((str(row.get("time") or "") for row in snapshot), default="")
+        return {
+            "row_count": len(snapshot),
+            "latest_timestamp": latest or None,
+            "latest_ingested_at": None,
+        }

--- a/src/storage/clickhouse/store.py
+++ b/src/storage/clickhouse/store.py
@@ -7,6 +7,8 @@ needs to serve market reads and route market writes:
   adjusted OHLCV per the caller flag.
 * ``latest_market_snapshot`` — most-recent bar per instrument_id (powers
   ``_op_get_market_snapshot``).
+* ``get_manifest_stats`` — low-cost market availability stats for the
+  public data manifest.
 * ``upsert_market_bars`` / ``upsert_corp_actions`` /
   ``upsert_market_instrument`` — batch writers used by ingestion.
 * ``lookup_instrument`` — by ``instrument_id`` or ``ticker``, used by
@@ -202,6 +204,39 @@ class ClickHouseMarketStore:
             )
             for row in result.result_rows
         ]
+
+    def get_manifest_stats(self) -> dict[str, Any]:
+        """Metadata-backed availability stats for the consumer manifest.
+
+        ``system.parts`` keeps this public endpoint cheap on large
+        backfills. ``row_count`` reflects active MergeTree part rows, so
+        it may include replacements that background merges have yet to
+        collapse; the manifest only needs availability and freshness.
+        """
+        sql = (
+            "SELECT sum(rows) AS row_count, max(max_time) AS latest_timestamp, "
+            "max(modification_time) AS latest_ingested_at "
+            "FROM system.parts "
+            "WHERE database = {database:String} "
+            "AND table = {table:String} "
+            "AND active"
+        )
+        result = self._client.query(
+            sql,
+            parameters={"database": self._database, "table": "bars_1d"},
+        )
+        row = (
+            dict(zip(result.column_names, result.result_rows[0], strict=True))
+            if result.result_rows
+            else {}
+        )
+        row = self._stringify_temporal(row)
+        row_count = int(row.get("row_count") or 0)
+        return {
+            "row_count": row_count,
+            "latest_timestamp": row.get("latest_timestamp") if row_count else None,
+            "latest_ingested_at": row.get("latest_ingested_at") if row_count else None,
+        }
 
     def lookup_instrument(
         self,

--- a/src/storage/queries/manifest.py
+++ b/src/storage/queries/manifest.py
@@ -1,0 +1,412 @@
+"""Consumer-facing data availability manifest queries.
+
+The manifest is intentionally table-count based: consumers need a fast,
+read-only inventory before choosing a data surface. SQLite owns the macro
+line; the service passes ClickHouse market stats into this mixin.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+from contracts import format_epoch_iso, format_epoch_ms_iso, utc_now
+
+
+@dataclass(frozen=True)
+class _DatasetDefinition:
+    dataset: str
+    label: str
+    storage: str
+    launch_state: str
+
+
+_DATASETS: tuple[_DatasetDefinition, ...] = (
+    _DatasetDefinition(
+        "macro_timeseries",
+        "Macro time series",
+        "indicator_vintages",
+        "available",
+    ),
+    _DatasetDefinition(
+        "calendar",
+        "Economic calendar",
+        "cal_econ_event",
+        "available",
+    ),
+    _DatasetDefinition(
+        "documents",
+        "Documents",
+        "document",
+        "available",
+    ),
+    _DatasetDefinition(
+        "news",
+        "News",
+        "news_articles",
+        "available",
+    ),
+    _DatasetDefinition(
+        "market_bars",
+        "Market bars",
+        "clickhouse.bars_1d",
+        "empty",
+    ),
+    _DatasetDefinition(
+        "fundamentals",
+        "Fundamentals",
+        "fundamentals_*",
+        "empty",
+    ),
+    _DatasetDefinition(
+        "corp_calendar",
+        "Corporate calendar",
+        "cal_corp_event",
+        "empty",
+    ),
+)
+
+_QUALITY_ALIASES: dict[str, tuple[str, ...]] = {
+    "macro_timeseries": (
+        "macro_timeseries",
+        "timeseries",
+        "indicators",
+        "indicator_vintages",
+        "concept:",
+    ),
+    "calendar": ("calendar", "economic_calendar", "cal_econ_event"),
+    "documents": ("documents", "document"),
+    "news": ("news", "news_articles"),
+    "market_bars": ("market_bars", "market_price", "market"),
+    "fundamentals": ("fundamentals",),
+    "corp_calendar": ("corp_calendar", "corporate_calendar", "cal_corp_event"),
+}
+_GLOBAL_QUALITY_SOURCES = {"all", "data_quality", "macro_data", "macro-data"}
+
+
+class _ManifestQueriesMixin:
+    def get_data_manifest(
+        self,
+        *,
+        market_bars: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return the launch-facing dataset availability contract."""
+        with self._connection(commit=False) as connection:
+            quality_reports = _load_quality_reports(connection)
+            rows = [
+                self._dataset_manifest_row(
+                    connection,
+                    definition,
+                    quality_reports=quality_reports,
+                    market_bars=market_bars or {},
+                )
+                for definition in _DATASETS
+            ]
+        summary = {
+            "total": len(rows),
+            "available": sum(1 for row in rows if row["status"] == "available"),
+            "empty": sum(1 for row in rows if row["status"] == "empty"),
+            "degraded": sum(1 for row in rows if row["status"] == "degraded"),
+            "experimental": sum(1 for row in rows if row["status"] == "experimental"),
+        }
+        return {
+            "version": "v1",
+            "generated_at": utc_now().isoformat(),
+            "summary": summary,
+            "datasets": rows,
+        }
+
+    def _dataset_manifest_row(
+        self,
+        connection: sqlite3.Connection,
+        definition: _DatasetDefinition,
+        *,
+        quality_reports: list[dict[str, Any]],
+        market_bars: dict[str, Any],
+    ) -> dict[str, Any]:
+        stats = _dataset_stats(connection, definition.dataset, market_bars=market_bars)
+        quality = _quality_for_dataset(definition.dataset, quality_reports)
+        status = _dataset_status(
+            row_count=int(stats.get("row_count") or 0),
+            launch_state=definition.launch_state,
+            quality_status=quality["quality_status"],
+        )
+        row = {
+            "dataset": definition.dataset,
+            "label": definition.label,
+            "status": status,
+            "launch_state": definition.launch_state,
+            "row_count": int(stats.get("row_count") or 0),
+            "latest_timestamp": stats.get("latest_timestamp"),
+            "latest_ingested_at": stats.get("latest_ingested_at"),
+            "last_quality_run": quality["last_quality_run"],
+            "quality_status": quality["quality_status"],
+            "storage": definition.storage,
+        }
+        if stats.get("notes"):
+            row["notes"] = list(stats["notes"])
+        if stats.get("error"):
+            row["error"] = str(stats["error"])
+        return row
+
+
+def _dataset_stats(
+    connection: sqlite3.Connection,
+    dataset: str,
+    *,
+    market_bars: dict[str, Any],
+) -> dict[str, Any]:
+    if dataset == "macro_timeseries":
+        return {
+            "row_count": _int_scalar(connection, "SELECT COUNT(*) FROM indicator_vintages"),
+            "latest_timestamp": _text_scalar(
+                connection,
+                "SELECT MAX(observation_date) FROM indicator_vintages",
+            ),
+            "latest_ingested_at": _text_scalar(
+                connection,
+                "SELECT MAX(scraped_at) FROM indicator_vintages",
+            ),
+        }
+    if dataset == "calendar":
+        return {
+            "row_count": _int_scalar(connection, "SELECT COUNT(*) FROM cal_econ_event"),
+            "latest_timestamp": _text_scalar(
+                connection,
+                "SELECT MAX(event_time_utc) FROM cal_econ_event",
+            ),
+            "latest_ingested_at": _text_scalar(
+                connection,
+                "SELECT MAX(updated_at) FROM cal_econ_event",
+            ),
+        }
+    if dataset == "documents":
+        return {
+            "row_count": _int_scalar(connection, "SELECT COUNT(*) FROM document"),
+            "latest_timestamp": _text_scalar(
+                connection,
+                "SELECT MAX(COALESCE(published_at, published_date)) FROM document",
+            ),
+            "latest_ingested_at": _text_scalar(
+                connection,
+                "SELECT MAX(updated_at) FROM document",
+            ),
+        }
+    if dataset == "news":
+        latest_epoch = _optional_int_scalar(
+            connection,
+            "SELECT MAX(timestamp) FROM news_articles",
+        )
+        return {
+            "row_count": _int_scalar(connection, "SELECT COUNT(*) FROM news_articles"),
+            "latest_timestamp": (
+                format_epoch_iso(latest_epoch) if latest_epoch is not None else None
+            ),
+            "latest_ingested_at": _text_scalar(
+                connection,
+                "SELECT MAX(scraped_at) FROM news_articles",
+            ),
+        }
+    if dataset == "market_bars":
+        return {
+            "row_count": int(market_bars.get("row_count") or 0),
+            "latest_timestamp": market_bars.get("latest_timestamp"),
+            "latest_ingested_at": market_bars.get("latest_ingested_at"),
+            "notes": market_bars.get("notes", []),
+            "error": market_bars.get("error"),
+        }
+    if dataset == "fundamentals":
+        row_count = sum(
+            _int_scalar(connection, f"SELECT COUNT(*) FROM {table}")
+            for table in (
+                "fundamentals_company",
+                "fundamentals_financials",
+                "fundamentals_highlights",
+                "fundamentals_estimates",
+            )
+        )
+        latest_epoch_ms = _max_optional_int([
+            _optional_int_scalar(
+                connection,
+                "SELECT MAX(observed_at_epoch_ms) FROM fundamentals_company",
+            ),
+            _optional_int_scalar(
+                connection,
+                "SELECT MAX(observed_at_epoch_ms) FROM fundamentals_financials",
+            ),
+            _optional_int_scalar(
+                connection,
+                "SELECT MAX(observed_at_epoch_ms) FROM fundamentals_highlights",
+            ),
+            _optional_int_scalar(
+                connection,
+                "SELECT MAX(observed_at_epoch_ms) FROM fundamentals_estimates",
+            ),
+        ])
+        return {
+            "row_count": row_count,
+            "latest_timestamp": _max_text([
+                _text_scalar(
+                    connection,
+                    "SELECT MAX(period_end) FROM fundamentals_financials",
+                ),
+                _text_scalar(
+                    connection,
+                    "SELECT MAX(as_of_date) FROM fundamentals_highlights",
+                ),
+                _text_scalar(
+                    connection,
+                    "SELECT MAX(period_end) FROM fundamentals_estimates",
+                ),
+            ]),
+            "latest_ingested_at": (
+                format_epoch_ms_iso(latest_epoch_ms)
+                if latest_epoch_ms is not None
+                else None
+            ),
+        }
+    if dataset == "corp_calendar":
+        return {
+            "row_count": _int_scalar(connection, "SELECT COUNT(*) FROM cal_corp_event"),
+            "latest_timestamp": _text_scalar(
+                connection,
+                "SELECT MAX(event_time_utc) FROM cal_corp_event",
+            ),
+            "latest_ingested_at": _text_scalar(
+                connection,
+                "SELECT MAX(updated_at) FROM cal_corp_event",
+            ),
+        }
+    raise KeyError(f"unknown manifest dataset: {dataset}")
+
+
+def _load_quality_reports(connection: sqlite3.Connection) -> list[dict[str, Any]]:
+    if not _table_exists(connection, "validation_reports"):
+        return []
+    rows = connection.execute(
+        """
+        SELECT source, timestamp, passed, error_count, warning_count,
+               total_checks, report_json
+        FROM validation_reports
+        ORDER BY timestamp DESC, id DESC
+        """
+    ).fetchall()
+    reports: list[dict[str, Any]] = []
+    for row in rows:
+        report_json: dict[str, Any] = {}
+        raw = row["report_json"]
+        if raw:
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict):
+                    report_json = parsed
+            except json.JSONDecodeError:
+                report_json = {}
+        reports.append({
+            "source": str(row["source"] or report_json.get("source") or ""),
+            "timestamp": str(row["timestamp"] or report_json.get("timestamp") or ""),
+            "passed": bool(row["passed"]),
+            "error_count": int(row["error_count"] or 0),
+            "warning_count": int(row["warning_count"] or 0),
+            "total_checks": int(row["total_checks"] or 0),
+        })
+    return reports
+
+
+def _quality_for_dataset(
+    dataset: str,
+    reports: list[dict[str, Any]],
+) -> dict[str, str | None]:
+    aliases = _QUALITY_ALIASES.get(dataset, ())
+    for report in reports:
+        source = str(report.get("source") or "")
+        if _source_matches_aliases(source, aliases):
+            return _quality_payload(report)
+    for report in reports:
+        source = str(report.get("source") or "")
+        if source in _GLOBAL_QUALITY_SOURCES:
+            return _quality_payload(report)
+    return {"last_quality_run": None, "quality_status": "unknown"}
+
+
+def _quality_payload(report: dict[str, Any]) -> dict[str, str | None]:
+    if not bool(report.get("passed")):
+        status = "fail"
+    elif int(report.get("warning_count") or 0) > 0:
+        status = "warning"
+    else:
+        status = "pass"
+    return {
+        "last_quality_run": str(report.get("timestamp") or "") or None,
+        "quality_status": status,
+    }
+
+
+def _source_matches_aliases(source: str, aliases: tuple[str, ...]) -> bool:
+    for alias in aliases:
+        if alias.endswith(":"):
+            if source.startswith(alias):
+                return True
+        elif source == alias:
+            return True
+    return False
+
+
+def _dataset_status(
+    *,
+    row_count: int,
+    launch_state: str,
+    quality_status: str | None,
+) -> str:
+    if row_count <= 0:
+        return "empty"
+    if quality_status == "fail":
+        return "degraded"
+    if launch_state == "experimental":
+        return "experimental"
+    return "available"
+
+
+def _table_exists(connection: sqlite3.Connection, table_name: str) -> bool:
+    row = connection.execute(
+        """
+        SELECT 1 FROM sqlite_master
+        WHERE type IN ('table', 'view') AND name = ?
+        LIMIT 1
+        """,
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _int_scalar(connection: sqlite3.Connection, sql: str) -> int:
+    row = connection.execute(sql).fetchone()
+    if row is None:
+        return 0
+    return int(row[0] or 0)
+
+
+def _optional_int_scalar(connection: sqlite3.Connection, sql: str) -> int | None:
+    row = connection.execute(sql).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return int(row[0])
+
+
+def _text_scalar(connection: sqlite3.Connection, sql: str) -> str | None:
+    row = connection.execute(sql).fetchone()
+    if row is None or row[0] in (None, ""):
+        return None
+    return str(row[0])
+
+
+def _max_optional_int(values: list[int | None]) -> int | None:
+    present = [value for value in values if value is not None]
+    return max(present) if present else None
+
+
+def _max_text(values: list[str | None]) -> str | None:
+    present = [value for value in values if value]
+    return max(present) if present else None

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -70,6 +70,7 @@ from storage.queries.calendar import (
 from storage.queries.documents import _DocumentsQueriesMixin
 from storage.queries.fundamentals import _FundamentalsQueriesMixin
 from storage.queries.indicator import _IndicatorQueriesMixin
+from storage.queries.manifest import _ManifestQueriesMixin
 from storage.queries.news import _NewsQueriesMixin
 from storage.queries.sentiment import _SentimentQueriesMixin
 from storage.schema import apply_schema
@@ -85,6 +86,7 @@ class SQLiteEngineStore(
     _DocumentsQueriesMixin,
     _FundamentalsQueriesMixin,
     _IndicatorQueriesMixin,
+    _ManifestQueriesMixin,
     _NewsQueriesMixin,
     _SentimentQueriesMixin,
 ):

--- a/tests/test_data_manifest.py
+++ b/tests/test_data_manifest.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from datetime import datetime, timezone
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from ingestion.validation import ValidationStore
+from macro_data.server import MacroDataRequestHandler
+from macro_data.service import LocalMacroDataService
+from storage.sqlite import (
+    DocSourceRecord,
+    DocumentRecord,
+    IndicatorVintageRecord,
+    NewsArticleRecord,
+    SQLiteEngineStore,
+)
+
+
+class _FakeMarketStore:
+    def __init__(self, stats: dict[str, Any]) -> None:
+        self._stats = stats
+
+    def get_manifest_stats(self) -> dict[str, Any]:
+        return dict(self._stats)
+
+
+class _FakeQueryResult:
+    def __init__(self, column_names: list[str], result_rows: list[tuple[Any, ...]]) -> None:
+        self.column_names = column_names
+        self.result_rows = result_rows
+
+
+class _RecordingClickHouseClient:
+    def __init__(self, result: _FakeQueryResult) -> None:
+        self.result = result
+        self.sql = ""
+        self.parameters: dict[str, Any] = {}
+
+    def query(
+        self,
+        sql: str,
+        *,
+        parameters: dict[str, Any] | None = None,
+    ) -> _FakeQueryResult:
+        self.sql = sql
+        self.parameters = dict(parameters or {})
+        return self.result
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteEngineStore:
+    return SQLiteEngineStore(db_path=tmp_path / "engine.db")
+
+
+def _seed_available_surfaces(store: SQLiteEngineStore) -> None:
+    now = "2026-05-02T10:00:00+00:00"
+    store.upsert_indicator_vintage(
+        IndicatorVintageRecord(
+            series_id="CPIAUCSL",
+            source="fred",
+            observation_date="2026-03-31",
+            vintage_date="2026-04-10",
+            value=310.12,
+            vintage_quality="native_pit",
+        )
+    )
+    with store._connection(commit=True) as connection:
+        connection.execute(
+            """
+            INSERT INTO cal_econ_event (
+                provider, provider_event_id, event_time_utc,
+                event_time_precision, reference_date, reference_label,
+                country_code, indicator_id, category, title, importance,
+                currency, unit, actual, previous, revised, forecast,
+                consensus_forecast, ticker, source, source_url, content_hash,
+                last_update_epoch_ms, observed_at_epoch_ms, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "bls",
+                "cpi-2026-03",
+                "2026-04-10T12:30:00+00:00",
+                "datetime",
+                "2026-03-31",
+                "Mar 2026",
+                "US",
+                None,
+                "inflation",
+                "CPI",
+                "high",
+                "USD",
+                "index",
+                "310.12",
+                None,
+                None,
+                None,
+                None,
+                "",
+                "bls",
+                "https://example.test/cpi",
+                "1" * 64,
+                1_775_822_400_000,
+                1_775_822_400_000,
+                now,
+                now,
+            ),
+        )
+
+    store.upsert_doc_source(
+        DocSourceRecord(
+            source_id="us.bls",
+            source_code="BLS",
+            source_name="Bureau of Labor Statistics",
+            source_type="government_agency",
+            country_code="US",
+            default_language_code="en",
+            homepage_url="https://www.bls.gov",
+            is_active=True,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    store.upsert_document(
+        DocumentRecord(
+            document_id="doc-cpi",
+            release_family_id="",
+            source_id="us.bls",
+            canonical_url="https://example.test/cpi",
+            title="CPI report",
+            subtitle="",
+            document_type="report",
+            mime_type="text/html",
+            language_code="en",
+            country_code="US",
+            topic_code="inflation",
+            published_date="2026-04-10",
+            published_at="2026-04-10T12:30:00+00:00",
+            status="published",
+            version_no=1,
+            parent_document_id="",
+            hash_sha256="2" * 64,
+            created_at=now,
+            updated_at=now,
+            published_precision="exact",
+        )
+    )
+    store.upsert_news_article(
+        NewsArticleRecord(
+            url_hash="news-1",
+            source_feed="reuters",
+            feed_category="macro",
+            title="Macro news",
+            url="https://example.test/news",
+            timestamp=1_775_830_000,
+            description="News item",
+            content_markdown="Body",
+            content_fetched=True,
+        )
+    )
+
+
+def _save_quality_report(
+    store: SQLiteEngineStore,
+    *,
+    source: str,
+    passed: bool,
+    timestamp: str = "2026-05-02T11:00:00+00:00",
+) -> None:
+    validation = ValidationStore(str(store.db_path))
+    try:
+        validation.save_report({
+            "source": source,
+            "run_id": f"{source}-{timestamp}",
+            "timestamp": timestamp,
+            "passed": passed,
+            "error_count": 0 if passed else 1,
+            "warning_count": 0,
+            "total_checks": 1,
+            "duration_ms": 10,
+        })
+    finally:
+        validation.close()
+
+
+def _by_dataset(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {row["dataset"]: row for row in payload["datasets"]}
+
+
+def test_manifest_reports_available_and_empty_launch_surfaces(
+    store: SQLiteEngineStore,
+) -> None:
+    _seed_available_surfaces(store)
+    _save_quality_report(store, source="macro_timeseries", passed=True)
+    service = LocalMacroDataService(store=store)
+
+    payload = service.invoke("get_data_manifest", {})
+    rows = _by_dataset(payload)
+
+    assert payload["version"] == "v1"
+    assert set(rows) == {
+        "macro_timeseries",
+        "calendar",
+        "documents",
+        "news",
+        "market_bars",
+        "fundamentals",
+        "corp_calendar",
+    }
+    assert rows["macro_timeseries"]["status"] == "available"
+    assert rows["macro_timeseries"]["row_count"] == 1
+    assert rows["macro_timeseries"]["latest_timestamp"] == "2026-03-31"
+    assert rows["macro_timeseries"]["quality_status"] == "pass"
+    assert rows["macro_timeseries"]["last_quality_run"] == "2026-05-02T11:00:00+00:00"
+
+    assert rows["calendar"]["status"] == "available"
+    assert rows["documents"]["status"] == "available"
+    assert rows["news"]["status"] == "available"
+    assert rows["market_bars"]["status"] == "empty"
+    assert rows["fundamentals"]["status"] == "empty"
+    assert rows["corp_calendar"]["status"] == "empty"
+    assert payload["summary"]["available"] == 4
+    assert payload["summary"]["empty"] == 3
+
+
+def test_manifest_marks_failed_quality_report_as_degraded(
+    store: SQLiteEngineStore,
+) -> None:
+    _seed_available_surfaces(store)
+    _save_quality_report(store, source="calendar", passed=False)
+    service = LocalMacroDataService(store=store)
+
+    rows = _by_dataset(service.invoke("get_data_manifest", {}))
+
+    assert rows["calendar"]["row_count"] == 1
+    assert rows["calendar"]["status"] == "degraded"
+    assert rows["calendar"]["quality_status"] == "fail"
+
+
+def test_manifest_uses_market_store_stats(store: SQLiteEngineStore) -> None:
+    service = LocalMacroDataService(
+        store=store,
+        market_store=_FakeMarketStore({
+            "row_count": 12,
+            "latest_timestamp": "2026-05-01T00:00:00Z",
+            "latest_ingested_at": "2026-05-01T00:10:00Z",
+        }),
+    )
+
+    rows = _by_dataset(service.invoke("get_data_manifest", {}))
+
+    assert rows["market_bars"]["status"] == "available"
+    assert rows["market_bars"]["row_count"] == 12
+    assert rows["market_bars"]["latest_timestamp"] == "2026-05-01T00:00:00Z"
+
+
+def test_clickhouse_manifest_stats_use_part_metadata() -> None:
+    from storage.clickhouse.store import ClickHouseMarketStore
+
+    client = _RecordingClickHouseClient(
+        _FakeQueryResult(
+            ["row_count", "latest_timestamp", "latest_ingested_at"],
+            [(
+                180_000_000,
+                datetime(2026, 5, 1, 20, 0, tzinfo=timezone.utc),
+                datetime(2026, 5, 2, 2, 10, tzinfo=timezone.utc),
+            )],
+        )
+    )
+
+    stats = ClickHouseMarketStore(client, database="market").get_manifest_stats()
+
+    assert "FROM system.parts" in client.sql
+    assert client.sql.count("FINAL") == 0
+    assert client.parameters == {"database": "market", "table": "bars_1d"}
+    assert stats == {
+        "row_count": 180_000_000,
+        "latest_timestamp": "2026-05-01T20:00:00Z",
+        "latest_ingested_at": "2026-05-02T02:10:00Z",
+    }
+
+
+@pytest.fixture()
+def live_server(store: SQLiteEngineStore):
+    service = LocalMacroDataService(store=store)
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
+    httpd.service = service  # type: ignore[attr-defined]
+    httpd.api_token = ""  # type: ignore[attr-defined]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    host, port = httpd.server_address[0], httpd.server_address[1]
+    try:
+        yield host, port
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+def _http_get(host: str, port: int, path: str) -> tuple[int, dict[str, Any]]:
+    conn = HTTPConnection(host, port, timeout=5)
+    try:
+        conn.request("GET", path)
+        response = conn.getresponse()
+        raw = response.read().decode("utf-8")
+    finally:
+        conn.close()
+    payload = json.loads(raw) if raw else {}
+    return response.status, payload
+
+
+def test_http_manifest_route_returns_manifest(
+    store: SQLiteEngineStore,
+    live_server,
+) -> None:
+    _seed_available_surfaces(store)
+    host, port = live_server
+
+    status, payload = _http_get(host, port, "/v1/manifest")
+
+    assert status == 200
+    rows = _by_dataset(payload)
+    assert rows["macro_timeseries"]["status"] == "available"
+    assert rows["fundamentals"]["status"] == "empty"

--- a/tests/test_public_ops_allowlist.py
+++ b/tests/test_public_ops_allowlist.py
@@ -82,6 +82,7 @@ def test_public_read_ops_matches_issue_104_contract() -> None:
     assert PUBLIC_READ_OPS == frozenset({
         "resolve_indicator",
         "resolve_indicator_history",
+        "get_data_manifest",
         "list_items",
         "get_document",
         "get_release_schedule",

--- a/tests/test_read_only_service.py
+++ b/tests/test_read_only_service.py
@@ -192,6 +192,33 @@ def test_writable_factory_keeps_orchestrator(
     assert service._store.get_source_capability("fred") is not None
 
 
+def test_read_only_factory_wires_market_store_for_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "engine.db"
+    _seed_reader_fixture(db_path)
+    sentinel_market = object()
+    calls: list[bool] = []
+
+    def fake_build_clickhouse_market_store(
+        *,
+        initialize_schema: bool = True,
+    ) -> object:
+        calls.append(initialize_schema)
+        return sentinel_market
+
+    monkeypatch.setattr(
+        factory,
+        "_build_clickhouse_market_store",
+        fake_build_clickhouse_market_store,
+    )
+
+    service = build_read_only_macro_data_service(db_path=db_path)
+
+    assert calls == [False]
+    assert service._market_store is sentinel_market
+
+
 def test_read_only_factory_requires_bootstrap_rows(tmp_path: Path) -> None:
     db_path = tmp_path / "engine.db"
     SQLiteEngineStore(db_path=db_path)


### PR DESCRIPTION
Closes #107

## Shipped
- Added `get_data_manifest` across SQLite storage, service dispatch, public ops allowlist, and `GET /v1/manifest`.
- Reports dataset status, row counts, freshness, quality metadata, launch state, and storage identity for macro, calendar, documents, news, market bars, fundamentals, and corporate calendar.
- Wired read-only public service instances to attach ClickHouse market stats while skipping schema initialization.
- Switched market manifest stats to ClickHouse `system.parts` metadata for active row count, latest bar time, and ingest freshness.
- Updated README, architecture docs, and service package docs.

## Verification
- `pytest tests/test_data_manifest.py tests/test_public_ops_allowlist.py tests/test_read_only_service.py tests/test_calendar_http_route.py` -> 63 passed
- `git diff --check` over touched files -> clean
- `python3 -m compileall -q src/macro_data/service/_manifest.py src/storage/queries/manifest.py src/storage/clickhouse/store.py tests/test_data_manifest.py` -> clean

## Review
- Codex review round 1: fixed read-only public service market-store wiring.
- Codex review round 2: replaced public manifest `bars_1d FINAL` aggregation with `system.parts` metadata.