### PR TITLE
feat(api): production HTTP stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,17 @@ Calendar and fundamentals use the same replay shape. `cal_econ_raw`, `cal_corp_r
 
 ## HTTP API
 
+The API is served by FastAPI under uvicorn. `GET /healthz` is the liveness
+probe and is open for uptime checks. Other routes require `X-API-Key`;
+tokens are loaded at startup from `/etc/macro-data/api_tokens.json` unless
+`ANALYST_MACRO_DATA_API_TOKENS_PATH` is set.
+
 - `GET /health`      customer-facing source health matrix
 - `GET /healthz`     lightweight liveness probe
 - `GET /v1/manifest` data availability manifest for consumer routing
+- `GET /v1/calendar` unified calendar feed
+- `GET /v1/calendar/revisions` corporate calendar revision feed
+- `GET /v1/fundamentals/{ticker}` fundamentals projection
 - `POST /v1/ops/<operation>`
 
 Key operations:
@@ -448,6 +456,19 @@ macro-data-service serve --host 127.0.0.1 --port 8765
 
 SQLite path: `.macro-data/engine.db`
 
+API token file shape:
+
+```json
+{
+  "tokens": {
+    "secret-token": {
+      "consumer_id": "analyst-project",
+      "rate_limit_per_minute": 60
+    }
+  }
+}
+```
+
 ### Environment variables
 
 `src/env.py` reads from process env first, then `.env` at the repo root.
@@ -464,6 +485,10 @@ SQLite path: `.macro-data/engine.db`
 | `OPENFIGI_API_KEY` | historical identity-repair prototype | optional (anonymous tier works) |
 | `DOCUMENT_EXTRACT_API_KEY` / `OPENAI_API_KEY` | Gov-report 17-field LLM extraction (`make_extractor_from_env`, **reads `os.environ` only — not `.env`**) | optional; unset → scraper metadata |
 | `DOCUMENT_EXTRACT_MODEL`, `DOCUMENT_EXTRACT_BASE_URL`, `DOCUMENT_EXTRACT_CONTEXT_CHARS` | Model / endpoint / chunk-size overrides for the gov-report extractor (same process-env-only loading) | optional |
+| `ANALYST_MACRO_DATA_API_TOKENS_PATH` | FastAPI public API token mapping path | optional; default `/etc/macro-data/api_tokens.json` |
+| `ANALYST_MACRO_DATA_RATE_LIMIT_DB` | shared SQLite fixed-window rate-limit state | optional; default `/tmp/macro-data-api-rate-limits.sqlite3` |
+| `ANALYST_MACRO_DATA_WORKERS` | uvicorn worker count for `macro-data-service serve` | optional; default `2` |
+| `ANALYST_MACRO_DATA_API_TOKEN` | client token sent as `X-API-Key`; server also accepts it as a local inline token for CLI launches | optional |
 
 ## Agent wiring
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -429,27 +429,37 @@ expose an HTTP route → call it. No exceptions, no "for now we'll just
 import it." Breaking this rule couples downstream to our storage shape and
 defeats the whole aggregation-layer premise.
 
-- **HTTP API** (`macro-data-api`) — the contract. Routes are a thin mapping
-  over `LocalMacroDataService` ops; schema is the `contracts.py` DTOs.
-  Runtime construction uses `build_read_only_macro_data_service`: SQLite
-  opens live WAL paths with `mode=ro` when WAL sidecars exist and
-  checkpointed snapshots with `mode=ro&immutable=1`, schema/seed bootstrap
-  writes are disabled, and `/health` reads existing capability/checkpoint
-  rows through a reader health backend. The public service also attaches a
-  ClickHouse market store without schema initialization so `/v1/manifest`
-  reports market-bar availability from the market lane. Startup validates `concept_map`,
-  `release_schedule`, `source_capability`, `subjects`, and
-  `subject_aliases` contain rows.
+- **HTTP API** (`macro-data-api`) — the contract. FastAPI serves the app under
+  uvicorn, with worker count from `ANALYST_MACRO_DATA_WORKERS` / `UVICORN_WORKERS`
+  and a default of 2. Routes are a thin mapping over `LocalMacroDataService`
+  ops; schema is the `contracts.py` DTOs. Runtime construction uses
+  `build_read_only_macro_data_service`: SQLite opens live WAL paths with
+  `mode=ro` when WAL sidecars exist and checkpointed snapshots with
+  `mode=ro&immutable=1`, schema/seed bootstrap writes are disabled, and
+  `/health` reads existing capability/checkpoint rows through a reader health
+  backend. The public service also attaches a ClickHouse market store without
+  schema initialization so `/v1/manifest` reports market-bar availability from
+  the market lane. Startup validates `concept_map`, `release_schedule`,
+  `source_capability`, `subjects`, and `subject_aliases` contain rows.
+  Startup also loads `/etc/macro-data/api_tokens.json` (override:
+  `ANALYST_MACRO_DATA_API_TOKENS_PATH`) as a token → consumer mapping. Every
+  route except `/healthz` requires `X-API-Key`; unknown or missing tokens return
+  HTTP 401. Each token has a 60 req/min fixed-window limit by default and may set
+  `rate_limit_per_minute` in the token file; the production limiter stores
+  shared window state in SQLite at `ANALYST_MACRO_DATA_RATE_LIMIT_DB` (default
+  `/tmp/macro-data-api-rate-limits.sqlite3`) so multiple uvicorn workers enforce
+  one cap. Access logs are JSON records with `method`, `path`, `status`,
+  `consumer_id`, and `latency_ms`.
   `POST /v1/ops/<op>` is locked to a read-only allowlist
   (`PUBLIC_READ_OPS` in `macro_data/server.py`, issue #104):
   `resolve_indicator`, `resolve_indicator_history`, `get_data_manifest`,
-  `list_items`, `get_document`, `get_release_schedule`, `get_release_status`. Anything
-  else returns HTTP 403, even with a valid bearer token. Existing
-  `GET` routes (`/healthz`, `/health`, `/v1/manifest`, `/v1/calendar`,
-  `/v1/calendar/revisions`, `/v1/fundamentals/{ticker}`) stay public.
+  `list_items`, `get_document`, `get_release_schedule`, `get_release_status`.
+  All other ops return HTTP 403 after authentication. Existing read `GET` routes
+  (`/health`, `/v1/manifest`, `/v1/calendar`, `/v1/calendar/revisions`,
+  `/v1/fundamentals/{ticker}`) remain available behind the same API-key gate.
   Admin / write ops (`refresh_*`, `run_schedule`, `fundamentals_fetch`,
   `sync_catalog_*`, …) reach the same in-process service through the CLI
-  and systemd jobs but are not exposed over HTTP.
+  and systemd jobs.
 - **CLI** (`macro-data-service`) — operational only. Subcommands like
   `refresh`, `refresh-source`, `schedule --run`, `health`, plus the new
   `list_items` op (issue #5). Used for bootstrap, backfills, and debugging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "clickhouse-connect>=0.7",
     "curl_cffi",
     "feedparser",
+    "fastapi",
     "httpx",
     "markdownify",
     "mmh3>=4.1.0",
@@ -24,6 +25,8 @@ dependencies = [
     "PyYAML",
     "readability-lxml",
     "requests",
+    "slowapi",
+    "uvicorn[standard]",
     "yfinance",
 ]
 

--- a/src/macro_data/cli.py
+++ b/src/macro_data/cli.py
@@ -27,6 +27,8 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--port", type=int, default=None)
     serve.add_argument("--db-path", default=None)
     serve.add_argument("--api-token", default=None)
+    serve.add_argument("--api-tokens-path", default=None)
+    serve.add_argument("--workers", type=int, default=None)
 
     refresh = subparsers.add_parser("refresh")
     refresh.add_argument("--db-path", default=None)
@@ -728,6 +730,10 @@ def main(argv: list[str] | None = None) -> int:
             serve_argv.extend(["--db-path", args.db_path])
         if args.api_token is not None:
             serve_argv.extend(["--api-token", args.api_token])
+        if args.api_tokens_path is not None:
+            serve_argv.extend(["--api-tokens-path", args.api_tokens_path])
+        if args.workers is not None:
+            serve_argv.extend(["--workers", str(args.workers)])
         return serve_main(serve_argv)
 
     # World Bank commands (no service needed)

--- a/src/macro_data/client.py
+++ b/src/macro_data/client.py
@@ -45,7 +45,7 @@ class HttpMacroDataClient:
     def invoke(self, operation: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
         headers = {"Content-Type": "application/json"}
         if self._config.api_token:
-            headers["Authorization"] = f"Bearer {self._config.api_token}"
+            headers["X-API-Key"] = self._config.api_token
         response = httpx.post(
             f"{self._config.base_url}/v1/ops/{operation}",
             headers=headers,

--- a/src/macro_data/server.py
+++ b/src/macro_data/server.py
@@ -1,26 +1,37 @@
 from __future__ import annotations
 
 import argparse
-from http import HTTPStatus
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import asyncio
+from dataclasses import dataclass
+import hashlib
 import json
 import logging
+import os
 from pathlib import Path
-from typing import Any
-from urllib.parse import parse_qs, urlparse
+import sqlite3
+import threading
+import time
+from typing import Any, Callable
+
+from fastapi import FastAPI, Query, Request
+from fastapi.responses import JSONResponse
 
 from env import get_env_value
 
-from .client import encode_json
 from .service import LocalMacroDataService
 
 logger = logging.getLogger(__name__)
+access_logger = logging.getLogger("macro_data.access")
+
+DEFAULT_API_TOKENS_PATH = Path("/etc/macro-data/api_tokens.json")
+DEFAULT_RATE_LIMIT_PER_MINUTE = 60
+DEFAULT_RATE_LIMIT_DB_PATH = Path("/tmp/macro-data-api-rate-limits.sqlite3")
 
 
 # Public-read allowlist for ``POST /v1/ops/<operation>`` (issue #104).
 # Anything not in this set is rejected with HTTP 403 by the public server,
 # even if the underlying ``LocalMacroDataService`` op exists. Admin / write
-# ops (refresh_*, run_schedule, fundamentals_fetch, …) stay reachable
+# ops (refresh_*, run_schedule, fundamentals_fetch, ...) stay reachable
 # through the CLI / SSH / systemd jobs that share the same in-process
 # service.
 PUBLIC_READ_OPS: frozenset[str] = frozenset({
@@ -34,265 +45,580 @@ PUBLIC_READ_OPS: frozenset[str] = frozenset({
 })
 
 
-class MacroDataRequestHandler(BaseHTTPRequestHandler):
-    server_version = "AnalystMacroData/0.1"
+@dataclass(frozen=True)
+class ApiToken:
+    consumer_id: str
+    rate_limit_per_minute: int = DEFAULT_RATE_LIMIT_PER_MINUTE
 
-    def do_GET(self) -> None:  # noqa: N802
-        parsed = urlparse(self.path)
-        if parsed.path == "/healthz":
-            self._write_json(HTTPStatus.OK, {"status": "ok"})
+
+class FixedWindowRateLimiter:
+    def __init__(self, *, clock: Callable[[], float] | None = None) -> None:
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        self._windows: dict[str, tuple[float, int]] = {}
+
+    def check(self, key: str, limit: int) -> tuple[bool, int]:
+        now = self._clock()
+        window_seconds = 60.0
+        with self._lock:
+            start, count = self._windows.get(key, (now, 0))
+            if now - start >= window_seconds:
+                start, count = now, 0
+            if count >= limit:
+                retry_after = max(1, int(window_seconds - (now - start)))
+                self._windows[key] = (start, count)
+                return False, retry_after
+            self._windows[key] = (start, count + 1)
+            return True, 0
+
+
+class SQLiteFixedWindowRateLimiter:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._path = path
+        self._clock = clock or time.time
+        self._init_lock = threading.Lock()
+        self._initialized = False
+
+    def _ensure_schema(self) -> None:
+        if self._initialized:
             return
-        if parsed.path == "/health":
-            include_internal = parse_qs(parsed.query).get("all", ["0"])[0] in {"1", "true", "yes"}
-            service = self.server.service  # type: ignore[attr-defined]
-            try:
-                payload = service.invoke(
-                    "get_source_health_dashboard",
-                    {"include_internal": include_internal},
+        with self._init_lock:
+            if self._initialized:
+                return
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with sqlite3.connect(self._path, timeout=5.0) as connection:
+                connection.execute("PRAGMA journal_mode=WAL")
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS rate_limit_windows (
+                        token_hash TEXT PRIMARY KEY,
+                        window_start REAL NOT NULL,
+                        count INTEGER NOT NULL
+                    )
+                    """
                 )
-            except Exception as exc:
-                logger.exception("macro-data health request failed")
-                self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"status": "error", "error": str(exc)})
-                return
-            self._write_json(HTTPStatus.OK, payload)
-            return
-        if parsed.path == "/v1/manifest":
-            service = self.server.service  # type: ignore[attr-defined]
-            try:
-                payload = service.invoke("get_data_manifest", {})
-            except Exception as exc:
-                logger.exception("GET /v1/manifest failed")
-                self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
-                return
-            self._write_json(HTTPStatus.OK, payload)
-            return
-        if parsed.path == "/v1/calendar":
-            self._handle_calendar_list(parsed.query)
-            return
-        if parsed.path == "/v1/calendar/revisions":
-            self._handle_calendar_revisions(parsed.query)
-            return
-        if parsed.path.startswith("/v1/fundamentals/"):
-            ticker = parsed.path[len("/v1/fundamentals/"):]
-            if not ticker:
-                self._write_json(
-                    HTTPStatus.BAD_REQUEST, {"error": "ticker is required"},
-                )
-                return
-            self._handle_fundamentals_get(ticker, parsed.query)
-            return
-        self._write_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            self._initialized = True
 
-    def _handle_calendar_list(self, query: str) -> None:
-        """GET /v1/calendar — JSON:API-shaped list over ``v_calendar_item``.
-
-        Query params:
-
-        - ``domain`` / ``country`` / ``ticker`` / ``subtype`` / ``provider``
-          — equality filters; see :meth:`LocalMacroDataService._op_list_calendar_items`.
-        - ``as_of`` — ISO-8601 UTC point-in-time cutoff (issue #65).
-          Future timestamps map to HTTP 400.
-        - ``page[offset]`` (default 0), ``page[limit]`` (default 100,
-          max 500) — JSON:API pagination.
-
-        Issue #9 P7 — replaces the need for downstream consumers to
-        reach into ``engine.db`` or import from ``src/``.
-        """
-        params = parse_qs(query, keep_blank_values=False)
-        def _first(key: str) -> str:
-            values = params.get(key) or []
-            return values[0] if values else ""
-        arguments: dict[str, Any] = {
-            "domain":      _first("domain"),
-            "country":     _first("country"),
-            "ticker":      _first("ticker"),
-            "subtype":     _first("subtype"),
-            "provider":    _first("provider"),
-            "as_of":       _first("as_of"),
-            "page_offset": _first("page[offset]"),
-            "page_limit":  _first("page[limit]"),
-        }
-        service = self.server.service  # type: ignore[attr-defined]
+    def check(self, key: str, limit: int) -> tuple[bool, int]:
+        self._ensure_schema()
+        now = self._clock()
+        window_seconds = 60.0
+        token_hash = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        connection = sqlite3.connect(self._path, timeout=5.0, isolation_level=None)
         try:
-            result = service.invoke("list_calendar_items", arguments)
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """
+                SELECT window_start, count
+                FROM rate_limit_windows
+                WHERE token_hash = ?
+                """,
+                (token_hash,),
+            ).fetchone()
+            if row is None or now - float(row[0]) >= window_seconds:
+                connection.execute(
+                    """
+                    INSERT INTO rate_limit_windows (
+                        token_hash, window_start, count
+                    ) VALUES (?, ?, 1)
+                    ON CONFLICT(token_hash) DO UPDATE SET
+                        window_start = excluded.window_start,
+                        count = excluded.count
+                    """,
+                    (token_hash, now),
+                )
+                connection.commit()
+                return True, 0
+
+            start = float(row[0])
+            count = int(row[1])
+            if count >= limit:
+                connection.commit()
+                retry_after = max(1, int(window_seconds - (now - start)))
+                return False, retry_after
+
+            connection.execute(
+                """
+                UPDATE rate_limit_windows
+                SET count = count + 1
+                WHERE token_hash = ?
+                """,
+                (token_hash,),
+            )
+            connection.commit()
+            return True, 0
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+
+def _positive_int(value: Any, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _token_entry(
+    token: str,
+    raw: Any,
+    *,
+    default_rate_limit_per_minute: int,
+) -> ApiToken | None:
+    if isinstance(raw, str):
+        consumer_id = raw.strip()
+        if consumer_id:
+            return ApiToken(
+                consumer_id=consumer_id,
+                rate_limit_per_minute=default_rate_limit_per_minute,
+            )
+        return None
+    if isinstance(raw, dict):
+        consumer_id = str(
+            raw.get("consumer_id")
+            or raw.get("consumer")
+            or raw.get("id")
+            or ""
+        ).strip()
+        if not consumer_id:
+            return None
+        rate_limit = _positive_int(
+            raw.get("rate_limit_per_minute")
+            or raw.get("limit_per_minute")
+            or raw.get("rate_limit"),
+            default=default_rate_limit_per_minute,
+        )
+        return ApiToken(
+            consumer_id=consumer_id,
+            rate_limit_per_minute=rate_limit,
+        )
+    if token and raw is True:
+        return ApiToken(
+            consumer_id=token,
+            rate_limit_per_minute=default_rate_limit_per_minute,
+        )
+    return None
+
+
+def _iter_token_entries(payload: Any) -> list[tuple[str, Any]]:
+    if isinstance(payload, dict):
+        entries = payload.get("tokens", payload)
+        if isinstance(entries, dict):
+            return [(str(token), raw) for token, raw in entries.items()]
+        if isinstance(entries, list):
+            return [
+                (str(raw.get("token", "")), raw)
+                for raw in entries
+                if isinstance(raw, dict)
+            ]
+    if isinstance(payload, list):
+        return [
+            (str(raw.get("token", "")), raw)
+            for raw in payload
+            if isinstance(raw, dict)
+        ]
+    return []
+
+
+def load_api_tokens(
+    path: Path,
+    *,
+    inline_api_token: str = "",
+    default_rate_limit_per_minute: int = DEFAULT_RATE_LIMIT_PER_MINUTE,
+) -> dict[str, ApiToken]:
+    tokens: dict[str, ApiToken] = {}
+    if path.exists():
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        for token, raw in _iter_token_entries(payload):
+            token = token.strip()
+            if not token:
+                continue
+            entry = _token_entry(
+                token,
+                raw,
+                default_rate_limit_per_minute=default_rate_limit_per_minute,
+            )
+            if entry is not None:
+                tokens[token] = entry
+    if inline_api_token and inline_api_token not in tokens:
+        tokens[inline_api_token] = ApiToken(
+            consumer_id="inline",
+            rate_limit_per_minute=default_rate_limit_per_minute,
+        )
+    return tokens
+
+
+def _api_tokens_path(configured_path: Path | None = None) -> Path:
+    if configured_path is not None:
+        return configured_path
+    raw = get_env_value(
+        "ANALYST_MACRO_DATA_API_TOKENS_PATH",
+        "MACRO_DATA_API_TOKENS_PATH",
+        default=str(DEFAULT_API_TOKENS_PATH),
+    )
+    return Path(raw)
+
+
+def _inline_api_token() -> str:
+    return get_env_value("ANALYST_MACRO_DATA_API_TOKEN", default="").strip()
+
+
+def _default_rate_limit_per_minute() -> int:
+    return _positive_int(
+        get_env_value("ANALYST_MACRO_DATA_RATE_LIMIT_PER_MINUTE", default="60"),
+        default=DEFAULT_RATE_LIMIT_PER_MINUTE,
+    )
+
+
+def _default_rate_limit_db_path() -> Path:
+    raw = get_env_value(
+        "ANALYST_MACRO_DATA_RATE_LIMIT_DB",
+        default=str(DEFAULT_RATE_LIMIT_DB_PATH),
+    )
+    return Path(raw)
+
+
+def _build_read_only_service_from_env() -> LocalMacroDataService:
+    from macro_data.factory import build_read_only_macro_data_service
+
+    raw_db_path = get_env_value("ANALYST_MACRO_DATA_DB_PATH", default="").strip()
+    db_path = Path(raw_db_path) if raw_db_path else None
+    return build_read_only_macro_data_service(db_path=db_path)
+
+
+def _get_service(request: Request) -> LocalMacroDataService:
+    service = request.app.state.service
+    if service is None:
+        service = request.app.state.service_factory()
+        request.app.state.service = service
+    return service
+
+
+async def _invoke_service(
+    request: Request,
+    operation: str,
+    arguments: dict[str, Any],
+) -> Any:
+    service = _get_service(request)
+    if request.app.state.invoke_in_thread:
+        return await asyncio.to_thread(service.invoke, operation, arguments)
+    return service.invoke(operation, arguments)
+
+
+def _json(payload: Any, status_code: int = 200, headers: dict[str, str] | None = None) -> JSONResponse:
+    return JSONResponse(content=payload, status_code=status_code, headers=headers)
+
+
+def _is_truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes"}
+
+
+def create_app(
+    *,
+    service: LocalMacroDataService | None = None,
+    service_factory: Callable[[], LocalMacroDataService] | None = None,
+    token_config: dict[str, ApiToken] | None = None,
+    token_path: Path | None = None,
+    rate_limiter: FixedWindowRateLimiter | None = None,
+    invoke_in_thread: bool | None = None,
+) -> FastAPI:
+    app = FastAPI(title="Analyst Macro Data API")
+    app.state.service = service
+    app.state.service_factory = service_factory or _build_read_only_service_from_env
+    app.state.token_config = token_config
+    app.state.token_path = token_path
+    app.state.api_tokens = dict(token_config) if token_config is not None else {}
+    app.state.rate_limiter = (
+        rate_limiter
+        or (
+            SQLiteFixedWindowRateLimiter(_default_rate_limit_db_path())
+            if service is None
+            else FixedWindowRateLimiter()
+        )
+    )
+    app.state.invoke_in_thread = (
+        service is None
+        if invoke_in_thread is None
+        else invoke_in_thread
+    )
+
+    async def _load_tokens_on_startup() -> None:
+        if app.state.service is None:
+            app.state.service = app.state.service_factory()
+        if app.state.token_config is not None:
+            app.state.api_tokens = dict(app.state.token_config)
+            return
+        path = _api_tokens_path(app.state.token_path)
+        app.state.api_tokens = load_api_tokens(
+            path,
+            inline_api_token=_inline_api_token(),
+            default_rate_limit_per_minute=_default_rate_limit_per_minute(),
+        )
+        if not app.state.api_tokens:
+            logger.warning("macro-data API token config is empty: %s", path)
+
+    app.add_event_handler("startup", _load_tokens_on_startup)
+
+    @app.middleware("http")
+    async def _auth_rate_limit_and_log(request: Request, call_next: Any) -> JSONResponse:
+        start = time.perf_counter()
+        consumer_id: str | None = None
+        status_code = 500
+        try:
+            if request.url.path == "/healthz":
+                response = await call_next(request)
+                status_code = response.status_code
+                return response
+
+            token = request.headers.get("X-API-Key", "").strip()
+            token_entry = app.state.api_tokens.get(token) if token else None
+            if token_entry is None:
+                response = _json({"error": "unauthorized"}, status_code=401)
+                status_code = response.status_code
+                return response
+
+            consumer_id = token_entry.consumer_id
+            request.state.consumer_id = consumer_id
+            allowed, retry_after = app.state.rate_limiter.check(
+                token,
+                token_entry.rate_limit_per_minute,
+            )
+            if not allowed:
+                response = _json(
+                    {"error": "rate limit exceeded"},
+                    status_code=429,
+                    headers={"Retry-After": str(retry_after)},
+                )
+                status_code = response.status_code
+                return response
+
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        finally:
+            latency_ms = round((time.perf_counter() - start) * 1000, 3)
+            access_logger.info(
+                json.dumps(
+                    {
+                        "method": request.method,
+                        "path": request.url.path,
+                        "status": status_code,
+                        "consumer_id": consumer_id,
+                        "latency_ms": latency_ms,
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+
+    @app.get("/healthz")
+    async def healthz() -> JSONResponse:
+        return _json({"status": "ok"})
+
+    @app.get("/health")
+    async def health(
+        request: Request,
+        all_: str = Query(default="0", alias="all"),
+    ) -> JSONResponse:
+        try:
+            payload = await _invoke_service(
+                request,
+                "get_source_health_dashboard",
+                {"include_internal": _is_truthy(all_)},
+            )
+        except Exception as exc:
+            logger.exception("macro-data health request failed")
+            return _json({"status": "error", "error": str(exc)}, status_code=500)
+        return _json(payload)
+
+    @app.get("/v1/manifest")
+    async def manifest(request: Request) -> JSONResponse:
+        try:
+            payload = await _invoke_service(request, "get_data_manifest", {})
+        except Exception as exc:
+            logger.exception("GET /v1/manifest failed")
+            return _json({"error": str(exc)}, status_code=500)
+        return _json(payload)
+
+    @app.get("/v1/calendar")
+    async def calendar(
+        request: Request,
+        domain: str = "",
+        country: str = "",
+        ticker: str = "",
+        subtype: str = "",
+        provider: str = "",
+        as_of: str = "",
+        page_offset: str = Query(default="", alias="page[offset]"),
+        page_limit: str = Query(default="", alias="page[limit]"),
+    ) -> JSONResponse:
+        arguments: dict[str, Any] = {
+            "domain": domain,
+            "country": country,
+            "ticker": ticker,
+            "subtype": subtype,
+            "provider": provider,
+            "as_of": as_of,
+            "page_offset": page_offset,
+            "page_limit": page_limit,
+        }
+        try:
+            result = await _invoke_service(request, "list_calendar_items", arguments)
         except Exception as exc:
             logger.exception("GET /v1/calendar failed")
-            self._write_json(
-                HTTPStatus.INTERNAL_SERVER_ERROR,
-                {"error": str(exc)},
-            )
-            return
+            return _json({"error": str(exc)}, status_code=500)
         if isinstance(result, dict) and "error" in result:
-            self._write_json(HTTPStatus.BAD_REQUEST, result)
-            return
-        self._write_json(HTTPStatus.OK, result)
+            return _json(result, status_code=400)
+        return _json(result)
 
-    def _handle_calendar_revisions(self, query: str) -> None:
-        """GET /v1/calendar/revisions — surface ``cal_corp_raw`` revisions.
-
-        Query params:
-
-        - ``from_ts`` / ``to_ts`` — ISO-8601 UTC bounds on
-          ``snapshot_epoch_ms``; filter the GROUP BY so the version
-          count reflects revisions seen *inside* the window.
-        - ``ticker`` / ``subtype`` — equality filters on the
-          ``cal_corp_event`` projection.
-        - ``min_versions`` — default 2; set to 1 to enumerate every
-          event with at least one snapshot.
-        - ``event_id`` + ``include_versions=true`` — drill into a
-          single event and return its raw-snapshot chain instead of
-          the aggregate listing.
-        - ``page[offset]`` / ``page[limit]`` — JSON:API pagination
-          (default 0 / 100, max 500).
-
-        Issue #66 — paired with structured ``corp-event revised`` log
-        lines from ``store_corp_raw`` for cheap observability.
-        """
-        params = parse_qs(query, keep_blank_values=False)
-        def _first(key: str) -> str:
-            values = params.get(key) or []
-            return values[0] if values else ""
-        include_versions_raw = _first("include_versions").lower()
+    @app.get("/v1/calendar/revisions")
+    async def calendar_revisions(
+        request: Request,
+        from_ts: str = "",
+        to_ts: str = "",
+        ticker: str = "",
+        subtype: str = "",
+        min_versions: str = "",
+        event_id: str = "",
+        include_versions: str = "",
+        page_offset: str = Query(default="", alias="page[offset]"),
+        page_limit: str = Query(default="", alias="page[limit]"),
+    ) -> JSONResponse:
         arguments: dict[str, Any] = {
-            "from_ts":          _first("from_ts"),
-            "to_ts":            _first("to_ts"),
-            "ticker":           _first("ticker"),
-            "subtype":          _first("subtype"),
-            "min_versions":     _first("min_versions"),
-            "event_id":         _first("event_id"),
-            "include_versions": include_versions_raw in {"1", "true", "yes"},
-            "page_offset":      _first("page[offset]"),
-            "page_limit":       _first("page[limit]"),
+            "from_ts": from_ts,
+            "to_ts": to_ts,
+            "ticker": ticker,
+            "subtype": subtype,
+            "min_versions": min_versions,
+            "event_id": event_id,
+            "include_versions": _is_truthy(include_versions),
+            "page_offset": page_offset,
+            "page_limit": page_limit,
         }
-        service = self.server.service  # type: ignore[attr-defined]
         try:
-            result = service.invoke("list_corp_revisions", arguments)
+            result = await _invoke_service(request, "list_corp_revisions", arguments)
         except Exception as exc:
             logger.exception("GET /v1/calendar/revisions failed")
-            self._write_json(
-                HTTPStatus.INTERNAL_SERVER_ERROR,
-                {"error": str(exc)},
-            )
-            return
+            return _json({"error": str(exc)}, status_code=500)
         if isinstance(result, dict) and "error" in result:
-            self._write_json(HTTPStatus.BAD_REQUEST, result)
-            return
-        self._write_json(HTTPStatus.OK, result)
+            return _json(result, status_code=400)
+        return _json(result)
 
-    def _handle_fundamentals_get(self, ticker: str, query: str) -> None:
-        """GET /v1/fundamentals/{ticker} — read fundamentals projection.
-
-        Query params:
-
-        - ``provider`` — optional, default ``eodhd``.
-        - ``as_of`` — ISO-8601 UTC point-in-time cutoff (issue #65).
-          Future timestamps map to HTTP 400.
-        - ``statement`` — ``IS`` / ``BS`` / ``CF`` financials filter.
-        - ``period`` — ``Q`` / ``A`` financials filter.
-        - ``limit`` — financials row cap (default 100, max 500).
-
-        Returns ``{"ticker", "provider", "as_of", "company",
-        "highlights", "financials"}`` over the same shape produced by
-        the ``get_fundamentals`` op.
-        """
-        from urllib.parse import unquote
-
-        params = parse_qs(query, keep_blank_values=False)
-
-        def _first(key: str) -> str:
-            values = params.get(key) or []
-            return values[0] if values else ""
-
+    @app.get("/v1/fundamentals/{ticker:path}")
+    async def fundamentals(
+        request: Request,
+        ticker: str,
+        provider: str = "",
+        as_of: str = "",
+        statement: str = "",
+        period: str = "",
+        limit: str = "",
+    ) -> JSONResponse:
+        if not ticker:
+            return _json({"error": "ticker is required"}, status_code=400)
         arguments: dict[str, Any] = {
-            "ticker":    unquote(ticker),
-            "provider":  _first("provider"),
-            "as_of":     _first("as_of"),
-            "statement": _first("statement"),
-            "period":    _first("period"),
-            "limit":     _first("limit"),
+            "ticker": ticker,
+            "provider": provider,
+            "as_of": as_of,
+            "statement": statement,
+            "period": period,
+            "limit": limit,
         }
-        service = self.server.service  # type: ignore[attr-defined]
         try:
-            result = service.invoke("get_fundamentals", arguments)
+            result = await _invoke_service(request, "get_fundamentals", arguments)
         except Exception as exc:
             logger.exception("GET /v1/fundamentals/%s failed", ticker)
-            self._write_json(
-                HTTPStatus.INTERNAL_SERVER_ERROR,
-                {"error": str(exc)},
-            )
-            return
+            return _json({"error": str(exc)}, status_code=500)
         if isinstance(result, dict) and "error" in result:
-            self._write_json(HTTPStatus.BAD_REQUEST, result)
-            return
-        self._write_json(HTTPStatus.OK, result)
+            return _json(result, status_code=400)
+        return _json(result)
 
-    def do_POST(self) -> None:  # noqa: N802
-        if not self.path.startswith("/v1/ops/"):
-            self._write_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
-            return
-        token = self.server.api_token  # type: ignore[attr-defined]
-        if token:
-            auth_header = self.headers.get("Authorization", "")
-            if auth_header != f"Bearer {token}":
-                self._write_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
-                return
-        operation = self.path.rsplit("/", 1)[-1]
+    @app.post("/v1/ops/{operation}")
+    async def invoke_operation(request: Request, operation: str) -> JSONResponse:
         if operation not in PUBLIC_READ_OPS:
-            self._write_json(
-                HTTPStatus.FORBIDDEN,
+            return _json(
                 {"error": "operation not permitted on public API"},
+                status_code=403,
             )
-            return
-        try:
-            length = int(self.headers.get("Content-Length", "0"))
-        except ValueError:
-            length = 0
-        raw_body = self.rfile.read(length) if length > 0 else b"{}"
+        raw_body = await request.body()
+        if not raw_body:
+            raw_body = b"{}"
         try:
             payload = json.loads(raw_body.decode("utf-8"))
         except json.JSONDecodeError:
-            self._write_json(HTTPStatus.BAD_REQUEST, {"error": "invalid json"})
-            return
+            return _json({"error": "invalid json"}, status_code=400)
         arguments = payload.get("arguments") if isinstance(payload, dict) else {}
         if not isinstance(arguments, dict):
-            self._write_json(HTTPStatus.BAD_REQUEST, {"error": "arguments must be an object"})
-            return
-        service = self.server.service  # type: ignore[attr-defined]
+            return _json({"error": "arguments must be an object"}, status_code=400)
         try:
-            result = service.invoke(operation, arguments)
+            result = await _invoke_service(request, operation, arguments)
         except KeyError as exc:
-            self._write_json(HTTPStatus.NOT_FOUND, {"error": str(exc)})
-            return
+            return _json({"error": str(exc)}, status_code=404)
         except Exception as exc:
             logger.exception("macro-data operation failed: %s", operation)
-            self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
-            return
-        self._write_json(HTTPStatus.OK, result)
+            return _json({"error": str(exc)}, status_code=500)
+        return _json(result)
 
-    def log_message(self, format: str, *args: Any) -> None:
-        logger.info("%s - %s", self.address_string(), format % args)
+    @app.api_route(
+        "/{path_name:path}",
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    )
+    async def not_found(path_name: str) -> JSONResponse:
+        return _json({"error": "not found"}, status_code=404)
 
-    def _write_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
-        encoded = encode_json(payload)
-        self.send_response(status.value)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Content-Length", str(len(encoded)))
-        self.end_headers()
-        self.wfile.write(encoded)
+    return app
+
+
+app = create_app()
 
 
 def serve(
     *,
     host: str,
     port: int,
-    service: LocalMacroDataService,
+    service: LocalMacroDataService | None = None,
     api_token: str = "",
+    workers: int = 1,
 ) -> None:
-    httpd = ThreadingHTTPServer((host, port), MacroDataRequestHandler)
-    httpd.service = service  # type: ignore[attr-defined]
-    httpd.api_token = api_token  # type: ignore[attr-defined]
-    logger.info("macro-data API listening on http://%s:%s", host, port)
-    httpd.serve_forever()
+    import uvicorn
+
+    if api_token:
+        os.environ["ANALYST_MACRO_DATA_API_TOKEN"] = api_token
+    if service is not None:
+        uvicorn.run(
+            create_app(
+                service=service,
+                token_config=(
+                    {api_token: ApiToken("inline")}
+                    if api_token
+                    else None
+                ),
+                rate_limiter=SQLiteFixedWindowRateLimiter(
+                    _default_rate_limit_db_path()
+                ),
+                invoke_in_thread=True,
+            ),
+            host=host,
+            port=port,
+            workers=1,
+        )
+        return
+    uvicorn.run(
+        "macro_data.server:app",
+        host=host,
+        port=port,
+        workers=max(workers, 1),
+    )
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -301,20 +627,25 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--port", type=int, default=int(get_env_value("ANALYST_MACRO_DATA_PORT", default="8765") or "8765"))
     parser.add_argument("--db-path", default=None)
     parser.add_argument("--api-token", default=get_env_value("ANALYST_MACRO_DATA_API_TOKEN", default=""))
+    parser.add_argument("--api-tokens-path", default=get_env_value("ANALYST_MACRO_DATA_API_TOKENS_PATH", default=""))
+    parser.add_argument("--workers", type=int, default=int(get_env_value("ANALYST_MACRO_DATA_WORKERS", "UVICORN_WORKERS", default="2") or "2"))
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
-    from macro_data.factory import build_read_only_macro_data_service
-
-    service = build_read_only_macro_data_service(db_path=Path(args.db_path) if args.db_path else None)
+    if args.db_path:
+        os.environ["ANALYST_MACRO_DATA_DB_PATH"] = args.db_path
+    if args.api_token:
+        os.environ["ANALYST_MACRO_DATA_API_TOKEN"] = args.api_token
+    if args.api_tokens_path:
+        os.environ["ANALYST_MACRO_DATA_API_TOKENS_PATH"] = args.api_tokens_path
     serve(
         host=args.host,
         port=args.port,
-        service=service,
         api_token=args.api_token,
+        workers=max(args.workers, 1),
     )
     return 0
 

--- a/tests/market/fundamentals/eodhd/test_http_route.py
+++ b/tests/market/fundamentals/eodhd/test_http_route.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import json
-import threading
-from http.client import HTTPConnection
-from http.server import ThreadingHTTPServer
+import asyncio
 from pathlib import Path
 from urllib.parse import quote
 
+from fastapi import FastAPI
+import httpx
 import pytest
 
 from ingestion.market.fundamentals.eodhd_fundamentals import (
@@ -19,7 +19,7 @@ from ingestion.market.fundamentals.eodhd_fundamentals import (
     project_fundamentals_highlights,
     store_fundamentals_raw,
 )
-from macro_data.server import MacroDataRequestHandler
+from macro_data.server import ApiToken, create_app
 from macro_data.service import LocalMacroDataService
 from storage.sqlite import SQLiteEngineStore
 
@@ -88,35 +88,26 @@ def store(tmp_path: Path) -> SQLiteEngineStore:
 @pytest.fixture()
 def live_server(store: SQLiteEngineStore):
     svc = LocalMacroDataService(store=store)
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
-    httpd.service = svc  # type: ignore[attr-defined]
-    httpd.api_token = ""  # type: ignore[attr-defined]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    host, port = httpd.server_address[0], httpd.server_address[1]
-    try:
-        yield host, port
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=5)
+    return create_app(
+        service=svc,
+        token_config={"valid-token": ApiToken("test-consumer")},
+    )
 
 
-def _get(host: str, port: int, path: str) -> tuple[int, dict]:
-    conn = HTTPConnection(host, port, timeout=5)
-    try:
-        conn.request("GET", path)
-        resp = conn.getresponse()
-        body = resp.read().decode("utf-8")
-    finally:
-        conn.close()
-    parsed = json.loads(body) if body else {}
-    return resp.status, parsed
+async def _async_get(app: FastAPI, path: str) -> tuple[int, dict]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(path, headers={"X-API-Key": "valid-token"})
+    parsed = response.json() if response.content else {}
+    return response.status_code, parsed
+
+
+def _get(app: FastAPI, path: str) -> tuple[int, dict]:
+    return asyncio.run(_async_get(app, path))
 
 
 def test_get_fundamentals_returns_company_and_financials(live_server) -> None:
-    host, port = live_server
-    status, body = _get(host, port, "/v1/fundamentals/AAPL.US")
+    status, body = _get(live_server, "/v1/fundamentals/AAPL.US")
     assert status == 200
     assert body["company"]["name"] == "Apple Inc"
     assert len(body["financials"]) == 1
@@ -124,9 +115,8 @@ def test_get_fundamentals_returns_company_and_financials(live_server) -> None:
 
 
 def test_get_fundamentals_filter_by_statement_and_period(live_server) -> None:
-    host, port = live_server
     status, body = _get(
-        host, port, "/v1/fundamentals/AAPL.US?statement=IS&period=A",
+        live_server, "/v1/fundamentals/AAPL.US?statement=IS&period=A",
     )
     assert status == 200
     assert all(
@@ -136,16 +126,14 @@ def test_get_fundamentals_filter_by_statement_and_period(live_server) -> None:
 
 
 def test_get_fundamentals_invalid_statement_400(live_server) -> None:
-    host, port = live_server
-    status, body = _get(host, port, "/v1/fundamentals/AAPL.US?statement=XX")
+    status, body = _get(live_server, "/v1/fundamentals/AAPL.US?statement=XX")
     assert status == 400
     assert "error" in body
 
 
 def test_get_fundamentals_future_as_of_400(live_server) -> None:
-    host, port = live_server
     status, body = _get(
-        host, port, "/v1/fundamentals/AAPL.US?as_of=9999-01-01T00:00:00Z",
+        live_server, "/v1/fundamentals/AAPL.US?as_of=9999-01-01T00:00:00Z",
     )
     assert status == 400
     assert "error" in body
@@ -154,8 +142,7 @@ def test_get_fundamentals_future_as_of_400(live_server) -> None:
 def test_get_fundamentals_unknown_ticker_returns_empty_projections(
     live_server,
 ) -> None:
-    host, port = live_server
-    status, body = _get(host, port, "/v1/fundamentals/UNKNOWN.X")
+    status, body = _get(live_server, "/v1/fundamentals/UNKNOWN.X")
     assert status == 200
     assert body["company"] is None
     assert body["highlights"] is None
@@ -163,15 +150,13 @@ def test_get_fundamentals_unknown_ticker_returns_empty_projections(
 
 
 def test_get_fundamentals_url_decodes_ticker(live_server) -> None:
-    host, port = live_server
     encoded = quote("AAPL.US", safe="")
-    status, body = _get(host, port, f"/v1/fundamentals/{encoded}")
+    status, body = _get(live_server, f"/v1/fundamentals/{encoded}")
     assert status == 200
     assert body["ticker"] == "AAPL.US"
 
 
 def test_get_fundamentals_missing_ticker_400(live_server) -> None:
-    host, port = live_server
-    status, body = _get(host, port, "/v1/fundamentals/")
+    status, body = _get(live_server, "/v1/fundamentals/")
     assert status == 400
     assert "error" in body

--- a/tests/test_calendar_corp_revisions.py
+++ b/tests/test_calendar_corp_revisions.py
@@ -5,8 +5,7 @@ Three layers, mirroring ``test_calendar_http_route``:
 - **Storage** — direct ``SQLiteEngineStore.list_corp_revisions`` calls
   and ``list_corp_revision_versions`` for the per-event chain.
 - **Service op** — ``LocalMacroDataService.invoke("list_corp_revisions")``.
-- **HTTP route** — ``GET /v1/calendar/revisions`` driven by a real
-  ``ThreadingHTTPServer``.
+- **HTTP route** — ``GET /v1/calendar/revisions`` driven through FastAPI.
 
 Plus a projector-level test that ``store_corp_raw`` emits a structured
 log line when a new ``content_hash`` lands for an already-seen
@@ -18,17 +17,17 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
-import threading
+import asyncio
 from datetime import datetime, timezone
-from http.client import HTTPConnection
-from http.server import ThreadingHTTPServer
 from pathlib import Path
 
+from fastapi import FastAPI
+import httpx
 import pytest
 
 from ingestion.calendar.eodhd_api.parser import CalendarCorpRawRecord
 from ingestion.calendar.eodhd_api.projector import store_corp_raw
-from macro_data.server import MacroDataRequestHandler
+from macro_data.server import ApiToken, create_app
 from macro_data.service import LocalMacroDataService
 from storage.sqlite import SQLiteEngineStore
 
@@ -411,37 +410,28 @@ def test_service_op_handles_blank_filters(store: SQLiteEngineStore) -> None:
 @pytest.fixture()
 def live_server(store: SQLiteEngineStore):
     svc = LocalMacroDataService(store=store)
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
-    httpd.service = svc  # type: ignore[attr-defined]
-    httpd.api_token = ""  # type: ignore[attr-defined]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    host, port = httpd.server_address[0], httpd.server_address[1]
-    try:
-        yield host, port
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=5)
+    return create_app(
+        service=svc,
+        token_config={"valid-token": ApiToken("test-consumer")},
+    )
 
 
-def _http_get(host: str, port: int, path: str) -> tuple[int, dict]:
-    conn = HTTPConnection(host, port, timeout=5)
-    try:
-        conn.request("GET", path)
-        resp = conn.getresponse()
-        body = resp.read().decode("utf-8")
-    finally:
-        conn.close()
-    return resp.status, json.loads(body) if body else {}
+async def _async_get(app: FastAPI, path: str) -> tuple[int, dict]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(path, headers={"X-API-Key": "valid-token"})
+    return response.status_code, response.json() if response.content else {}
+
+
+def _http_get(app: FastAPI, path: str) -> tuple[int, dict]:
+    return asyncio.run(_async_get(app, path))
 
 
 def test_http_route_returns_revisions_envelope(
     store: SQLiteEngineStore, live_server,
 ) -> None:
     _seed_event_with_revisions(store)
-    host, port = live_server
-    status, payload = _http_get(host, port, "/v1/calendar/revisions")
+    status, payload = _http_get(live_server, "/v1/calendar/revisions")
     assert status == 200
     assert payload["meta"]["count"] == 1
     assert payload["data"][0]["versions"] == 3
@@ -456,9 +446,8 @@ def test_http_route_filter_by_ticker(
     _seed_event_with_revisions(
         store, provider_event_id="eodhd-earn-MSFT", ticker="MSFT",
     )
-    host, port = live_server
     status, payload = _http_get(
-        host, port, "/v1/calendar/revisions?ticker=AAPL",
+        live_server, "/v1/calendar/revisions?ticker=AAPL",
     )
     assert status == 200
     assert payload["meta"]["count"] == 1
@@ -469,9 +458,8 @@ def test_http_route_include_versions_for_one_event(
     store: SQLiteEngineStore, live_server,
 ) -> None:
     _seed_event_with_revisions(store)
-    host, port = live_server
     status, payload = _http_get(
-        host, port,
+        live_server,
         "/v1/calendar/revisions?event_id=eodhd:eodhd-earn-AAPL-20260201"
         "&include_versions=true",
     )
@@ -482,9 +470,8 @@ def test_http_route_include_versions_for_one_event(
 def test_http_route_invalid_from_ts_returns_400(
     store: SQLiteEngineStore, live_server,
 ) -> None:
-    host, port = live_server
     status, payload = _http_get(
-        host, port, "/v1/calendar/revisions?from_ts=not-a-date",
+        live_server, "/v1/calendar/revisions?from_ts=not-a-date",
     )
     assert status == 400
     assert "error" in payload

--- a/tests/test_calendar_http_route.py
+++ b/tests/test_calendar_http_route.py
@@ -4,9 +4,8 @@ Three layers:
 
 - **Storage** — direct ``SQLiteEngineStore.list_calendar_items`` calls.
 - **Service op** — ``LocalMacroDataService.invoke("list_calendar_items")``.
-- **HTTP route** — real ``ThreadingHTTPServer`` on a free port,
-  driven by ``http.client`` so the request path exercises the query-
-  parser, dispatcher, and JSON writer.
+- **HTTP route** — FastAPI app via ASGI transport so the request path exercises
+  middleware, query parsing, dispatch, and JSON response handling.
 
 Fixture data is seeded by projecting synthetic NBS + ECB scaffolds
 through the shared ``project_events``, so the test doubles as a
@@ -16,11 +15,11 @@ cross-connector smoke check on the consolidated projector.
 from __future__ import annotations
 
 import json
-import threading
-from http.client import HTTPConnection
-from http.server import ThreadingHTTPServer
+import asyncio
 from pathlib import Path
 
+from fastapi import FastAPI
+import httpx
 import pytest
 
 from ingestion.calendar.ecb_api import fetch_ecb_calendar
@@ -32,7 +31,7 @@ from ingestion.calendar._official_shared.projector import (
     store_raw,
 )
 from ingestion.timeseries.sdmx._types import SDMXObservation
-from macro_data.server import MacroDataRequestHandler
+from macro_data.server import ApiToken, create_app
 from macro_data.service import LocalMacroDataService
 from storage.sqlite import SQLiteEngineStore
 
@@ -311,41 +310,31 @@ def test_service_op_handles_non_int_pagination(
 
 @pytest.fixture()
 def live_server(store: SQLiteEngineStore):
-    """Start a real ThreadingHTTPServer on a free port, yield its
-    (host, port) tuple, then shut down cleanly."""
     svc = LocalMacroDataService(store=store)
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
-    httpd.service = svc  # type: ignore[attr-defined]
-    httpd.api_token = ""  # type: ignore[attr-defined]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    host, port = httpd.server_address[0], httpd.server_address[1]
-    try:
-        yield host, port
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=5)
+    return create_app(
+        service=svc,
+        token_config={"valid-token": ApiToken("test-consumer")},
+    )
 
 
-def _http_get(host: str, port: int, path: str) -> tuple[int, dict]:
-    conn = HTTPConnection(host, port, timeout=5)
-    try:
-        conn.request("GET", path)
-        resp = conn.getresponse()
-        body = resp.read().decode("utf-8")
-    finally:
-        conn.close()
-    parsed = json.loads(body) if body else {}
-    return resp.status, parsed
+async def _async_get(app: FastAPI, path: str, *, token: str | None = "valid-token") -> tuple[int, dict]:
+    headers = {"X-API-Key": token} if token is not None else {}
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(path, headers=headers)
+    parsed = response.json() if response.content else {}
+    return response.status_code, parsed
+
+
+def _http_get(app: FastAPI, path: str, *, token: str | None = "valid-token") -> tuple[int, dict]:
+    return asyncio.run(_async_get(app, path, token=token))
 
 
 def test_http_route_returns_full_envelope(
     store: SQLiteEngineStore, live_server,
 ) -> None:
     _seed_nbs_cpi(store, months=[1, 2, 3])
-    host, port = live_server
-    status, payload = _http_get(host, port, "/v1/calendar")
+    status, payload = _http_get(live_server, "/v1/calendar")
     assert status == 200
     assert payload["meta"]["count"] == 3
     assert len(payload["data"]) == 3
@@ -356,9 +345,8 @@ def test_http_route_parses_jsonapi_pagination(
     store: SQLiteEngineStore, live_server,
 ) -> None:
     _seed_nbs_cpi(store, months=[1, 2, 3, 4, 5])
-    host, port = live_server
     status, payload = _http_get(
-        host, port, "/v1/calendar?page%5Boffset%5D=2&page%5Blimit%5D=2",
+        live_server, "/v1/calendar?page%5Boffset%5D=2&page%5Blimit%5D=2",
     )
     assert status == 200
     assert payload["meta"] == {"count": 5, "offset": 2, "limit": 2}
@@ -371,8 +359,7 @@ def test_http_route_applies_query_filters(
 ) -> None:
     _seed_nbs_cpi(store, months=[1, 2])
     _seed_ecb_dfr(store)
-    host, port = live_server
-    status, payload = _http_get(host, port, "/v1/calendar?provider=ecb")
+    status, payload = _http_get(live_server, "/v1/calendar?provider=ecb")
     assert status == 200
     assert payload["meta"]["count"] == 1
     assert payload["data"][0]["provider"] == "ecb"
@@ -381,8 +368,7 @@ def test_http_route_applies_query_filters(
 def test_http_route_empty_result_still_has_envelope(
     store: SQLiteEngineStore, live_server,
 ) -> None:
-    host, port = live_server
-    status, payload = _http_get(host, port, "/v1/calendar?provider=unknown")
+    status, payload = _http_get(live_server, "/v1/calendar?provider=unknown")
     assert status == 200
     assert payload["meta"]["count"] == 0
     assert payload["data"] == []
@@ -392,8 +378,7 @@ def test_http_route_empty_result_still_has_envelope(
 def test_http_route_unknown_path_returns_404(
     store: SQLiteEngineStore, live_server,
 ) -> None:
-    host, port = live_server
-    status, payload = _http_get(host, port, "/v1/does-not-exist")
+    status, payload = _http_get(live_server, "/v1/does-not-exist")
     assert status == 404
     assert "error" in payload
 
@@ -402,7 +387,6 @@ def test_healthz_still_responds(
     store: SQLiteEngineStore, live_server,
 ) -> None:
     # Safety rail — the new route must not shadow existing handlers.
-    host, port = live_server
-    status, payload = _http_get(host, port, "/healthz")
+    status, payload = _http_get(live_server, "/healthz", token=None)
     assert status == 200
     assert payload == {"status": "ok"}

--- a/tests/test_calendar_pit_as_of.py
+++ b/tests/test_calendar_pit_as_of.py
@@ -16,12 +16,12 @@ resolve. A separate corp dividend fixture exercises the C1 fallback.
 from __future__ import annotations
 
 import json
-import threading
+import asyncio
 from datetime import datetime, timedelta, timezone
-from http.client import HTTPConnection
-from http.server import ThreadingHTTPServer
 from pathlib import Path
 
+from fastapi import FastAPI
+import httpx
 import pytest
 
 from ingestion.calendar.nbs_api import release_entry_to_records
@@ -30,7 +30,7 @@ from ingestion.calendar._official_shared.projector import (
     project_events,
     store_raw,
 )
-from macro_data.server import MacroDataRequestHandler
+from macro_data.server import ApiToken, create_app
 from macro_data.service import LocalMacroDataService
 from storage.sqlite import SQLiteEngineStore
 
@@ -475,38 +475,29 @@ def test_service_op_no_corp_unsupported_flag(
 @pytest.fixture()
 def live_server(store: SQLiteEngineStore):
     svc = LocalMacroDataService(store=store)
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
-    httpd.service = svc  # type: ignore[attr-defined]
-    httpd.api_token = ""  # type: ignore[attr-defined]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    host, port = httpd.server_address[0], httpd.server_address[1]
-    try:
-        yield host, port
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=5)
+    return create_app(
+        service=svc,
+        token_config={"valid-token": ApiToken("test-consumer")},
+    )
 
 
-def _http_get(host: str, port: int, path: str) -> tuple[int, dict]:
-    conn = HTTPConnection(host, port, timeout=5)
-    try:
-        conn.request("GET", path)
-        resp = conn.getresponse()
-        body = resp.read().decode("utf-8")
-    finally:
-        conn.close()
-    return resp.status, json.loads(body) if body else {}
+async def _async_get(app: FastAPI, path: str) -> tuple[int, dict]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(path, headers={"X-API-Key": "valid-token"})
+    return response.status_code, response.json() if response.content else {}
+
+
+def _http_get(app: FastAPI, path: str) -> tuple[int, dict]:
+    return asyncio.run(_async_get(app, path))
 
 
 def test_http_route_as_of_resolves_vintage(
     store: SQLiteEngineStore, live_server,
 ) -> None:
     _seed_revised_econ_event(store)
-    host, port = live_server
     status, payload = _http_get(
-        host, port,
+        live_server,
         "/v1/calendar?as_of=2026-02-01T00:00:00%2B00:00",
     )
     assert status == 200
@@ -516,10 +507,9 @@ def test_http_route_as_of_resolves_vintage(
 def test_http_route_future_as_of_returns_400(
     store: SQLiteEngineStore, live_server,
 ) -> None:
-    host, port = live_server
     future = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
     status, payload = _http_get(
-        host, port,
+        live_server,
         f"/v1/calendar?as_of={future}",
     )
     assert status == 400

--- a/tests/test_data_manifest.py
+++ b/tests/test_data_manifest.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 import json
 import sys
-import threading
+import asyncio
 from datetime import datetime, timezone
-from http.client import HTTPConnection
-from http.server import ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
+from fastapi import FastAPI
+import httpx
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from ingestion.validation import ValidationStore
-from macro_data.server import MacroDataRequestHandler
+from macro_data.server import ApiToken, create_app
 from macro_data.service import LocalMacroDataService
 from storage.sqlite import (
     DocSourceRecord,
@@ -292,30 +292,22 @@ def test_clickhouse_manifest_stats_use_part_metadata() -> None:
 @pytest.fixture()
 def live_server(store: SQLiteEngineStore):
     service = LocalMacroDataService(store=store)
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
-    httpd.service = service  # type: ignore[attr-defined]
-    httpd.api_token = ""  # type: ignore[attr-defined]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    host, port = httpd.server_address[0], httpd.server_address[1]
-    try:
-        yield host, port
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=5)
+    return create_app(
+        service=service,
+        token_config={"valid-token": ApiToken("test-consumer")},
+    )
 
 
-def _http_get(host: str, port: int, path: str) -> tuple[int, dict[str, Any]]:
-    conn = HTTPConnection(host, port, timeout=5)
-    try:
-        conn.request("GET", path)
-        response = conn.getresponse()
-        raw = response.read().decode("utf-8")
-    finally:
-        conn.close()
-    payload = json.loads(raw) if raw else {}
-    return response.status, payload
+async def _async_get(app: FastAPI, path: str) -> tuple[int, dict[str, Any]]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(path, headers={"X-API-Key": "valid-token"})
+    payload = response.json() if response.content else {}
+    return response.status_code, payload
+
+
+def _http_get(app: FastAPI, path: str) -> tuple[int, dict[str, Any]]:
+    return asyncio.run(_async_get(app, path))
 
 
 def test_http_manifest_route_returns_manifest(
@@ -323,9 +315,8 @@ def test_http_manifest_route_returns_manifest(
     live_server,
 ) -> None:
     _seed_available_surfaces(store)
-    host, port = live_server
 
-    status, payload = _http_get(host, port, "/v1/manifest")
+    status, payload = _http_get(live_server, "/v1/manifest")
 
     assert status == 200
     rows = _by_dataset(payload)

--- a/tests/test_macro_data_http_client.py
+++ b/tests/test_macro_data_http_client.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any
+
+from macro_data.client import HttpMacroDataClient, MacroDataHttpConfig
+
+
+def test_http_client_sends_x_api_key(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"ok": True}
+
+    def fake_post(
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        timeout: float,
+    ) -> _Response:
+        captured.update({
+            "url": url,
+            "headers": headers,
+            "json": json,
+            "timeout": timeout,
+        })
+        return _Response()
+
+    monkeypatch.setattr("macro_data.client.httpx.post", fake_post)
+
+    client = HttpMacroDataClient(
+        MacroDataHttpConfig(
+            base_url="http://macro-data.test",
+            api_token="secret",
+            timeout_seconds=3.0,
+        )
+    )
+    assert client.invoke("list_items", {"family": "calendar"}) == {"ok": True}
+
+    assert captured["url"] == "http://macro-data.test/v1/ops/list_items"
+    assert captured["headers"] == {
+        "Content-Type": "application/json",
+        "X-API-Key": "secret",
+    }
+    assert captured["json"] == {"arguments": {"family": "calendar"}}
+    assert captured["timeout"] == 3.0

--- a/tests/test_public_ops_allowlist.py
+++ b/tests/test_public_ops_allowlist.py
@@ -1,37 +1,30 @@
-"""Public-read allowlist tests for ``POST /v1/ops/<op>`` (issue #104).
-
-Pre-VPS launch the public HTTP surface must only expose read ops; admin /
-write ops stay reachable through CLI / SSH / systemd. The allowlist lives
-in ``macro_data.server.PUBLIC_READ_OPS`` and gates the dispatcher in
-``do_POST`` — anything else returns HTTP 403 without ever reaching the
-service.
-"""
+"""Public-read allowlist tests for ``POST /v1/ops/<op>``."""
 
 from __future__ import annotations
 
+import asyncio
 import json
-import sys
-import threading
-from http.client import HTTPConnection
-from http.server import ThreadingHTTPServer
+import logging
 from pathlib import Path
+import sqlite3
+import time
 from typing import Any
 
+from fastapi import FastAPI
+import httpx
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
-
-from macro_data.server import PUBLIC_READ_OPS, MacroDataRequestHandler
+from macro_data.server import (
+    ApiToken,
+    FixedWindowRateLimiter,
+    PUBLIC_READ_OPS,
+    SQLiteFixedWindowRateLimiter,
+    create_app,
+    load_api_tokens,
+)
 
 
 class _RecordingService:
-    """Minimal stand-in for ``LocalMacroDataService``.
-
-    Returns a sentinel envelope and records the op name so tests can
-    assert that admin ops never reach ``invoke`` while allowed reads do.
-    """
-
     def __init__(self) -> None:
         self.invoked: list[tuple[str, dict[str, Any]]] = []
 
@@ -40,45 +33,83 @@ class _RecordingService:
         return {"ok": True, "operation": operation}
 
 
-@pytest.fixture()
-def live_server():
-    service = _RecordingService()
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
-    httpd.service = service  # type: ignore[attr-defined]
-    httpd.api_token = ""  # type: ignore[attr-defined]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    host, port = httpd.server_address[0], httpd.server_address[1]
-    try:
-        yield host, port, service
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=5)
+def _app(
+    service: _RecordingService,
+    *,
+    token: str = "valid-token",
+    consumer_id: str = "consumer-a",
+    rate_limit_per_minute: int = 1000,
+) -> FastAPI:
+    return create_app(
+        service=service,  # type: ignore[arg-type]
+        token_config={
+            token: ApiToken(
+                consumer_id=consumer_id,
+                rate_limit_per_minute=rate_limit_per_minute,
+            )
+        },
+        rate_limiter=FixedWindowRateLimiter(),
+    )
 
 
-def _http_post(host: str, port: int, path: str) -> tuple[int, dict[str, Any]]:
-    conn = HTTPConnection(host, port, timeout=5)
-    try:
-        body = json.dumps({"arguments": {}}).encode("utf-8")
-        conn.request(
-            "POST", path, body=body,
-            headers={"Content-Type": "application/json"},
+async def _request(
+    app: FastAPI,
+    method: str,
+    path: str,
+    *,
+    token: str | None = "valid-token",
+    json_body: dict[str, Any] | None = None,
+) -> httpx.Response:
+    headers = {"X-API-Key": token} if token is not None else {}
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        return await client.request(
+            method,
+            path,
+            json=json_body,
+            headers=headers,
         )
-        resp = conn.getresponse()
-        raw = resp.read().decode("utf-8")
-    finally:
-        conn.close()
-    parsed = json.loads(raw) if raw else {}
-    return resp.status, parsed
 
 
-# ── allowlist constant ────────────────────────────────────────────────
+def _run_request(
+    app: FastAPI,
+    method: str,
+    path: str,
+    *,
+    token: str | None = "valid-token",
+    json_body: dict[str, Any] | None = None,
+) -> httpx.Response:
+    return asyncio.run(
+        _request(
+            app,
+            method,
+            path,
+            token=token,
+            json_body=json_body,
+        )
+    )
+
+
+def _post(
+    app: FastAPI,
+    path: str,
+    *,
+    token: str | None = "valid-token",
+) -> tuple[int, dict[str, Any]]:
+    response = _run_request(
+        app,
+        "POST",
+        path,
+        token=token,
+        json_body={"arguments": {}},
+    )
+    return response.status_code, response.json()
 
 
 def test_public_read_ops_matches_issue_104_contract() -> None:
-    """The exact set called out in the issue body. Adding or removing
-    entries is a contract change — this guards against silent drift."""
     assert PUBLIC_READ_OPS == frozenset({
         "resolve_indicator",
         "resolve_indicator_history",
@@ -90,19 +121,47 @@ def test_public_read_ops_matches_issue_104_contract() -> None:
     })
 
 
-# ── allowed read ops ──────────────────────────────────────────────────
-
-
 @pytest.mark.parametrize("op", sorted(PUBLIC_READ_OPS))
-def test_allowed_read_op_reaches_service(live_server, op: str) -> None:
-    host, port, service = live_server
-    status, payload = _http_post(host, port, f"/v1/ops/{op}")
+def test_allowed_read_op_with_valid_token_reaches_service(op: str) -> None:
+    service = _RecordingService()
+    app = _app(service)
+    status, payload = _post(app, f"/v1/ops/{op}")
     assert status == 200, f"{op} should be reachable, got {status} {payload}"
     assert payload == {"ok": True, "operation": op}
     assert service.invoked == [(op, {})]
 
 
-# ── blocked admin / write ops ─────────────────────────────────────────
+@pytest.mark.parametrize("op", sorted(PUBLIC_READ_OPS))
+def test_allowed_read_op_with_invalid_token_returns_401(op: str) -> None:
+    service = _RecordingService()
+    app = _app(service)
+    status, payload = _post(app, f"/v1/ops/{op}", token="wrong")
+    assert status == 401
+    assert payload == {"error": "unauthorized"}
+    assert service.invoked == []
+
+
+@pytest.mark.parametrize("op", sorted(PUBLIC_READ_OPS))
+def test_allowed_read_op_without_token_returns_401(op: str) -> None:
+    service = _RecordingService()
+    app = _app(service)
+    status, payload = _post(app, f"/v1/ops/{op}", token=None)
+    assert status == 401
+    assert payload == {"error": "unauthorized"}
+    assert service.invoked == []
+
+
+@pytest.mark.parametrize("op", sorted(PUBLIC_READ_OPS))
+def test_allowed_read_op_hits_per_token_rate_limit(op: str) -> None:
+    service = _RecordingService()
+    app = _app(service, rate_limit_per_minute=1)
+    first_status, first_payload = _post(app, f"/v1/ops/{op}")
+    second_status, second_payload = _post(app, f"/v1/ops/{op}")
+    assert first_status == 200
+    assert first_payload == {"ok": True, "operation": op}
+    assert second_status == 429
+    assert second_payload == {"error": "rate limit exceeded"}
+    assert service.invoked == [(op, {})]
 
 
 @pytest.mark.parametrize("op", [
@@ -125,91 +184,140 @@ def test_allowed_read_op_reaches_service(live_server, op: str) -> None:
     "fetch_article",
     "backfill_document_indexes",
 ])
-def test_blocked_admin_op_returns_403(live_server, op: str) -> None:
-    """Admin / write ops the issue calls out must return 403 and must
-    never reach the service. The list mixes representative writes
-    (``refresh_*``, ``sync_catalog_*``, ``backfill_*``) with fetchers
-    that hit external APIs and would be expensive / destructive on a
-    public surface (``fetch_live_*``, ``fundamentals_fetch``)."""
-    host, port, service = live_server
-    status, payload = _http_post(host, port, f"/v1/ops/{op}")
+def test_blocked_admin_op_returns_403(op: str) -> None:
+    service = _RecordingService()
+    app = _app(service)
+    status, payload = _post(app, f"/v1/ops/{op}")
     assert status == 403, f"{op} must be 403, got {status} {payload}"
     assert payload == {"error": "operation not permitted on public API"}
-    assert service.invoked == [], (
-        f"blocked op {op} reached the service: {service.invoked}"
-    )
+    assert service.invoked == []
 
 
-def test_unknown_op_returns_403_not_404(live_server) -> None:
-    """Unknown ops must look identical to disallowed ops on the public
-    surface — the HTTP layer does not leak which ops exist on the
-    underlying service. Pre-allowlist this returned 404 (KeyError from
-    ``invoke``); the allowlist now intercepts it as 403."""
-    host, port, service = live_server
-    status, payload = _http_post(host, port, "/v1/ops/totally_made_up_op")
+def test_unknown_op_returns_403() -> None:
+    service = _RecordingService()
+    app = _app(service)
+    status, payload = _post(app, "/v1/ops/totally_made_up_op")
     assert status == 403
     assert payload == {"error": "operation not permitted on public API"}
     assert service.invoked == []
 
 
-# ── auth interaction ──────────────────────────────────────────────────
-
-
-def test_unauthorized_blocks_before_allowlist_check(tmp_path: Path) -> None:
-    """When an API token is configured, unauthenticated callers see 401
-    regardless of whether the op is on the allowlist — auth is the
-    outer gate, allowlist is the inner gate."""
+def test_healthz_exempts_token_auth() -> None:
     service = _RecordingService()
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
-    httpd.service = service  # type: ignore[attr-defined]
-    httpd.api_token = "secret"  # type: ignore[attr-defined]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    host, port = httpd.server_address[0], httpd.server_address[1]
-    try:
-        # Allowed op without token → 401, not 200 and not 403.
-        status, payload = _http_post(host, port, "/v1/ops/list_items")
-        assert status == 401
-        assert payload == {"error": "unauthorized"}
-        # Blocked op without token → also 401, the auth check comes first.
-        status, payload = _http_post(host, port, "/v1/ops/refresh_source")
-        assert status == 401
-        assert service.invoked == []
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=5)
+    app = _app(service)
+    response = _run_request(app, "GET", "/healthz", token=None)
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
 
 
-def test_authorized_admin_op_still_returns_403(tmp_path: Path) -> None:
-    """A valid bearer token does not grant access to admin ops on the
-    public surface — the allowlist is operation-scoped, not auth-scoped."""
+def test_health_requires_token_before_service_call() -> None:
     service = _RecordingService()
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), MacroDataRequestHandler)
-    httpd.service = service  # type: ignore[attr-defined]
-    httpd.api_token = "secret"  # type: ignore[attr-defined]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    host, port = httpd.server_address[0], httpd.server_address[1]
-    try:
-        conn = HTTPConnection(host, port, timeout=5)
-        try:
-            conn.request(
-                "POST", "/v1/ops/refresh_all_sources",
-                body=b'{"arguments": {}}',
-                headers={
-                    "Content-Type": "application/json",
-                    "Authorization": "Bearer secret",
+    app = _app(service)
+    response = _run_request(app, "GET", "/health", token=None)
+    assert response.status_code == 401
+    assert response.json() == {"error": "unauthorized"}
+    assert service.invoked == []
+
+
+def test_token_file_loads_consumer_and_rate_overrides(tmp_path: Path) -> None:
+    token_path = tmp_path / "api_tokens.json"
+    token_path.write_text(
+        json.dumps({
+            "tokens": {
+                "alpha": {
+                    "consumer_id": "consumer-alpha",
+                    "rate_limit_per_minute": 7,
                 },
-            )
-            resp = conn.getresponse()
-            raw = resp.read().decode("utf-8")
-        finally:
-            conn.close()
-        assert resp.status == 403
-        assert json.loads(raw) == {"error": "operation not permitted on public API"}
-        assert service.invoked == []
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=5)
+                "beta": "consumer-beta",
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    tokens = load_api_tokens(token_path)
+
+    assert tokens["alpha"] == ApiToken(
+        consumer_id="consumer-alpha",
+        rate_limit_per_minute=7,
+    )
+    assert tokens["beta"] == ApiToken(
+        consumer_id="consumer-beta",
+        rate_limit_per_minute=60,
+    )
+
+
+def test_inline_token_preserves_file_metadata(tmp_path: Path) -> None:
+    token_path = tmp_path / "api_tokens.json"
+    token_path.write_text(
+        json.dumps({
+            "tokens": {
+                "alpha": {
+                    "consumer_id": "consumer-alpha",
+                    "rate_limit_per_minute": 7,
+                },
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    tokens = load_api_tokens(token_path, inline_api_token="alpha")
+
+    assert tokens["alpha"] == ApiToken(
+        consumer_id="consumer-alpha",
+        rate_limit_per_minute=7,
+    )
+
+
+def test_sqlite_rate_limiter_shares_windows_across_instances(tmp_path: Path) -> None:
+    db_path = tmp_path / "rate-limit.sqlite3"
+    first = SQLiteFixedWindowRateLimiter(db_path)
+    second = SQLiteFixedWindowRateLimiter(db_path)
+
+    assert first.check("token-a", 1) == (True, 0)
+    allowed, retry_after = second.check("token-a", 1)
+
+    assert allowed is False
+    assert retry_after > 0
+
+
+def test_sqlite_rate_limiter_persists_epoch_window_start(tmp_path: Path) -> None:
+    db_path = tmp_path / "rate-limit.sqlite3"
+    limiter = SQLiteFixedWindowRateLimiter(db_path)
+
+    before = time.time()
+    assert limiter.check("token-a", 10) == (True, 0)
+    after = time.time()
+
+    with sqlite3.connect(db_path) as connection:
+        row = connection.execute(
+            "SELECT window_start FROM rate_limit_windows"
+        ).fetchone()
+
+    assert row is not None
+    assert before <= float(row[0]) <= after
+
+
+def test_access_log_is_structured_json(caplog: pytest.LogCaptureFixture) -> None:
+    service = _RecordingService()
+    app = _app(service, consumer_id="consumer-log")
+    caplog.set_level(logging.INFO, logger="macro_data.access")
+
+    response = _run_request(
+        app,
+        "POST",
+        "/v1/ops/list_items",
+        token="valid-token",
+        json_body={"arguments": {}},
+    )
+
+    assert response.status_code == 200
+    payloads = [
+        json.loads(record.message)
+        for record in caplog.records
+        if record.name == "macro_data.access"
+    ]
+    assert payloads[-1]["method"] == "POST"
+    assert payloads[-1]["path"] == "/v1/ops/list_items"
+    assert payloads[-1]["status"] == 200
+    assert payloads[-1]["consumer_id"] == "consumer-log"
+    assert isinstance(payloads[-1]["latency_ms"], float)

--- a/tests/test_read_only_service.py
+++ b/tests/test_read_only_service.py
@@ -227,35 +227,49 @@ def test_read_only_factory_requires_bootstrap_rows(tmp_path: Path) -> None:
         build_read_only_macro_data_service(db_path=db_path)
 
 
-def test_server_main_uses_read_only_factory(
+def test_create_app_defers_token_file_parse_until_startup(tmp_path: Path) -> None:
+    token_path = tmp_path / "api_tokens.json"
+    token_path.write_text("not json", encoding="utf-8")
+
+    app = server.create_app(
+        service_factory=lambda: object(),  # type: ignore[return-value]
+        token_path=token_path,
+    )
+
+    assert app.state.api_tokens == {}
+
+
+def test_server_main_configures_uvicorn_entrypoint(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: dict[str, Any] = {}
-    sentinel_service = object()
-
-    def fake_build_read_only_macro_data_service(
-        db_path: Path | None = None,
-    ) -> object:
-        calls["db_path"] = db_path
-        return sentinel_service
 
     def fake_serve(**kwargs: Any) -> None:
         calls["serve"] = kwargs
 
-    monkeypatch.setattr(
-        factory,
-        "build_read_only_macro_data_service",
-        fake_build_read_only_macro_data_service,
-    )
     monkeypatch.setattr(server, "serve", fake_serve)
+    monkeypatch.setenv("ANALYST_MACRO_DATA_DB_PATH", "")
+    monkeypatch.setenv("ANALYST_MACRO_DATA_API_TOKEN", "")
+    monkeypatch.setenv("ANALYST_MACRO_DATA_API_TOKENS_PATH", "")
 
     db_path = tmp_path / "engine.db"
+    token_path = tmp_path / "api_tokens.json"
     result = server.main([
         "--host", "127.0.0.1",
         "--port", "0",
         "--db-path", str(db_path),
+        "--api-token", "secret",
+        "--api-tokens-path", str(token_path),
+        "--workers", "3",
     ])
 
     assert result == 0
-    assert calls["db_path"] == db_path
-    assert calls["serve"]["service"] is sentinel_service
+    assert os.environ["ANALYST_MACRO_DATA_DB_PATH"] == str(db_path)
+    assert os.environ["ANALYST_MACRO_DATA_API_TOKEN"] == "secret"
+    assert os.environ["ANALYST_MACRO_DATA_API_TOKENS_PATH"] == str(token_path)
+    assert calls["serve"] == {
+        "host": "127.0.0.1",
+        "port": 0,
+        "api_token": "secret",
+        "workers": 3,
+    }


### PR DESCRIPTION
Closes #134

## Shipped
- Migrates the public HTTP server to FastAPI served by uvicorn with worker count from env or CLI.
- Adds X-API-Key middleware, startup token-file loading, per-token limits, shared SQLite rate-limit state for worker processes, and structured JSON access logs.
- Preserves PUBLIC_READ_OPS semantics and keeps existing read endpoints available behind API-key auth while leaving /healthz open.
- Updates the HTTP client, CLI serve flags, README, and architecture docs.

## Verification
- PYTHONPATH=src python3 -m py_compile src/macro_data/server.py src/macro_data/client.py src/macro_data/cli.py
- git diff --check
- PYTHONPATH=src timeout 180s pytest tests/test_read_only_service.py tests/test_public_ops_allowlist.py tests/test_calendar_http_route.py tests/test_calendar_pit_as_of.py tests/test_calendar_corp_revisions.py tests/test_data_manifest.py tests/market/fundamentals/eodhd/test_http_route.py tests/test_macro_data_http_client.py tests/test_macro_data_cli.py tests/test_unified_api_ops.py tests/test_production_regressions.py

## Review
- Codex review round 1 found blocking service calls and per-worker limiter state; both fixed.
- Codex review round 2 found persisted-window clock and inline-token precedence issues; both fixed.