### PR TITLE
fix(cli): gate local writer ops by profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ PYTHONPATH=src python3 scripts/backfill_market_history.py --status active
 PYTHONPATH=src python3 scripts/market_daily_refresh.py --date 2026-05-01
 ```
 
+Writer and source-diagnostic commands run on the VPS with
+`MACRO_DATA_PROFILE=prod`. Local fixture/debug writer runs use
+`--allow-local-write` and a temporary `--db-path`.
+
 ### Resolution
 
 ```bash
@@ -471,10 +475,12 @@ API token file shape:
 
 ### Environment variables
 
-`src/env.py` reads from process env first, then `.env` at the repo root.
+`src/env.py` reads from process env first, then `.env` at the repo root, then
+`~/.macro-data/dev.env`.
 
 | Variable | Used by | Required? |
 |---|---|---|
+| `MACRO_DATA_PROFILE` | Deployment profile: `dev` local client, `prod` VPS writer/API | optional; default `dev` |
 | `FRED_API_KEY` | FRED series, FX, and macro-market rate/FX projection | yes for any FRED data |
 | `BLS_API_KEY` | BLS series | yes for BLS |
 | `BEA_API_KEY` | BEA series | yes for BEA |
@@ -488,6 +494,7 @@ API token file shape:
 | `ANALYST_MACRO_DATA_API_TOKENS_PATH` | FastAPI public API token mapping path | optional; default `/etc/macro-data/api_tokens.json` |
 | `ANALYST_MACRO_DATA_RATE_LIMIT_DB` | shared SQLite fixed-window rate-limit state | optional; default `/tmp/macro-data-api-rate-limits.sqlite3` |
 | `ANALYST_MACRO_DATA_WORKERS` | uvicorn worker count for `macro-data-service serve` | optional; default `2` |
+| `ANALYST_MACRO_DATA_BASE_URL` | dev-profile client base URL for prod API reads | yes for local `resolve` |
 | `ANALYST_MACRO_DATA_API_TOKEN` | client token sent as `X-API-Key`; server also accepts it as a local inline token for CLI launches | optional |
 
 ## Agent wiring

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,31 @@ the resolution layer.
 
 ---
 
+## Deployment topology
+
+Production has two VPS lanes and one local client lane.
+
+| Lane | Host | Responsibilities | Profile |
+|---|---|---|---|
+| Writer lane | VPS | Ingestion, release-aware refresh, calendar value sweeps, data-quality filing, backup snapshots, market/fundamentals refreshes | `MACRO_DATA_PROFILE=prod` |
+| Reader lane | VPS | `macro-data-api` / `macro-data-service serve`, public read ops, rate limiting, `X-API-Key` auth | `MACRO_DATA_PROFILE=prod` |
+| Local lane | Laptop / workstation | Development, parser/unit tests, read-only calls to the production API | `MACRO_DATA_PROFILE=dev` |
+
+`MACRO_DATA_PROFILE` defaults to `dev`. In the dev profile,
+`macro-data-service resolve ...` calls the HTTP API configured by
+`ANALYST_MACRO_DATA_BASE_URL` and sends `ANALYST_MACRO_DATA_API_TOKEN` as
+`X-API-Key`; both values can live in `~/.macro-data/dev.env`. Local writer CLI
+ops (`refresh`, `refresh-source`, `refresh-indicator`, catalog sync/refresh
+ops, `diagnose-sources`, `launch-gate`, and `schedule --run`) require either
+`MACRO_DATA_PROFILE=prod` or an explicit `--allow-local-write` debug/fixture
+override.
+
+Local tests use temporary DBs and fixtures. VPS systemd writer units set
+`Environment=MACRO_DATA_PROFILE=prod`, which gives ingestion ownership to the
+always-on host and keeps local work in the dev/read-only client lane.
+
+---
+
 ## Layers
 
 | Layer | Lives in | Role |

--- a/docs/dev_workflow.md
+++ b/docs/dev_workflow.md
@@ -1,0 +1,68 @@
+# Development Workflow
+
+This workflow keeps local development in the dev/read-only client lane and
+ships writer work through the VPS.
+
+## Local setup
+
+Create `~/.macro-data/dev.env` with the production API endpoint and token:
+
+```bash
+ANALYST_MACRO_DATA_BASE_URL=https://<prod-api-host>
+ANALYST_MACRO_DATA_API_TOKEN=<token>
+```
+
+`MACRO_DATA_PROFILE` defaults to `dev`. Read checks use the prod API:
+
+```bash
+macro-data-service resolve CPI_US --json
+```
+
+Local writer commands require the explicit debug flag:
+
+```bash
+macro-data-service refresh-source --source fred --allow-local-write --db-path /tmp/macro-data-dev.db
+```
+
+Use that path for fixture/debug runs with a temporary DB. Keep routine
+ingestion, release-aware refresh, launch-gate/data-quality filing, and backups
+on the VPS.
+
+## New fetcher to production
+
+1. Add or update the fetcher/parser code under `src/ingestion/...`.
+2. Add fixture-backed parser/projector tests under `tests/fixtures/...` and
+   `tests/...`.
+3. Run the focused local tests against fixtures and temporary DBs:
+
+   ```bash
+   pytest tests/test_<provider>.py
+   ```
+
+4. Push the branch:
+
+   ```bash
+   git push -u origin <branch>
+   ```
+
+5. Deploy on the VPS:
+
+   ```bash
+   ssh vps 'git -C /opt/macro-data pull && systemctl --user restart <unit>'
+   ```
+
+6. Verify the production unit:
+
+   ```bash
+   ssh vps 'journalctl --user -u <unit> -n 100 --no-pager'
+   ```
+
+7. Verify a read path from local dev:
+
+   ```bash
+   macro-data-service resolve <CONCEPT_ID> --json
+   ```
+
+The production systemd units carry `Environment=MACRO_DATA_PROFILE=prod`; local
+commands stay in `dev` unless a fixture/debug run opts into
+`--allow-local-write`.

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -3,6 +3,9 @@
 Files in this directory wire the recurring calendar jobs into
 `systemd --user` timers:
 
+Each service sets `Environment=MACRO_DATA_PROFILE=prod` so recurring writer
+jobs run under the VPS writer profile.
+
 | Unit | Cadence | Purpose | Issue |
 | --- | --- | --- | --- |
 | `calendar-schedule-refresh.timer` | daily 04:00 UTC | every connector pulls forward-looking schedule rows | #31 |

--- a/scripts/systemd/calendar-corp-backfill.service
+++ b/scripts/systemd/calendar-corp-backfill.service
@@ -19,6 +19,7 @@ Type=oneshot
 # Default is a dry-run plan — no credentials touched, no DB writes — so
 # `systemctl start` without overrides is safe.
 Environment="REPO_ROOT=%h/Desktop/analyst/macro-data-service"
+Environment="MACRO_DATA_PROFILE=prod"
 Environment="CORP_BACKFILL_ARGS=--dry-run --subtype split --phase early"
 WorkingDirectory=%h/Desktop/analyst/macro-data-service
 ExecStart=/bin/sh -c '%h/Desktop/analyst/macro-data-service/scripts/backfill_corp_calendar.py $CORP_BACKFILL_ARGS'

--- a/scripts/systemd/calendar-corp-forward.service
+++ b/scripts/systemd/calendar-corp-forward.service
@@ -9,6 +9,7 @@ Type=oneshot
 # close). The wrapper resolves .macro-data/, .env, and scripts/ relative
 # to REPO_ROOT and acquires the shared calendar_recurring.lock.
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/calendar_corp_forward_wrapper.sh
 
 # Soft watchdog — five subtypes × max 30 requests at EODHD's free-tier

--- a/scripts/systemd/calendar-schedule-refresh.service
+++ b/scripts/systemd/calendar-schedule-refresh.service
@@ -9,6 +9,7 @@ Type=oneshot
 # /home/rick/Desktop/analyst/macro-data-service. The wrapper resolves
 # .macro-data/, .env, and scripts/ relative to it.
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/calendar_refresh_schedules_wrapper.sh
 
 # Soft watchdog — 28 connectors at a few seconds each, plus per-connector

--- a/scripts/systemd/calendar-value-sweep.service
+++ b/scripts/systemd/calendar-value-sweep.service
@@ -9,6 +9,7 @@ Type=oneshot
 # /home/rick/Desktop/analyst/macro-data-service. The wrapper resolves
 # .macro-data/, .env, and scripts/ relative to it.
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/calendar_sweep_values_wrapper.sh
 
 # Soft watchdog — the hourly sweep is recent-window only, so a clean

--- a/scripts/systemd/fundamentals-forward.service
+++ b/scripts/systemd/fundamentals-forward.service
@@ -9,6 +9,7 @@ Type=oneshot
 # .env, and scripts/ relative to REPO_ROOT and acquires the
 # fundamentals_recurring.lock so two timers cannot race the engine DB.
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/backfill_fundamentals_wrapper.sh
 
 # Soft watchdog — 17-ticker default × 1 request each fits comfortably

--- a/scripts/systemd/macro-data-market-refresh.service
+++ b/scripts/systemd/macro-data-market-refresh.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/market_daily_refresh_wrapper.sh
 TimeoutStartSec=7200
 Restart=no

--- a/scripts/systemd/macro-data-market-self-heal.service
+++ b/scripts/systemd/macro-data-market-self-heal.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/market_self_heal_wrapper.sh
 TimeoutStartSec=7200
 Restart=no

--- a/scripts/systemd/macro-data-market-spot-check.service
+++ b/scripts/systemd/macro-data-market-spot-check.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/market_spot_check_wrapper.sh
 TimeoutStartSec=900
 Restart=no

--- a/scripts/systemd/macro-data-release-watch.service
+++ b/scripts/systemd/macro-data-release-watch.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/release_aware_refresh_wrapper.sh
 
 TimeoutStartSec=300

--- a/scripts/systemd/parity-daily.service
+++ b/scripts/systemd/parity-daily.service
@@ -17,6 +17,7 @@ Type=oneshot
 # /home/rick/Desktop/analyst/macro-data-service. The wrapper resolves
 # .macro-data/, .env, and scripts/ relative to it.
 Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
 ExecStart=%h/Desktop/analyst/macro-data-service/scripts/parity_daily_wrapper.sh
 
 # Soft watchdog — the daily pull plus comparator plus gh issue calls

--- a/src/env.py
+++ b/src/env.py
@@ -6,7 +6,19 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_ENV_FILES = (PROJECT_ROOT / ".env",)
+DEFAULT_PROFILE = "dev"
+VALID_PROFILES = frozenset({"dev", "prod"})
+DEFAULT_ENV_FILES = (
+    PROJECT_ROOT / ".env",
+    Path.home() / ".macro-data" / "dev.env",
+)
+
+
+def default_env_files() -> tuple[Path, ...]:
+    configured = os.environ.get("MACRO_DATA_ENV_FILES", "").strip()
+    if configured:
+        return tuple(Path(path).expanduser() for path in configured.split(os.pathsep) if path)
+    return DEFAULT_ENV_FILES
 
 
 @lru_cache(maxsize=None)
@@ -28,13 +40,22 @@ def get_env_value(*keys: str, default: str = "") -> str:
         value = os.environ.get(key)
         if value:
             return value
-    for env_file in DEFAULT_ENV_FILES:
+    for env_file in default_env_files():
         values = _read_env_file(env_file)
         for key in keys:
             value = values.get(key)
             if value:
                 return value
     return default
+
+
+def get_macro_data_profile() -> str:
+    profile = get_env_value("MACRO_DATA_PROFILE", default=DEFAULT_PROFILE).strip().lower()
+    profile = profile or DEFAULT_PROFILE
+    if profile not in VALID_PROFILES:
+        valid = ", ".join(sorted(VALID_PROFILES))
+        raise ValueError(f"MACRO_DATA_PROFILE must be one of: {valid}")
+    return profile
 
 
 def clear_env_cache() -> None:

--- a/src/macro_data/cli.py
+++ b/src/macro_data/cli.py
@@ -15,7 +15,58 @@ from ingestion.sources import (
     render_wb_series_configs,
 )
 
+from env import get_macro_data_profile
+
+from .client import HttpMacroDataClient, MacroDataHttpConfig
 from .server import main as serve_main
+
+
+class LocalWriterGuardError(RuntimeError):
+    pass
+
+
+_WRITER_GUARDED_COMMANDS = frozenset({
+    "refresh",
+    "refresh-source",
+    "refresh-indicator",
+    "news-refresh",
+    "oecd-refresh-catalog",
+    "wb-refresh-catalog",
+    "catalog-sync-discovery",
+    "catalog-sync-latest",
+    "diagnose-sources",
+    "launch-gate",
+})
+
+
+def _add_allow_local_write_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--allow-local-write",
+        action="store_true",
+        help="Allow this writer op in dev profile for fixture/debug runs.",
+    )
+
+
+def _is_writer_command(args: argparse.Namespace) -> bool:
+    if args.command in _WRITER_GUARDED_COMMANDS:
+        return True
+    if args.command == "catalog-list" and bool(getattr(args, "refresh", False)):
+        return True
+    if args.command == "schedule":
+        return bool(args.run or not (args.show or args.due or args.status))
+    return False
+
+
+def _guard_writer_command(args: argparse.Namespace) -> None:
+    if not _is_writer_command(args) or bool(getattr(args, "allow_local_write", False)):
+        return
+    profile = get_macro_data_profile()
+    if profile != "prod":
+        raise LocalWriterGuardError(
+            "writer ops run only on the VPS. "
+            "Set MACRO_DATA_PROFILE=prod in the VPS systemd unit, "
+            "or pass --allow-local-write for a local fixture/debug run."
+        )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -32,6 +83,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     refresh = subparsers.add_parser("refresh")
     refresh.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(refresh)
 
     schedule = subparsers.add_parser("schedule")
     schedule.add_argument("--show", action="store_true", help="Show all concepts with next expected release")
@@ -42,6 +94,7 @@ def build_parser() -> argparse.ArgumentParser:
     schedule.add_argument("--poll-interval", type=int, default=300, help="Poll interval seconds")
     schedule.add_argument("--json", action="store_true", dest="json_output")
     schedule.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(schedule)
 
     health = subparsers.add_parser("health")
     health.add_argument("--indicator", default=None, help="Filter to a single indicator")
@@ -52,10 +105,12 @@ def build_parser() -> argparse.ArgumentParser:
     news_refresh = subparsers.add_parser("news-refresh")
     news_refresh.add_argument("--category", default=None)
     news_refresh.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(news_refresh)
 
     refresh_source = subparsers.add_parser("refresh-source")
     refresh_source.add_argument("--source", required=True)
     refresh_source.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(refresh_source)
 
     list_sources = subparsers.add_parser("list-sources")
     list_sources.add_argument("--family", default=None)
@@ -75,6 +130,7 @@ def build_parser() -> argparse.ArgumentParser:
     catalog_list.add_argument("--limit", type=int, default=100)
     catalog_list.add_argument("--refresh", action="store_true")
     catalog_list.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(catalog_list)
 
     catalog_structure = subparsers.add_parser("catalog-structure")
     catalog_structure.add_argument("--source", required=True)
@@ -86,12 +142,14 @@ def build_parser() -> argparse.ArgumentParser:
     catalog_sync_discovery.add_argument("--query", default=None)
     catalog_sync_discovery.add_argument("--limit", type=int, default=None)
     catalog_sync_discovery.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(catalog_sync_discovery)
 
     catalog_sync_latest = subparsers.add_parser("catalog-sync-latest")
     catalog_sync_latest.add_argument("--source", required=True)
     catalog_sync_latest.add_argument("--entity", action="append", dest="entities", default=None)
     catalog_sync_latest.add_argument("--limit", type=int, default=None)
     catalog_sync_latest.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(catalog_sync_latest)
 
     catalog_status = subparsers.add_parser("catalog-status")
     catalog_status.add_argument("--source", default=None)
@@ -125,6 +183,7 @@ def build_parser() -> argparse.ArgumentParser:
     oecd_refresh.add_argument("--latest-observations", type=int, default=1)
     oecd_refresh.add_argument("--sleep-seconds", type=float, default=1.2)
     oecd_refresh.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(oecd_refresh)
 
     # -- World Bank catalog commands --
     subparsers.add_parser("wb-sources")
@@ -151,6 +210,7 @@ def build_parser() -> argparse.ArgumentParser:
     wb_refresh.add_argument("--latest-observations", type=int, default=5)
     wb_refresh.add_argument("--sleep-seconds", type=float, default=0.3)
     wb_refresh.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(wb_refresh)
 
     validate = subparsers.add_parser("validate")
     validate.add_argument("--source", default=None, help="Validate a single source")
@@ -183,6 +243,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Use an empty market-bars inventory instead of probing ClickHouse.",
     )
     launch_gate.add_argument("--json", action="store_true", dest="json_output")
+    _add_allow_local_write_argument(launch_gate)
 
     refresh_indicator = subparsers.add_parser("refresh-indicator")
     refresh_indicator.add_argument("concept_id", help="Concept ID (e.g. CPI_US)")
@@ -190,6 +251,7 @@ def build_parser() -> argparse.ArgumentParser:
     refresh_indicator.add_argument("--validate", action="store_true", help="Run validation after ingestion")
     refresh_indicator.add_argument("--json", action="store_true", dest="json_output", help="JSON output")
     refresh_indicator.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(refresh_indicator)
 
     validate_concept = subparsers.add_parser("validate-concept")
     validate_concept.add_argument("concept_id", nargs="?", default=None, help="Concept ID (e.g. CPI_US)")
@@ -220,6 +282,7 @@ def build_parser() -> argparse.ArgumentParser:
     diagnose = subparsers.add_parser("diagnose-sources")
     diagnose.add_argument("--json", action="store_true", dest="json_output")
     diagnose.add_argument("--db-path", default=None)
+    _add_allow_local_write_argument(diagnose)
 
     return parser
 
@@ -624,7 +687,85 @@ def _run_refresh_indicator(args: argparse.Namespace) -> int:
     return 0 if not report.error else 1
 
 
-def _run_resolve(args: argparse.Namespace) -> int:
+def _resolve_arguments(args: argparse.Namespace) -> dict[str, object]:
+    arguments: dict[str, object] = {"concept_id": args.concept_id}
+    if args.date:
+        arguments["date"] = args.date
+    if getattr(args, "as_of", None):
+        arguments["as_of"] = args.as_of
+    if args.min_vintage_quality:
+        arguments["min_vintage_quality"] = args.min_vintage_quality
+    if args.history:
+        arguments["limit"] = args.limit
+    return arguments
+
+
+def _print_resolve_history(rows: list[dict[str, object]]) -> None:
+    for row in rows:
+        alt_count = row.get("alternates") or 0
+        alt = f"+{alt_count}" if alt_count else ""
+        provenance = row.get("provenance") or "native"
+        tag = f" [{provenance}]" if provenance != "native" else ""
+        print(f"  {row.get('date')}  {float(row.get('value', 0.0)):>12.4f}  "
+              f"{row.get('source_id', ''):<18}  "
+              f"p={row.get('priority')}  {row.get('role')}{alt and '  alt=' + alt}{tag}")
+
+
+def _print_resolve_observation(row: dict[str, object]) -> None:
+    alt = f"  alt={row.get('alternates')}" if row.get("alternates") else ""
+    print(f"  {row.get('concept_id')}  {row.get('date')}  {float(row.get('value', 0.0)):.4f}  "
+          f"source={row.get('source_id')}  series={row.get('provider_series_id')}  "
+          f"p={row.get('priority')}  {row.get('role')}{alt}")
+
+
+def _run_resolve_http(args: argparse.Namespace) -> int:
+    config = MacroDataHttpConfig.from_env()
+    if config is None:
+        print(
+            "dev profile resolve requires ANALYST_MACRO_DATA_BASE_URL "
+            "in ~/.macro-data/dev.env or process env.",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = HttpMacroDataClient(config)
+    operation = "resolve_indicator_history" if args.history else "resolve_indicator"
+    try:
+        payload = client.invoke(operation, _resolve_arguments(args))
+    except Exception as exc:
+        print(f"prod API resolve failed at {config.base_url}: {exc}", file=sys.stderr)
+        return 1
+
+    if payload.get("error"):
+        if args.json_output:
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+        else:
+            print(str(payload["error"]), file=sys.stderr)
+        return 1
+
+    if args.history:
+        rows = payload.get("observations") or []
+        if not isinstance(rows, list) or not rows:
+            print(f"No data found for {args.concept_id}")
+            return 1
+        if args.json_output:
+            print(json.dumps(rows, ensure_ascii=False, indent=2))
+        else:
+            _print_resolve_history([dict(row) for row in rows if isinstance(row, dict)])
+        return 0
+
+    obs = payload.get("resolved")
+    if not isinstance(obs, dict):
+        print(f"No data found for {args.concept_id}" + (f" on {args.date}" if args.date else ""))
+        return 1
+    if args.json_output:
+        print(json.dumps(obs, ensure_ascii=False, indent=2))
+    else:
+        _print_resolve_observation(dict(obs))
+    return 0
+
+
+def _run_resolve_local(args: argparse.Namespace) -> int:
     from dataclasses import asdict
     from storage import SQLiteEngineStore
 
@@ -646,11 +787,7 @@ def _run_resolve(args: argparse.Namespace) -> int:
         if args.json_output:
             print(json.dumps([asdict(r) for r in results], ensure_ascii=False, indent=2))
         else:
-            for r in results:
-                alt = f"+{r.alternates}" if r.alternates else ""
-                tag = f" [{r.provenance}]" if r.provenance != "native" else ""
-                print(f"  {r.date}  {r.value:>12.4f}  {r.source_id:<18}  "
-                      f"p={r.priority}  {r.role}{alt and '  alt=' + alt}{tag}")
+            _print_resolve_history([asdict(r) for r in results])
         return 0
 
     obs = store.resolve_indicator(
@@ -665,11 +802,19 @@ def _run_resolve(args: argparse.Namespace) -> int:
     if args.json_output:
         print(json.dumps(asdict(obs), ensure_ascii=False, indent=2))
     else:
-        alt = f"  alt={obs.alternates}" if obs.alternates else ""
-        print(f"  {obs.concept_id}  {obs.date}  {obs.value:.4f}  "
-              f"source={obs.source_id}  series={obs.provider_series_id}  "
-              f"p={obs.priority}  {obs.role}{alt}")
+        _print_resolve_observation(asdict(obs))
     return 0
+
+
+def _run_resolve(args: argparse.Namespace) -> int:
+    try:
+        profile = get_macro_data_profile()
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    if profile == "dev":
+        return _run_resolve_http(args)
+    return _run_resolve_local(args)
 
 
 def _run_validate_concept(args: argparse.Namespace) -> int:
@@ -733,6 +878,11 @@ def _run_validate_concept(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    try:
+        _guard_writer_command(args)
+    except (LocalWriterGuardError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
 
     if args.command == "serve":
         serve_argv: list[str] = []

--- a/src/macro_data/client.py
+++ b/src/macro_data/client.py
@@ -23,7 +23,12 @@ class MacroDataHttpConfig:
 
     @classmethod
     def from_env(cls) -> MacroDataHttpConfig | None:
-        base_url = get_env_value("ANALYST_MACRO_DATA_BASE_URL", default="").strip()
+        base_url = get_env_value(
+            "ANALYST_MACRO_DATA_BASE_URL",
+            "MACRO_DATA_PROD_API_URL",
+            "MACRO_DATA_PROD_BASE_URL",
+            default="",
+        ).strip()
         if not base_url:
             return None
         timeout_raw = get_env_value("ANALYST_MACRO_DATA_TIMEOUT_SECONDS", default="20").strip()
@@ -33,7 +38,11 @@ class MacroDataHttpConfig:
             timeout_seconds = 20.0
         return cls(
             base_url=base_url.rstrip("/"),
-            api_token=get_env_value("ANALYST_MACRO_DATA_API_TOKEN", default="").strip(),
+            api_token=get_env_value(
+                "ANALYST_MACRO_DATA_API_TOKEN",
+                "MACRO_DATA_API_TOKEN",
+                default="",
+            ).strip(),
             timeout_seconds=max(timeout_seconds, 1.0),
         )
 

--- a/tests/test_macro_data_cli.py
+++ b/tests/test_macro_data_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -90,7 +91,12 @@ class MacroDataCLITest(unittest.TestCase):
         with patch("macro_data.cli.OECDIngestionClient", return_value=fake_ingestion):
             with patch("storage.SQLiteEngineStore", return_value=fake_store):
                 with redirect_stdout(output):
-                    rc = main(["oecd-refresh-catalog", "--dataflow-limit", "1", "--sleep-seconds", "0"])
+                    rc = main([
+                        "oecd-refresh-catalog",
+                        "--dataflow-limit", "1",
+                        "--sleep-seconds", "0",
+                        "--allow-local-write",
+                    ])
 
         self.assertEqual(rc, 0)
         self.assertIn("oecd_catalog", output.getvalue())
@@ -112,13 +118,40 @@ class MacroDataCLITest(unittest.TestCase):
         }
         with patch("macro_data.factory.build_local_macro_data_service", return_value=fake_service):
             with redirect_stdout(output):
-                rc = main(["refresh-source", "--source", "news"])
+                rc = main(["refresh-source", "--source", "news", "--allow-local-write"])
 
         self.assertEqual(rc, 0)
         payload = json.loads(output.getvalue())
         self.assertEqual(payload["source"], "news")
         self.assertEqual(payload["stored"], 4)
         fake_service.invoke.assert_called_once_with("refresh_source", {"source": "news"})
+
+    def test_refresh_source_requires_prod_profile_by_default(self) -> None:
+        stderr_buf = io.StringIO()
+        with patch.dict(os.environ, {"MACRO_DATA_PROFILE": "dev"}), \
+             patch("sys.stderr", stderr_buf):
+            rc = main(["refresh-source", "--source", "news"])
+
+        self.assertEqual(rc, 2)
+        self.assertIn("writer ops run only on the VPS", stderr_buf.getvalue())
+
+    def test_diagnose_sources_requires_prod_profile_by_default(self) -> None:
+        stderr_buf = io.StringIO()
+        with patch.dict(os.environ, {"MACRO_DATA_PROFILE": "dev"}), \
+             patch("sys.stderr", stderr_buf):
+            rc = main(["diagnose-sources"])
+
+        self.assertEqual(rc, 2)
+        self.assertIn("writer ops run only on the VPS", stderr_buf.getvalue())
+
+    def test_launch_gate_requires_prod_profile_by_default(self) -> None:
+        stderr_buf = io.StringIO()
+        with patch.dict(os.environ, {"MACRO_DATA_PROFILE": "dev"}), \
+             patch("sys.stderr", stderr_buf):
+            rc = main(["launch-gate", "--skip-issue-update"])
+
+        self.assertEqual(rc, 2)
+        self.assertIn("writer ops run only on the VPS", stderr_buf.getvalue())
 
     def test_sources_capabilities_command_invokes_service(self) -> None:
         output = io.StringIO()
@@ -166,7 +199,14 @@ class MacroDataCLITest(unittest.TestCase):
         }
         with patch("macro_data.factory.build_local_macro_data_service", return_value=fake_service):
             with redirect_stdout(output):
-                rc = main(["catalog-list", "--source", "oecd", "--query", "cli", "--limit", "5", "--refresh"])
+                rc = main([
+                    "catalog-list",
+                    "--source", "oecd",
+                    "--query", "cli",
+                    "--limit", "5",
+                    "--refresh",
+                    "--allow-local-write",
+                ])
 
         self.assertEqual(rc, 0)
         payload = json.loads(output.getvalue())
@@ -186,7 +226,13 @@ class MacroDataCLITest(unittest.TestCase):
         }
         with patch("macro_data.factory.build_local_macro_data_service", return_value=fake_service):
             with redirect_stdout(output):
-                rc = main(["catalog-sync-latest", "--source", "worldbank", "--entity", "SP.POP.TOTL", "--limit", "3"])
+                rc = main([
+                    "catalog-sync-latest",
+                    "--source", "worldbank",
+                    "--entity", "SP.POP.TOTL",
+                    "--limit", "3",
+                    "--allow-local-write",
+                ])
 
         self.assertEqual(rc, 0)
         payload = json.loads(output.getvalue())
@@ -194,6 +240,42 @@ class MacroDataCLITest(unittest.TestCase):
         fake_service.invoke.assert_called_once_with(
             "sync_catalog_latest",
             {"source_id": "worldbank", "entity_ids": ["SP.POP.TOTL"], "limit": 3},
+        )
+
+    def test_dev_profile_resolve_uses_http_api(self) -> None:
+        output = io.StringIO()
+        fake_client = Mock()
+        fake_client.invoke.return_value = {
+            "resolved": {
+                "concept_id": "CPI_US",
+                "date": "2026-04-01",
+                "value": 3.1,
+                "source_id": "bls",
+                "provider_series_id": "CPIAUCSL",
+                "priority": 1,
+                "role": "primary",
+                "alternates": 0,
+            }
+        }
+        env = {
+            "MACRO_DATA_PROFILE": "dev",
+            "ANALYST_MACRO_DATA_BASE_URL": "https://macro-data.example",
+            "ANALYST_MACRO_DATA_API_TOKEN": "secret",
+        }
+        with patch.dict(os.environ, env), \
+             patch("macro_data.cli.HttpMacroDataClient", return_value=fake_client) as http_cls:
+            with redirect_stdout(output):
+                rc = main(["resolve", "CPI_US", "--json"])
+
+        self.assertEqual(rc, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["concept_id"], "CPI_US")
+        config = http_cls.call_args.args[0]
+        self.assertEqual(config.base_url, "https://macro-data.example")
+        self.assertEqual(config.api_token, "secret")
+        fake_client.invoke.assert_called_once_with(
+            "resolve_indicator",
+            {"concept_id": "CPI_US"},
         )
 
     def test_default_engine_db_path_is_service_scoped(self) -> None:
@@ -340,6 +422,7 @@ class MacroDataCLITest(unittest.TestCase):
                     "--db-path", "/tmp/engine.db",
                     "--skip-issue-update",
                     "--no-clickhouse-market-stats",
+                    "--allow-local-write",
                 ])
 
         self.assertEqual(rc, 0)

--- a/tests/test_macro_data_http_client.py
+++ b/tests/test_macro_data_http_client.py
@@ -5,6 +5,34 @@ from typing import Any
 from macro_data.client import HttpMacroDataClient, MacroDataHttpConfig
 
 
+def test_http_config_reads_dev_env_file(monkeypatch, tmp_path) -> None:
+    env_file = tmp_path / "dev.env"
+    env_file.write_text(
+        "\n".join([
+            "ANALYST_MACRO_DATA_BASE_URL=https://macro-data.example",
+            "ANALYST_MACRO_DATA_API_TOKEN=secret",
+            "ANALYST_MACRO_DATA_TIMEOUT_SECONDS=7",
+        ]),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("ANALYST_MACRO_DATA_BASE_URL", raising=False)
+    monkeypatch.delenv("ANALYST_MACRO_DATA_API_TOKEN", raising=False)
+    monkeypatch.delenv("ANALYST_MACRO_DATA_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setenv("MACRO_DATA_ENV_FILES", str(env_file))
+
+    from env import clear_env_cache
+
+    clear_env_cache()
+    config = MacroDataHttpConfig.from_env()
+    clear_env_cache()
+
+    assert config == MacroDataHttpConfig(
+        base_url="https://macro-data.example",
+        api_token="secret",
+        timeout_seconds=7.0,
+    )
+
+
 def test_http_client_sends_x_api_key(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
Closes #141

## Changes
- Add MACRO_DATA_PROFILE=dev|prod with dev as the default.
- Load local dev API settings from ~/.macro-data/dev.env and route dev-profile resolve through the prod HTTP API with X-API-Key.
- Guard writer/diagnostic CLI paths behind prod profile or --allow-local-write.
- Set MACRO_DATA_PROFILE=prod on VPS systemd writer units.
- Document deployment topology and dev-to-prod workflow.

## Verification
- Codex review round 1: fixed DEFAULT_ENV_FILES compatibility and diagnose-sources guard.
- Codex review round 2: fixed launch-gate guard.
- PYTHONPATH=src pytest tests/test_macro_data_cli.py tests/test_macro_data_http_client.py tests/test_public_ops_allowlist.py tests/test_te_api_scaffold.py::test_client_auth_missing_is_raised_only_on_request tests/test_news_document_mirror.py::test_search_returns_empty_without_api_key tests/test_news_document_mirror.py::test_search_reads_key_from_env_file tests/market/fundamentals/eodhd/test_client.py::test_client_auth_missing_raised_only_on_call tests/calendar/eodhd/test_client.py::test_client_auth_missing_raised_only_on_call
- python3 -m py_compile src/env.py src/macro_data/client.py src/macro_data/cli.py
- git diff --check