### PR TITLE
Deploy pipeline + VPS bootstrap → master

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,88 @@
+# Mirrors the working tree to /home/data/macro-data-service/ on the data VPS via rsync.
+# Gate: GitHub Environment "prod" requires reviewer approval and is restricted to master.
+# Env-scoped secrets (set with `gh secret set <name> --env prod`):
+#   SSH_PRIVATE_KEY  ed25519 deploy key, no passphrase
+#   SSH_KNOWN_HOSTS  output of `ssh-keyscan -H <host>`
+#   SSH_HOST         VPS IP/hostname reachable from GH runner
+#   SSH_USER         remote user (data)
+
+name: Deploy to prod (data@vl)
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: rsync to data@vl
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: prod
+      url: https://github.com/${{ github.repository }}/deployments
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+        run: |
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: rsync source tree
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+        run: |
+          rsync -av --delete \
+            --exclude='.git/' \
+            --exclude='.github/' \
+            --exclude='.macro-data/' \
+            --exclude='__pycache__/' \
+            --exclude='*.pyc' \
+            --exclude='.venv/' \
+            --exclude='venv/' \
+            --exclude='.env' \
+            --exclude='.env.*' \
+            --exclude='*.db' \
+            --exclude='*.db-shm' \
+            --exclude='*.db-wal' \
+            --exclude='.idea/' \
+            --exclude='.vscode/' \
+            --exclude='*.log' \
+            --exclude='node_modules/' \
+            --exclude='.pytest_cache/' \
+            --exclude='.coderabbit.yaml' \
+            --exclude='.codex' \
+            --exclude='.agents/' \
+            --exclude='.claude/' \
+            -e "ssh -i ~/.ssh/id_ed25519" \
+            ./ "${SSH_USER}@${SSH_HOST}:/home/data/macro-data-service/"
+
+      - name: Verify on remote
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+        run: |
+          ssh -i ~/.ssh/id_ed25519 "${SSH_USER}@${SSH_HOST}" \
+            'set -e
+             cd ~/macro-data-service
+             echo "--- size ---"; du -sh .
+             echo "--- file count ---"; find . -type f | wc -l
+             echo "--- top-level ---"; ls -la | head -25
+             echo "--- src/ sanity ---"; ls src/'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ from ~25 free/licensed upstreams instead of BBG's paid feed.
 resolves macro + market + calendar + document data from ~25 upstreams into a
 single SQLite store that downstream services (analyst UI, RAG, agents) read
 through one service interface.
-**Last updated:** 2026-05-03 (branch `refactor/issue-123-retire-calendar-scrapers`: retired the legacy calendar HTML scraper subtree; TE country mapping now lives in `calendar/te_api`; official calendar APIs, `te_api`, and EODHD are the current calendar ingestion paths.)
+**Last updated:** 2026-05-09 (branch `dev`: GitHub Actions deploy pipeline wired — push to `master` triggers `rsync -av --delete` to `data@<vps>:/home/data/macro-data-service/`, gated by Environment `prod` with required-reviewer approval and master-only branch policy.)
 
 ### Bloomberg-capability coverage (current → 1.0)
 
@@ -72,6 +72,27 @@ override.
 Local tests use temporary DBs and fixtures. VPS systemd writer units set
 `Environment=MACRO_DATA_PROFILE=prod`, which gives ingestion ownership to the
 always-on host and keeps local work in the dev/read-only client lane.
+
+### Deployment pipeline (added 2026-05-09)
+
+Source ships to the VPS via GitHub Actions (`.github/workflows/deploy-prod.yml`).
+Routine work lands on the `dev` branch; `master` is the deploy trigger. On push
+to `master` (or manual `workflow_dispatch`), the workflow runs in GitHub
+Environment `prod`, which:
+
+- requires reviewer approval (R1cK-ChaN) before any job step executes;
+- restricts the deploying ref to `master` via `custom_branch_policies`;
+- holds env-scoped secrets `SSH_PRIVATE_KEY` (ed25519 deploy key, no passphrase),
+  `SSH_KNOWN_HOSTS`, `SSH_HOST`, `SSH_USER` — the workflow YAML carries no
+  hostnames or credentials.
+
+The deploy step runs `rsync -av --delete` from the runner checkout to
+`data@<host>:/home/data/macro-data-service/`. Excluded from the sync: `.env*`,
+`.macro-data/`, `*.db*`, `.venv` / `venv`, `__pycache__/`, `.github/`, and
+dev-local artifacts (`.agents/`, `.claude/`, `.coderabbit.yaml`,
+`.pytest_cache/`, `.codex`). The `data` user owns the tree (uid 1002, in the
+`sudo` group); the ed25519 deploy key is the only credential GitHub Actions
+holds.
 
 ---
 

--- a/docs/ops/vps_bootstrap.md
+++ b/docs/ops/vps_bootstrap.md
@@ -82,7 +82,7 @@ UFW, fail2ban, ClickHouse, directory skeleton. Re-runs are no-ops.
 |---|---|---|
 | `DATA_USER` | `data` | Non-root account systemd jobs run as |
 | `SSH_ALLOWED_FROM` | empty | If set (e.g. `1.2.3.4` or `1.2.3.0/24`), restricts port 22 to that source |
-| `LOCK_DATA_PASSWORD` | `1` | Set `0` to keep password sudo for emergency console access |
+| `LOCK_DATA_PASSWORD` | `0` | Set `1` to also `passwd -l` data's local password. SSH password login is already blocked by the sshd drop-in; locking on top closes local sudo + Contabo KVM console fallbacks. Default keeps `sudo` usable from data's own session. |
 
 After the script completes, verify:
 

--- a/docs/ops/vps_bootstrap.md
+++ b/docs/ops/vps_bootstrap.md
@@ -1,0 +1,151 @@
+# VPS bootstrap checklist
+
+End-to-end procedure to take a fresh Ubuntu 24.04 LTS host (target spec:
+Contabo Storage VPS 20 — 3 vCPU / 8 GB RAM / 400 GB SSD / Singapore
+region) to a state ready for the macro-data writer / reader lanes.
+Issue #133.
+
+The bootstrap is **idempotent** — re-running `vps_bootstrap.sh` against
+a partially-configured host is safe.
+
+---
+
+## Prerequisites (on local workstation)
+
+- ssh access to the VPS as a sudoer (initial Contabo `root` or your
+  uploaded SSH-key user).
+- Local clone of `macro-data-service` checked out at the commit you want
+  to deploy.
+
+## Phase 1 — manual: prep the sudoer account
+
+If the VPS does not yet have a non-root SSH-key sudoer:
+
+1. ssh in as the provider's initial user (Contabo provisions root by
+   default).
+2. Create your bootstrap account:
+   ```
+   adduser --disabled-password --gecos "" rick   # or your alias
+   usermod -aG sudo rick
+   install -d -m 700 -o rick -g rick /home/rick/.ssh
+   nano /home/rick/.ssh/authorized_keys           # paste your SSH pubkey
+   chown rick:rick /home/rick/.ssh/authorized_keys
+   chmod 600 /home/rick/.ssh/authorized_keys
+   ```
+3. From your laptop, `ssh rick@<vps>` and confirm sudo works.
+
+## Phase 2 — manual: ensure the `data` account
+
+The bootstrap script will create the `data` user if absent. To create it
+manually first (e.g. so GitHub Actions can deploy before bootstrap runs):
+
+```
+ssh rick@<vps>
+sudo adduser --disabled-password --gecos "" data
+sudo usermod -aG sudo data
+sudo install -d -m 700 -o data -g data /home/data/.ssh
+sudo cp /home/rick/.ssh/authorized_keys /home/data/.ssh/authorized_keys
+sudo chown data:data /home/data/.ssh/authorized_keys
+sudo chmod 600 /home/data/.ssh/authorized_keys
+```
+
+## Phase 3 — get the source on the VPS
+
+Either:
+
+- **Via GitHub Actions** (preferred steady-state): merge the `dev` branch
+  into `master`, approve the `prod` deployment in the GitHub Actions UI,
+  and `.github/workflows/deploy-prod.yml` rsyncs the working tree into
+  `/home/data/macro-data-service/` for you.
+- **Via manual rsync** (initial bring-up before the workflow is live):
+  ```
+  rsync -av --exclude='.git/' --exclude='.macro-data/' \
+    --exclude='.env' --exclude='*.db*' --exclude='.venv/' \
+    /path/to/macro-data-service/ data@<vps>:/home/data/macro-data-service/
+  ```
+
+## Phase 4 — run the bootstrap script
+
+```
+ssh rick@<vps>
+cd /home/data/macro-data-service
+sudo -v
+./scripts/bootstrap/vps_bootstrap.sh
+```
+
+Eight phases run in sequence: apt baseline, chrony, user, SSH hardening,
+UFW, fail2ban, ClickHouse, directory skeleton. Re-runs are no-ops.
+
+### Override variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `DATA_USER` | `data` | Non-root account systemd jobs run as |
+| `SSH_ALLOWED_FROM` | empty | If set (e.g. `1.2.3.4` or `1.2.3.0/24`), restricts port 22 to that source |
+| `LOCK_DATA_PASSWORD` | `1` | Set `0` to keep password sudo for emergency console access |
+
+After the script completes, verify:
+
+```
+timedatectl | grep 'Time zone'                 # Etc/UTC
+systemctl is-active chrony fail2ban ssh ufw clickhouse-server unattended-upgrades
+sudo ufw status numbered                        # only 22 + 443 rules
+clickhouse-client --query 'SELECT version()'    # returns a version string
+ssh -o PreferredAuthentications=password data@<vps>  # must refuse
+```
+
+## Phase 5 — fill secrets
+
+```
+sudo cp /home/data/macro-data-service/scripts/bootstrap/secrets.env.template \
+        /etc/macro-data/.env
+sudo chown data:data /etc/macro-data/.env
+sudo chmod 600 /etc/macro-data/.env
+sudo nano /etc/macro-data/.env
+```
+
+Empty values are acceptable for sources you do not yet ingest.
+
+The application reads env vars via two paths, and **both must point at
+`/etc/macro-data/.env`** for production secrets to resolve:
+
+- **`os.environ` direct reads** — `CLICKHOUSE_*`, `WAYBACK_*`,
+  `ANALYST_MACRO_DATA_API_TOKENS_PATH`, etc. are read straight from
+  process environment. Production systemd units must set
+  `EnvironmentFile=/etc/macro-data/.env` (covered in #106) so these
+  values reach the process.
+- **`get_env_value()` fallback** — source-API keys (`FRED_API_KEY`,
+  `BLS_API_KEY`, `EODHD_API_KEY`, …) flow through `src/env.py`, which
+  by default falls back to repo `.env` and `~/.macro-data/dev.env`. To
+  also include `/etc/macro-data/.env` in the fallback chain, set
+  `MACRO_DATA_ENV_FILES=/etc/macro-data/.env` in the same systemd unit.
+
+`EnvironmentFile=` covers both paths; setting only `MACRO_DATA_ENV_FILES`
+leaves `os.environ`-direct vars (notably `CLICKHOUSE_PASSWORD`) unloaded.
+
+## Phase 6 — what's next
+
+Bootstrap stops at "ready to install application". Subsequent issues
+take it forward:
+
+- **#106** — writer systemd timer pack (data-quality, shadow digest,
+  main ingestion refresh).
+- **#134** *(closed)* — production HTTP stack; the reader unit lands
+  in #106.
+- **#135** — Cloudflare front-door + UFW-vs-CF IP whitelist.
+- **#136** — backup + Backblaze B2 off-site replication.
+- **#137** — systemd unit hardening + Cloudflare Health Checks.
+- **#140** — cold migration of local `engine.db` + ClickHouse to VPS.
+
+## Rollback / re-bootstrap
+
+The script is intentionally idempotent. To reset a single concern:
+
+- `sudo rm /etc/ssh/sshd_config.d/10-bootstrap-hardening.conf && sudo systemctl reload ssh.service`
+  reverts SSH hardening (re-enables password login).
+- `sudo ufw reset` clears the firewall rules.
+- `sudo apt purge clickhouse-server clickhouse-client` removes ClickHouse
+  binaries; data dirs in `/var/lib/clickhouse/` survive purge.
+  `sudo rm -rf /var/lib/clickhouse` for a clean slate.
+
+A full host re-image is faster than chasing partial undo paths.

--- a/scripts/bootstrap/secrets.env.template
+++ b/scripts/bootstrap/secrets.env.template
@@ -1,0 +1,70 @@
+# /etc/macro-data/.env — production secrets for the data VPS
+#
+# Copy this file to /etc/macro-data/.env (chmod 600, owned by data:data)
+# and fill in the values you have. Empty values are fine for sources you
+# do not yet ingest — the application's get_env_value() returns "" and
+# the corresponding fetcher skips at runtime. Issue #133.
+#
+# DO NOT commit a populated copy back to git. The template tracks key
+# names only; secret rotation is operator-side.
+
+# ---------------- Application ----------------
+MACRO_DATA_PROFILE=prod
+ANALYST_MACRO_DATA_API_TOKEN=
+ANALYST_MACRO_DATA_API_TOKENS_PATH=/etc/macro-data/api_tokens.json
+ANALYST_MACRO_DATA_DB_PATH=/var/lib/macro-data/engine.db
+ANALYST_MACRO_DATA_HOST=127.0.0.1
+ANALYST_MACRO_DATA_PORT=8765
+ANALYST_MACRO_DATA_WORKERS=2
+ANALYST_MACRO_DATA_RATE_LIMIT_PER_MINUTE=60
+ANALYST_MACRO_DATA_RATE_LIMIT_DB=/var/lib/macro-data/rate-limits.sqlite3
+ANALYST_MACRO_DATA_TIMEOUT_SECONDS=20
+
+# ---------------- ClickHouse (local on VPS) --------------
+CLICKHOUSE_HOST=127.0.0.1
+CLICKHOUSE_HTTP_PORT=8123
+CLICKHOUSE_USER=default
+CLICKHOUSE_PASSWORD=
+CLICKHOUSE_DATABASE=market
+
+# ---------------- US macro upstream APIs ----------------
+FRED_API_KEY=
+BLS_API_KEY=
+BEA_API_KEY=
+CENSUS_API_KEY=
+EIA_API_KEY=
+
+# ---------------- Market / fundamentals -----------------
+EODHD_API_KEY=
+OPENFIGI_API_KEY=
+
+# ---------------- Calendar (historical / TE) ------------
+TE_API_KEY=
+
+# ---------------- EU / JP statistical agencies ----------
+ESTAT_APP_ID=
+# Destatis GENESIS-Online credentials. Empty leaves the client on guest
+# auth (`GAST`); registered creds unlock larger result windows + premium
+# tables. Variable names must match what the client reads.
+DESTATIS_GENESIS_USERNAME=
+DESTATIS_GENESIS_PASSWORD=
+
+# ---------------- Sentiment / X (twitter) (#76) ---------
+X_BEARER_TOKEN=
+
+# ---------------- Web search / discovery ----------------
+BRAVE_API_KEY=
+
+# ---------------- Wayback evidence (#36) ----------------
+WAYBACK_S3_ACCESSKEY=
+WAYBACK_S3_SECRET=
+
+# ---------------- Backups → Backblaze B2 (#136) --------
+B2_ACCOUNT_ID=
+B2_APPLICATION_KEY=
+B2_BUCKET=
+RCLONE_CRYPT_PASSWORD=
+
+# ---------------- Cloudflare (#135) ---------------------
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_ZONE_ID=

--- a/scripts/bootstrap/vps_bootstrap.sh
+++ b/scripts/bootstrap/vps_bootstrap.sh
@@ -6,7 +6,12 @@
 # Environment overrides:
 #   DATA_USER=data              non-root account systemd jobs run as
 #   SSH_ALLOWED_FROM=""         CIDR/IP to lock :22 down to (empty = open)
-#   LOCK_DATA_PASSWORD=1        set 0 to keep password sudo (testing only)
+#   LOCK_DATA_PASSWORD=0        set 1 to also lock data's local password.
+#                               SSH password login is already blocked by the
+#                               sshd drop-in; locking on top closes the local
+#                               sudo + console fallbacks for fully-key-only
+#                               hosts. Default 0 keeps `sudo` usable from
+#                               data's own session.
 #
 # Run as a sudoer (not root). Re-running on a partially-configured host
 # is a no-op. Targets Ubuntu 24.04 LTS.
@@ -16,7 +21,7 @@ IFS=$'\n\t'
 
 DATA_USER="${DATA_USER:-data}"
 SSH_ALLOWED_FROM="${SSH_ALLOWED_FROM:-}"
-LOCK_DATA_PASSWORD="${LOCK_DATA_PASSWORD:-1}"
+LOCK_DATA_PASSWORD="${LOCK_DATA_PASSWORD:-0}"
 
 DATA_DIR=/var/lib/macro-data
 LOG_DIR=/var/log/macro-data

--- a/scripts/bootstrap/vps_bootstrap.sh
+++ b/scripts/bootstrap/vps_bootstrap.sh
@@ -31,10 +31,9 @@ F2B_JAIL=/etc/fail2ban/jail.d/sshd.local
 CH_KEYRING=/etc/apt/keyrings/clickhouse-keyring.gpg
 CH_LIST=/etc/apt/sources.list.d/clickhouse.list
 
-if [[ $EUID -eq 0 ]]; then
-  echo "Run as a sudoer, not root. Aborting." >&2
-  exit 1
-fi
+# Works as either: root (via `sudo ./vps_bootstrap.sh`) or sudoer with
+# cached/NOPASSWD sudo (via `sudo -v && ./vps_bootstrap.sh`). Inner sudo
+# calls are no-op passthroughs when EUID is 0.
 if ! sudo -n true 2>/dev/null; then
   echo "Need cached or passwordless sudo. Run 'sudo -v' first." >&2
   exit 1

--- a/scripts/bootstrap/vps_bootstrap.sh
+++ b/scripts/bootstrap/vps_bootstrap.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# vps_bootstrap.sh — idempotent VPS bootstrap for the data lane (issue #133).
+#
+# Usage: sudo -v && ./scripts/bootstrap/vps_bootstrap.sh
+#
+# Environment overrides:
+#   DATA_USER=data              non-root account systemd jobs run as
+#   SSH_ALLOWED_FROM=""         CIDR/IP to lock :22 down to (empty = open)
+#   LOCK_DATA_PASSWORD=1        set 0 to keep password sudo (testing only)
+#
+# Run as a sudoer (not root). Re-running on a partially-configured host
+# is a no-op. Targets Ubuntu 24.04 LTS.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+DATA_USER="${DATA_USER:-data}"
+SSH_ALLOWED_FROM="${SSH_ALLOWED_FROM:-}"
+LOCK_DATA_PASSWORD="${LOCK_DATA_PASSWORD:-1}"
+
+DATA_DIR=/var/lib/macro-data
+LOG_DIR=/var/log/macro-data
+SECRETS_DIR=/etc/macro-data
+SSHD_DROPIN=/etc/ssh/sshd_config.d/10-bootstrap-hardening.conf
+F2B_JAIL=/etc/fail2ban/jail.d/sshd.local
+CH_KEYRING=/etc/apt/keyrings/clickhouse-keyring.gpg
+CH_LIST=/etc/apt/sources.list.d/clickhouse.list
+
+if [[ $EUID -eq 0 ]]; then
+  echo "Run as a sudoer, not root. Aborting." >&2
+  exit 1
+fi
+if ! sudo -n true 2>/dev/null; then
+  echo "Need cached or passwordless sudo. Run 'sudo -v' first." >&2
+  exit 1
+fi
+
+log() { printf '[%s] bootstrap: %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+# ---------- 1/8 apt baseline + unattended security updates ----------------
+log "phase 1/8: apt baseline + unattended-upgrades"
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+  ca-certificates curl gnupg lsb-release apt-transport-https \
+  unattended-upgrades chrony fail2ban ufw git \
+  python3.12 python3.12-venv python3-pip
+sudo systemctl enable --now unattended-upgrades.service >/dev/null
+
+# ---------- 2/8 timezone UTC + chrony -------------------------------------
+log "phase 2/8: timezone UTC + chrony"
+if [[ "$(timedatectl show -p Timezone --value)" != "Etc/UTC" ]]; then
+  sudo timedatectl set-timezone Etc/UTC
+fi
+sudo systemctl enable --now chrony.service >/dev/null
+
+# ---------- 3/8 data user + sudo + ssh dir --------------------------------
+log "phase 3/8: ensure $DATA_USER user with sudo"
+if ! id -u "$DATA_USER" >/dev/null 2>&1; then
+  sudo adduser --disabled-password --gecos "" "$DATA_USER"
+fi
+sudo usermod -aG sudo "$DATA_USER"
+sudo install -d -m 700 -o "$DATA_USER" -g "$DATA_USER" "/home/$DATA_USER/.ssh"
+
+# ---------- 4/8 SSH hardening (key-only, no root, no password) ------------
+log "phase 4/8: SSH hardening"
+sudo install -m 644 /dev/stdin "$SSHD_DROPIN" <<'SSHD_EOF'
+# Managed by scripts/bootstrap/vps_bootstrap.sh — issue #133.
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin no
+PermitEmptyPasswords no
+SSHD_EOF
+# Validate before reload — bad sshd_config kills the only path back in.
+sudo sshd -t
+sudo systemctl reload ssh.service
+
+if [[ "$LOCK_DATA_PASSWORD" == "1" ]]; then
+  sudo passwd -l "$DATA_USER" >/dev/null
+  log "  $DATA_USER password locked (key-only login). Override with LOCK_DATA_PASSWORD=0."
+fi
+
+# ---------- 5/8 UFW firewall ----------------------------------------------
+log "phase 5/8: UFW firewall (default deny, allow 22 + 443)"
+sudo ufw --force default deny incoming >/dev/null
+sudo ufw --force default allow outgoing >/dev/null
+# Strip any pre-existing :22 rule (broad or scoped) so SSH_ALLOWED_FROM
+# toggles between runs cleanly — without this, a later allowlisted run
+# leaves the prior broad rule active and SSH stays open globally.
+while :; do
+  rule=$(sudo ufw status numbered 2>/dev/null \
+    | awk '/22\/tcp/ {gsub(/[][]/,"",$1); print $1; exit}')
+  [ -z "$rule" ] && break
+  sudo ufw --force delete "$rule" >/dev/null
+done
+# Allow 22 BEFORE enable so the active SSH session does not drop.
+if [[ -n "$SSH_ALLOWED_FROM" ]]; then
+  sudo ufw allow from "$SSH_ALLOWED_FROM" to any port 22 proto tcp \
+    comment 'ssh (allowlisted)' >/dev/null
+else
+  sudo ufw allow 22/tcp comment 'ssh' >/dev/null
+fi
+sudo ufw allow 443/tcp comment 'https (will be CF-restricted in #135)' >/dev/null
+sudo ufw --force enable >/dev/null
+
+# ---------- 6/8 fail2ban (sshd jail) --------------------------------------
+log "phase 6/8: fail2ban sshd jail"
+sudo install -m 644 /dev/stdin "$F2B_JAIL" <<'F2B_EOF'
+# Managed by scripts/bootstrap/vps_bootstrap.sh — issue #133.
+[sshd]
+enabled = true
+maxretry = 5
+findtime = 10m
+bantime = 1h
+F2B_EOF
+sudo systemctl enable --now fail2ban.service >/dev/null
+sudo systemctl reload fail2ban.service >/dev/null 2>&1 || true
+
+# ---------- 7/8 ClickHouse server (DEB repo) ------------------------------
+log "phase 7/8: ClickHouse server"
+if ! command -v clickhouse-server >/dev/null 2>&1; then
+  sudo install -d -m 755 /etc/apt/keyrings
+  # --batch --yes lets a partial-rerun (keyring written, apt-install failed)
+  # overwrite the existing keyring instead of aborting on prompt.
+  curl -fsSL https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key \
+    | sudo gpg --batch --yes --dearmor -o "$CH_KEYRING"
+  sudo chmod 644 "$CH_KEYRING"
+  arch=$(dpkg --print-architecture)
+  echo "deb [signed-by=$CH_KEYRING arch=${arch}] https://packages.clickhouse.com/deb stable main" \
+    | sudo tee "$CH_LIST" >/dev/null
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
+  # Skip the interactive default-user password prompt.
+  echo "clickhouse-server clickhouse-server/default-password password " \
+    | sudo debconf-set-selections
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install clickhouse-server clickhouse-client
+fi
+sudo systemctl enable --now clickhouse-server.service >/dev/null
+
+# ---------- 8/8 directory skeleton (owned by data) ------------------------
+log "phase 8/8: directory skeleton"
+for d in "$DATA_DIR" "$LOG_DIR"; do
+  sudo install -d -o "$DATA_USER" -g "$DATA_USER" -m 755 "$d"
+done
+sudo install -d -o "$DATA_USER" -g "$DATA_USER" -m 700 "$SECRETS_DIR"
+
+if [[ ! -f "$SECRETS_DIR/.env" ]]; then
+  log "  $SECRETS_DIR/.env missing — copy scripts/bootstrap/secrets.env.template and fill"
+fi
+
+log "DONE. Verify:"
+log "  timedatectl | grep 'Time zone'"
+log "  systemctl is-active chrony fail2ban ssh ufw clickhouse-server unattended-upgrades"
+log "  sudo ufw status numbered"
+log "  clickhouse-client --query 'SELECT version()'"
+log "  ssh -o PreferredAuthentications=password $DATA_USER@<host>  # should refuse"


### PR DESCRIPTION
## Summary
Bring the deploy pipeline + bootstrap layer to master so push-to-master triggers GH Actions deploy and the bootstrap toolchain ships to the data VPS.

Includes (in order):
- `ci: add prod deploy workflow targeting data@vl` (`5fb1ae9`) — `.github/workflows/deploy-prod.yml`, env `prod` with required reviewer + master-only branch policy.
- `docs(architecture): document GH Actions deploy pipeline` (`70b3237`).
- `feat(ops): VPS bootstrap script + secrets template + runbook` (`bb02c22`) — issue #133.
- `fix(ops): default LOCK_DATA_PASSWORD=0 to preserve data sudo` (`c6b905e`).
- `fix(ops): allow vps_bootstrap.sh to run as root` (`0c1dd58`).
- Merge commit from PR #148 with verification record.

## Pre-merge state
- Branch protections: none yet on master (planned follow-up).
- The deploy workflow lives on the merging branch, so this merge will be the first push event that triggers it.
- Workflow `deploy` job runs in environment `prod` → **will pause at required-reviewer gate** waiting for R1cK-ChaN approval in the GitHub Actions UI before any rsync executes.

## Test plan
- [ ] After merge, observe a workflow run appear at https://github.com/R1cK-ChaN/macro-data-service/actions paused at "Waiting for review"
- [ ] Approve the deployment in the GH Actions UI
- [ ] Verify rsync lands on `data@vl:/home/data/macro-data-service/scripts/bootstrap/` and `/docs/ops/vps_bootstrap.md`
- [ ] Spot-check `ssh data@vl 'ls /home/data/macro-data-service/scripts/bootstrap/'`

## Out of scope (next issues)
- #106 — writer systemd timer pack (needs venv + API keys)
- #135 — Cloudflare front-door (needs domain + CF account)
- #136 — backup B2 (needs B2 creds)
- #137 — systemd hardening + CF Health Checks (needs #135)
- #140 — cold migration (needs #136)

Closes #133.