### PR TITLE
feat(ops): writer timer pack (issue #106)

### DIFF
--- a/scripts/data_quality_daily_wrapper.sh
+++ b/scripts/data_quality_daily_wrapper.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Wrapper for scripts/data_quality_daily.py invoked from systemd --user timer.
+#
+# Responsibilities:
+#   * flock guard — overlapping fires cannot race the engine DB.
+#   * cd into the repo so .macro-data/, .env, and scripts/ resolve.
+#   * exec the python entry-point so the systemd unit's MainPID
+#     tracks Python directly (clean exit-code reporting).
+#
+# Override REPO_ROOT to point at a different checkout (smoke-testing
+# the timer in a worktree). The default is the directory containing
+# this script's parent.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+LOCK_FILE="${REPO_ROOT}/.macro-data/data_quality_daily.lock"
+
+mkdir -p "$(dirname "$LOCK_FILE")"
+
+cd "$REPO_ROOT"
+exec flock --nonblock "$LOCK_FILE" \
+    python3 scripts/data_quality_daily.py "$@"

--- a/scripts/macro_data_refresh_wrapper.sh
+++ b/scripts/macro_data_refresh_wrapper.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Wrapper for the umbrella `macro-data-service refresh` invoked from
+# systemd --user timer (issue #106).
+#
+# Calls `refresh_all_sources` — the catch-all daily refresh for every
+# source registered in the orchestrator. The release-aware watcher
+# (`macro-data-release-watch.timer`, #130) handles high-priority
+# concepts on a tighter loop; this umbrella covers everything else
+# and acts as a safety-net so no source goes more than 24h without
+# a refresh attempt.
+#
+# Per-family timers (US / EU / JP / CN / global) are a future
+# enhancement once each family's refresh budget and cadence are
+# tuned independently.
+#
+# Responsibilities:
+#   * flock guard — overlapping fires cannot race the engine DB.
+#   * cd into the repo so .macro-data/, .env, and scripts/ resolve.
+#   * exec the python module so the systemd unit's MainPID tracks
+#     the CLI entry-point directly (clean exit-code reporting).
+#
+# Override REPO_ROOT to point at a different checkout. The default is
+# the directory containing this script's parent.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+LOCK_FILE="${REPO_ROOT}/.macro-data/macro_data_refresh.lock"
+
+mkdir -p "$(dirname "$LOCK_FILE")"
+
+cd "$REPO_ROOT"
+# PYTHONPATH=src makes the CLI runnable even on hosts without an
+# editable install (`pip install -e .`).
+exec flock --nonblock "$LOCK_FILE" \
+    env PYTHONPATH="${REPO_ROOT}/src" \
+    python3 -m macro_data.cli refresh "$@"

--- a/scripts/shadow_runner_wrapper.sh
+++ b/scripts/shadow_runner_wrapper.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Wrapper for shadow_runner.py invoked from systemd --user timer.
+#
+# Always passes --once: the script's internal sleep loop is for daemon
+# use; under systemd, the timer drives cadence and each firing is a
+# single cycle that exits cleanly.
+#
+# Responsibilities:
+#   * flock guard — overlapping fires cannot race the engine DB.
+#   * cd into the repo so .macro-data/, .env, and scripts/ resolve.
+#   * exec python so the systemd unit's MainPID tracks the entry-point
+#     directly (clean exit-code reporting).
+#
+# Override REPO_ROOT to point at a different checkout (smoke-testing
+# the timer in a worktree). The default is the directory containing
+# this script's parent.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+LOCK_FILE="${REPO_ROOT}/.macro-data/shadow_digest.lock"
+
+mkdir -p "$(dirname "$LOCK_FILE")"
+
+cd "$REPO_ROOT"
+exec flock --nonblock "$LOCK_FILE" \
+    python3 shadow_runner.py --once "$@"

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -16,6 +16,9 @@ jobs run under the VPS writer profile.
 | `macro-data-market-refresh.timer` | daily 22:00 ET | EODHD US bulk bars/dividends/splits refresh | #119 |
 | `macro-data-market-self-heal.timer` | weekly Sunday 03:00 ET | stale-bar refetch and delisting detection | #119 |
 | `macro-data-market-spot-check.timer` | daily 22:30 ET | realtime-close spot check against stored closes | #119 |
+| `macro-data-refresh.timer` | daily 02:00 UTC | umbrella `refresh_all_sources` — catch-all for sources not on a release-watch loop | #106 |
+| `shadow-digest.timer` | every 6h at :30 (00/06/12/18 UTC) | full ingestion cycle + coverage digest (`shadow_runner.py --once`) | #106 |
+| `data-quality-daily.timer` | daily 07:00 UTC | macro DQ rollup → single GH `data-quality` issue (filer #102, packaging #106) | #106 |
 
 # Parity tripwire systemd unit
 
@@ -242,3 +245,91 @@ scripts/market_daily_refresh_wrapper.sh
 scripts/market_self_heal_wrapper.sh
 scripts/market_spot_check_wrapper.sh
 ```
+
+## Writer timer pack (issue #106)
+
+Three timers complete the writer set so a fresh VPS does not depend on
+manual `macro-data-service refresh` runs:
+
+- `macro-data-refresh.timer` (daily 02:00 UTC) — umbrella refresh of
+  every registered source. Catch-all for sources not on the
+  release-aware watcher (`macro-data-release-watch.timer` handles the
+  high-priority concepts).
+- `shadow-digest.timer` (every 6h at :30 — 00/06/12/18 UTC) — runs
+  `shadow_runner.py --once` for one full ingestion + coverage digest
+  cycle. Detects coverage drops outside the daily DQ window.
+- `data-quality-daily.timer` (daily 07:00 UTC) — wraps
+  `scripts/data_quality_daily.py` (filer #102), files / updates the
+  single `data-quality` GitHub issue based on validation + digest +
+  secret-leak signal.
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp scripts/systemd/macro-data-refresh.service ~/.config/systemd/user/
+cp scripts/systemd/macro-data-refresh.timer   ~/.config/systemd/user/
+cp scripts/systemd/shadow-digest.service      ~/.config/systemd/user/
+cp scripts/systemd/shadow-digest.timer        ~/.config/systemd/user/
+cp scripts/systemd/data-quality-daily.service ~/.config/systemd/user/
+cp scripts/systemd/data-quality-daily.timer   ~/.config/systemd/user/
+
+# Same Environment= / ExecStart= caveat as the other units — edit each
+# .service if your checkout is at a path other than
+# %h/Desktop/analyst/macro-data-service. On the VPS data lane this is
+# /home/data/macro-data-service.
+
+systemctl --user daemon-reload
+systemctl --user enable --now macro-data-refresh.timer
+systemctl --user enable --now shadow-digest.timer
+systemctl --user enable --now data-quality-daily.timer
+```
+
+Verify:
+
+```bash
+systemctl --user list-timers \
+    macro-data-refresh.timer shadow-digest.timer data-quality-daily.timer
+journalctl --user -u macro-data-refresh.service -n 50
+journalctl --user -u shadow-digest.service -n 50
+journalctl --user -u data-quality-daily.service -n 50
+```
+
+Manual run:
+
+```bash
+scripts/macro_data_refresh_wrapper.sh
+scripts/shadow_runner_wrapper.sh
+scripts/data_quality_daily_wrapper.sh
+
+# --help on each entry-point surfaces dry-run / subset flags
+python3 scripts/data_quality_daily.py --help
+PYTHONPATH=src python3 -m macro_data.cli refresh --help
+python3 shadow_runner.py --help
+```
+
+Operations:
+
+* `macro-data-refresh` log: stdout/stderr to journal; one structured
+  `refresh_all_sources` op result printed per run.
+* `shadow-digest` log: `.macro-data/logs/shadow.log` (one line per
+  source × cycle), `.macro-data/logs/daily_digest.jsonl` (one digest
+  per cycle).
+* `data-quality-daily` log: `.macro-data/logs/data_quality.log` (one
+  JSON per run); state at `.macro-data/data_quality_state.json`.
+* Lock files (one per job, none shared): `.macro-data/`
+  `macro_data_refresh.lock`, `shadow_digest.lock`,
+  `data_quality_daily.lock`.
+
+Design notes:
+
+* **Cadence design** — 02:00 UTC umbrella refresh seeds the engine DB
+  before calendar refresh (04:00), parity (06:00), and DQ (07:00) read
+  from it. Shadow cycles at :30 of each 6h slot stay clear of every
+  hour-of-day write window and the hourly :15 calendar value sweep.
+* **`shadow_runner.py --once`** (added in #106) — the script's
+  `while True` interval loop is for ad-hoc daemon runs. Under systemd,
+  `--once` exits after one cycle so the timer drives cadence,
+  matching the rest of the pack.
+* **No per-family refresh yet** — `macro-data-refresh` calls the
+  umbrella `refresh_all_sources` op. Per-family timers
+  (US / EU / JP / CN / global) are a future enhancement once each
+  family's refresh budget and cadence justify independent scheduling.

--- a/scripts/systemd/data-quality-daily.service
+++ b/scripts/systemd/data-quality-daily.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Macro-data daily data-quality auto-filer (issue #102)
+After=network-online.target
+Wants=network-online.target
+
+# Catch-up ordering after a long suspend: data-quality reads results
+# from validation + parity, so wait for parity to land first.
+After=parity-daily.service
+
+[Service]
+Type=oneshot
+# Replace REPO_ROOT below with the absolute path to your checkout, e.g.
+# /home/data/macro-data-service on the VPS data lane. The wrapper
+# resolves .macro-data/, .env, and scripts/ relative to it.
+Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
+ExecStart=%h/Desktop/analyst/macro-data-service/scripts/data_quality_daily_wrapper.sh
+
+# Validation + digest + gh API calls finish in well under 5 min;
+# 10 min covers anomalies. Beyond that means a stuck gh API call
+# and the job should be killed.
+TimeoutStartSec=600
+
+# Don't restart on failure — daily cadence + the script's own
+# self-monitor on the GH issue thread is the retry mechanism.
+Restart=no
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/data-quality-daily.timer
+++ b/scripts/systemd/data-quality-daily.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=Daily 07:00 UTC macro data-quality auto-filer (issue #102)
+
+[Timer]
+# Daily at 07:00 UTC — sits one hour after parity-daily (06:00) so
+# the daily DQ rollup picks up today's parity verdict and avoids
+# fighting parity for the engine DB read lock.
+OnCalendar=*-*-* 07:00:00
+AccuracySec=1m
+
+# Late catch-up (e.g. host suspended overnight) is harmless: the
+# script is idempotent and the GH filer's clean-streak logic absorbs
+# repeated clean runs.
+Persistent=true
+
+Unit=data-quality-daily.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/systemd/macro-data-refresh.service
+++ b/scripts/systemd/macro-data-refresh.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Macro-data umbrella source refresh (issue #106)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Replace REPO_ROOT below with the absolute path to your checkout, e.g.
+# /home/data/macro-data-service on the VPS data lane.
+Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
+ExecStart=%h/Desktop/analyst/macro-data-service/scripts/macro_data_refresh_wrapper.sh
+
+# Catch-all daily refresh across all registered sources. Cold-start
+# can take 30-60 min if many caches are stale; 90 min covers worst
+# case. Anything longer is a stuck upstream and should be killed.
+TimeoutStartSec=5400
+
+Restart=no
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/macro-data-refresh.timer
+++ b/scripts/systemd/macro-data-refresh.timer
@@ -1,0 +1,22 @@
+[Unit]
+Description=Daily 02:00 UTC umbrella refresh of all sources (issue #106)
+
+[Timer]
+# Daily at 02:00 UTC — earliest of the day so newly-refreshed source
+# data lands in the engine DB before calendar-schedule-refresh
+# (04:00), parity (06:00), data-quality-daily (07:00), and the
+# shadow-digest cycles consume it. Cleared of the 23:00 ET / 22:00 ET
+# fundamentals + corp-calendar windows (which are 03:00-04:00 UTC
+# depending on DST) by sitting an hour earlier.
+OnCalendar=*-*-* 02:00:00
+AccuracySec=1m
+
+# Persistent catch-up is safe — refresh_all_sources is upsert-shaped
+# and the orchestrator already deduplicates on (source, series_id,
+# content_hash) at the bronze tier (issue #131).
+Persistent=true
+
+Unit=macro-data-refresh.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/systemd/shadow-digest.service
+++ b/scripts/systemd/shadow-digest.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Macro-data shadow ingestion + digest cycle (issue #106)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Replace REPO_ROOT below with the absolute path to your checkout, e.g.
+# /home/data/macro-data-service on the VPS data lane.
+Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
+ExecStart=%h/Desktop/analyst/macro-data-service/scripts/shadow_runner_wrapper.sh
+
+# A full ingestion cycle across all sources can take 20-40 min on a
+# warm cache. 90 min covers cold-start and a slow upstream; longer
+# means a stuck upstream and the cycle should be killed.
+TimeoutStartSec=5400
+
+Restart=no
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/shadow-digest.timer
+++ b/scripts/systemd/shadow-digest.timer
@@ -1,0 +1,21 @@
+[Unit]
+Description=6-hour shadow ingestion + digest cycle (issue #106)
+
+[Timer]
+# Four cycles a day at :30 of 00/06/12/18 UTC — staggered off the
+# busy hour-of-day slots so the full ingestion run does not collide
+# with the umbrella refresh (02:00), calendar refresh (04:00),
+# parity (06:00), or data-quality (07:00) timers on the engine DB
+# write lock. The :30 offset also keeps clear of the hourly :15
+# calendar value sweep.
+OnCalendar=*-*-* 00,06,12,18:30:00
+AccuracySec=1m
+
+# Late catch-up is fine — each cycle is idempotent across run_source
+# upserts and the digest is re-computed each fire.
+Persistent=true
+
+Unit=shadow-digest.service
+
+[Install]
+WantedBy=timers.target

--- a/shadow_runner.py
+++ b/shadow_runner.py
@@ -210,8 +210,14 @@ def run_shadow(
     *,
     interval_hours: float = 6,
     db_path: str | None = None,
+    cycles: int | None = None,
 ) -> None:
-    """Run ingestion every N hours, log everything, write daily digest."""
+    """Run ingestion every N hours, log everything, write daily digest.
+
+    ``cycles`` caps the loop after that many iterations; ``None`` (default)
+    means run forever. ``cycles=1`` is the systemd-timer mode — one full
+    pass + digest write + exit, with the timer driving the next firing.
+    """
     # Lazy import so logging is set up first
     sys.path.insert(0, str(Path(__file__).parent / "src"))
     from macro_data.factory import build_local_macro_data_service
@@ -228,7 +234,7 @@ def run_shadow(
     logger.info("Release schedules seeded")
 
     cycle = 0
-    while True:
+    while cycles is None or cycle < cycles:
         cycle += 1
         logger.info("═══ Shadow cycle %d starting ═══", cycle)
         t0 = time.perf_counter()
@@ -281,7 +287,13 @@ def run_shadow(
         except Exception as exc:
             logger.error("Failed to compute digest: %s", exc)
 
-        # Sleep until next cycle
+        # Skip the inter-cycle sleep when this was the last scheduled
+        # cycle — under systemd `--once` (cycles=1) the timer drives the
+        # next firing, so any sleep here would just push the oneshot
+        # service into TimeoutStartSec and cost a failed unit per run.
+        if cycles is not None and cycle >= cycles:
+            break
+
         logger.info("Sleeping %.1fh until next cycle...", interval_hours)
         time.sleep(interval_hours * 3600)
 
@@ -292,11 +304,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Shadow mode ingestion runner")
     parser.add_argument("--interval", type=float, default=6, help="Hours between cycles (default 6)")
     parser.add_argument("--db-path", default=None, help="Database path")
+    parser.add_argument("--once", action="store_true",
+                        help="Run a single cycle and exit (for systemd timer use)")
     args = parser.parse_args()
 
     setup_logging()
-    logger.info("Starting shadow mode (interval=%.1fh)", args.interval)
+    cycles = 1 if args.once else None
+    logger.info("Starting shadow mode (interval=%.1fh, cycles=%s)",
+                args.interval, "once" if args.once else "forever")
     try:
-        run_shadow(interval_hours=args.interval, db_path=args.db_path)
+        run_shadow(interval_hours=args.interval, db_path=args.db_path, cycles=cycles)
     except KeyboardInterrupt:
         logger.info("Shadow mode stopped by user")


### PR DESCRIPTION
## Summary
Three systemd unit pairs that complete the VPS writer set, plus a `--once` mode for `shadow_runner.py` so the daemon's interval loop is bypassable under timer-driven scheduling.

| New unit | Cadence | Wraps |
|---|---|---|
| `macro-data-refresh.{service,timer}` | daily 02:00 UTC | `python3 -m macro_data.cli refresh` (umbrella `refresh_all_sources`) |
| `shadow-digest.{service,timer}` | every 6h at :30 (00/06/12/18 UTC) | `python3 shadow_runner.py --once` |
| `data-quality-daily.{service,timer}` | daily 07:00 UTC | `python3 scripts/data_quality_daily.py` |

Plus 3 wrappers (`scripts/{data_quality_daily,shadow_runner,macro_data_refresh}_wrapper.sh`), an `--once` flag on `shadow_runner.py`, and a "Writer timer pack (issue #106)" section appended to `scripts/systemd/README.md`.

## Codex review round 1 — 1 P1 accepted (rule 4)
- shadow_runner.py was sleeping for the full interval after the final `--once` cycle. Under the systemd `oneshot` service this would push every firing past `TimeoutStartSec=5400` and record a failed unit per run. Fix: break before the sleep when this was the last scheduled cycle.

## Test plan
- [x] bash -n on all 3 wrappers
- [x] `python3 -c 'import ast; ast.parse(open("shadow_runner.py").read())'` — AST parses
- [x] `python3 shadow_runner.py --help` shows `--once` flag
- [x] All 3 wrappers chmod +x (mode 100755 in commit)
- [ ] After dev → master merge, GH Actions auto-deploys files to `data@vl:/home/data/macro-data-service/scripts/`
- [ ] Manual systemctl install + enable on VPS (requires `pip install -e .` or PYTHONPATH=src + `/etc/macro-data/.env` filled with at least one upstream API key)

## Out of scope (deferred to follow-ups)
- Per-family `refresh-source` timers (US / EU / JP / CN / global) — current umbrella covers every source today
- VPS-side install: needs Python venv, dependencies (`pip install -e .` or `uv sync`), and `/etc/macro-data/.env` filled with API keys
- The `EnvironmentFile=` systemd directive linking units to `/etc/macro-data/.env` — same pattern as #133 doc note; lands when systemd unit hardening (#137) covers all production units

Refs #106.