### PR TITLE
fix: VPS enablement unblockers — wrapper venv + fastapi pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "clickhouse-connect>=0.7",
     "curl_cffi",
     "feedparser",
-    "fastapi",
+    "fastapi<0.111",  # add_event_handler removed in 0.111; migrate to lifespan as follow-up
     "httpx",
     "markdownify",
     "mmh3>=4.1.0",

--- a/scripts/data_quality_daily_wrapper.sh
+++ b/scripts/data_quality_daily_wrapper.sh
@@ -19,5 +19,10 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/data_quality_daily.lock"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
+# Prefer the repo-local venv if present (VPS install pattern); fall back
+# to system python3 for dev workstations that have deps available
+# system-wide.
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/data_quality_daily.py "$@"
+    "$PYTHON_BIN" scripts/data_quality_daily.py "$@"

--- a/scripts/macro_data_refresh_wrapper.sh
+++ b/scripts/macro_data_refresh_wrapper.sh
@@ -30,8 +30,15 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/macro_data_refresh.lock"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
-# PYTHONPATH=src makes the CLI runnable even on hosts without an
-# editable install (`pip install -e .`).
-exec flock --nonblock "$LOCK_FILE" \
-    env PYTHONPATH="${REPO_ROOT}/src" \
-    python3 -m macro_data.cli refresh "$@"
+# Prefer the repo-local venv (VPS install pattern, deps already
+# installed via `pip install -e .`); fall back to system python3 + an
+# explicit PYTHONPATH for dev workstations without an editable install.
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+if [ -x "$PYTHON_BIN" ]; then
+  exec flock --nonblock "$LOCK_FILE" \
+      "$PYTHON_BIN" -m macro_data.cli refresh "$@"
+else
+  exec flock --nonblock "$LOCK_FILE" \
+      env PYTHONPATH="${REPO_ROOT}/src" \
+      python3 -m macro_data.cli refresh "$@"
+fi

--- a/scripts/shadow_runner_wrapper.sh
+++ b/scripts/shadow_runner_wrapper.sh
@@ -23,5 +23,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/shadow_digest.lock"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 shadow_runner.py --once "$@"
+    "$PYTHON_BIN" shadow_runner.py --once "$@"


### PR DESCRIPTION
## Summary
Two follow-up fixes for #106 VPS enablement, surfaced while installing the timer pack on `data@vl`:

- `cbc35e7` — wrappers prefer `.venv/bin/python` if present (was hardcoded `python3` which on a fresh host had no deps).
- `fc9950e` — pin `fastapi<0.111` (the latest 0.118 removed `add_event_handler` which `server.py:370` still uses). Follow-up to migrate to `lifespan` filed as #153.

Triggers auto-deploy.

## Test plan
- [x] On dev: bash -n on wrappers, AST on shadow_runner.py
- [ ] After merge, deploy delivers updated wrappers + pyproject.toml to VPS
- [ ] On VPS: `.venv/bin/pip install --upgrade -e .` picks fastapi<0.111
- [ ] On VPS: `from macro_data import cli` succeeds
- [ ] systemd timer pack enable + verify firing

Refs #106, #153.