### PR TITLE
feat(ops): macro-data-api systemd unit + Caddy front-door (#137 Option A)

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -19,6 +19,7 @@ jobs run under the VPS writer profile.
 | `macro-data-refresh.timer` | daily 02:00 UTC | umbrella `refresh_all_sources` — catch-all for sources not on a release-watch loop | #106 |
 | `shadow-digest.timer` | every 6h at :30 (00/06/12/18 UTC) | full ingestion cycle + coverage digest (`shadow_runner.py --once`) | #106 |
 | `data-quality-daily.timer` | daily 07:00 UTC | macro DQ rollup → single GH `data-quality` issue (filer #102, packaging #106) | #106 |
+| `macro-data-api.service` | always-on | uvicorn HTTP reader API on 127.0.0.1:8765 — Caddy / proxy fronts external traffic | #137 (Option A subset, no CF Health Check) |
 
 # Parity tripwire systemd unit
 
@@ -264,6 +265,15 @@ manual `macro-data-service refresh` runs:
   secret-leak signal.
 
 ```bash
+# 1. Enable lingering once per host for the user that owns the units.
+#    Without this, the systemd --user manager exits at logout and the
+#    timers stop firing until next interactive login. Idempotent.
+sudo loginctl enable-linger data
+
+# 2. Copy units. Same Environment= / ExecStart= caveat as the other
+#    units — edit each .service if your checkout is at a path other
+#    than %h/Desktop/analyst/macro-data-service. On the VPS data lane
+#    this is /home/data/macro-data-service.
 mkdir -p ~/.config/systemd/user
 cp scripts/systemd/macro-data-refresh.service ~/.config/systemd/user/
 cp scripts/systemd/macro-data-refresh.timer   ~/.config/systemd/user/
@@ -271,11 +281,6 @@ cp scripts/systemd/shadow-digest.service      ~/.config/systemd/user/
 cp scripts/systemd/shadow-digest.timer        ~/.config/systemd/user/
 cp scripts/systemd/data-quality-daily.service ~/.config/systemd/user/
 cp scripts/systemd/data-quality-daily.timer   ~/.config/systemd/user/
-
-# Same Environment= / ExecStart= caveat as the other units — edit each
-# .service if your checkout is at a path other than
-# %h/Desktop/analyst/macro-data-service. On the VPS data lane this is
-# /home/data/macro-data-service.
 
 systemctl --user daemon-reload
 systemctl --user enable --now macro-data-refresh.timer
@@ -333,3 +338,75 @@ Design notes:
   umbrella `refresh_all_sources` op. Per-family timers
   (US / EU / JP / CN / global) are a future enhancement once each
   family's refresh budget and cadence justify independent scheduling.
+
+## HTTP reader API (Option A subset of issue #137)
+
+`macro-data-api.service` runs uvicorn as a long-running daemon that
+binds **127.0.0.1:8765** only — public traffic comes in via a
+reverse-proxy front-door (currently Caddy on the data VPS).
+
+Install:
+
+```bash
+# 1. Enable lingering for the data user so the systemd --user manager
+#    survives logout (otherwise the API stops the moment the install
+#    SSH session closes, and Caddy proxies to a dead 127.0.0.1:8765).
+#    Idempotent — re-running is a no-op.
+sudo loginctl enable-linger data
+
+# 2. Stamp the unit with the VPS path and copy to the user manager.
+mkdir -p ~/.config/systemd/user
+sed 's|%h/Desktop/analyst/macro-data-service|/home/data/macro-data-service|g' \
+    scripts/systemd/macro-data-api.service \
+    > ~/.config/systemd/user/macro-data-api.service
+
+systemctl --user daemon-reload
+systemctl --user enable --now macro-data-api.service
+```
+
+Verify:
+
+```bash
+systemctl --user status macro-data-api.service --no-pager
+journalctl --user -u macro-data-api.service -n 50 --no-pager
+curl -s http://127.0.0.1:8765/healthz
+```
+
+Caddy front-door (data VPS specific — `/etc/caddy/Caddyfile`):
+
+```
+macro.217-15-165-83.sslip.io {
+    encode gzip
+    reverse_proxy 127.0.0.1:8765 {
+        flush_interval -1
+    }
+}
+```
+
+Then `sudo systemctl reload caddy`. Caddy auto-issues an LE cert for
+the new hostname on first request.
+
+Operations:
+
+* Logs: `journalctl --user -u macro-data-api.service` (structured access
+  log JSON per request: `method`, `path`, `status`, `consumer_id`,
+  `latency_ms`).
+* `/healthz` is unauthenticated; everything else requires `X-API-Key`
+  matching `/etc/macro-data/api_tokens.json`.
+* `MemoryMax=2G` + `CPUQuota=200%` — caps a runaway query at 2GB / two
+  cores. Adjust upward only after observing a real workload squeezing
+  these limits.
+
+Design notes:
+
+* **Bind 127.0.0.1**, not 0.0.0.0 — defense in depth. UFW already
+  blocks public :8765 (only :22 + :443 + bench's pre-existing :80
+  are allowed), and binding to loopback closes the gap if UFW ever
+  has a hole.
+* **EnvironmentFile=-/etc/macro-data/.env** — `-` makes it optional so
+  laptop dev installs without the file don't fail unit start. Production
+  fills the file via the #133 secrets template.
+* **Coexistence with bench's :8000 quanttutor on Caddy** — the
+  Caddyfile addition is a brand-new site block, not a modification of
+  bench's existing block. `caddy reload` is graceful (zero downtime
+  for quanttutor). No coordination needed beyond a heads-up.

--- a/scripts/systemd/macro-data-api.service
+++ b/scripts/systemd/macro-data-api.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=macro-data-service HTTP reader API (uvicorn)
+After=network-online.target
+Wants=network-online.target
+# Crash-loop cap: belongs in [Unit] (systemd 255 ignores these under
+# [Service]). Pairs with Restart=on-failure + RestartSec below.
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+# Replace WorkingDirectory + ExecStart paths below with the absolute path
+# to your checkout, e.g. /home/data/macro-data-service on the VPS data
+# lane. Same edit caveat as the timer pack units.
+WorkingDirectory=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
+# Leading `-` means optional — laptop dev hosts without /etc/macro-data
+# don't fail unit start.
+EnvironmentFile=-/etc/macro-data/.env
+
+# Wait for ClickHouse on 127.0.0.1:8123 before starting uvicorn — running
+# as systemd --user means After=clickhouse-server.service can't reach the
+# system manager, so on reboot the API can start before CH and the
+# factory's clickhouse_client_from_env() returns None for the lifetime
+# of the process (no market reads). The poll fails after ~20s and lets
+# Restart=on-failure handle it.
+ExecStartPre=/bin/bash -c 'for i in 1 2 3 4 5 6 7 8 9 10; do clickhouse-client --host 127.0.0.1 --query "SELECT 1" >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1'
+
+ExecStart=%h/Desktop/analyst/macro-data-service/.venv/bin/python -m macro_data.server --host 127.0.0.1 --port 8765
+
+# uvicorn crashes are usually transient (upstream timeouts, OOM); restart
+# fast but cap is enforced via [Unit] StartLimit* — a wedged crash loop
+# surfaces as a failed unit instead of churning forever.
+Restart=on-failure
+RestartSec=5s
+
+# Resource limits (#137) — read API is single-process + worker pool;
+# 2GB caps a runaway query, 200% lets it burst across two cores.
+MemoryMax=2G
+CPUQuota=200%
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=macro-data-api
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
Adds the missing always-on uvicorn unit so macro-data API stops being a manually-`tmux`'d rick session, and documents the Caddy site block that exposes it externally without colliding with bench's pre-existing `217-15-165-83.sslip.io` quanttutor.

| File | New / mod | Purpose |
|---|---|---|
| `scripts/systemd/macro-data-api.service` | new | uvicorn 127.0.0.1:8765, EnvironmentFile=/etc/macro-data/.env, MemoryMax=2G, CPUQuota=200%, ExecStartPre wait-for-CH |
| `scripts/systemd/README.md` | mod | adds "HTTP reader API" section + linger note in install steps (also adds linger note to existing #106 timer-pack section for consistency) |

External hostname: `macro.217-15-165-83.sslip.io` (sslip.io subdomain syntax, no domain registration needed). Caddy auto-issues LE cert on first request.

## Codex review round 1 — 3 P1/P2 accepted
- **P1** README install adds `sudo loginctl enable-linger data` so user-manager survives logout. Same line added to #106 timer-pack block (root cause identical).
- **P2** Drops no-op cross-namespace `After=clickhouse-server.service` and adds an `ExecStartPre` poll that waits ~20s for `clickhouse-client SELECT 1`. Prevents uvicorn starting before CH on reboot (would otherwise serve `market_store=None` for process lifetime).
- **P2** Moves `StartLimitBurst` / `StartLimitIntervalSec` from `[Service]` to `[Unit]` — systemd 255 ignores them under `[Service]`, the 5-per-60s crash-loop cap was a no-op.

## Test plan
- [x] `systemd-analyze --user verify` passes (the laptop `.venv` not-found warning is expected; VPS install sed-substitutes the path)
- [ ] After merge dev → master + auto-deploy, install on VPS via the documented steps
- [ ] Kill rick's manual `pid 62481` (51-day-old session-bound instance on :8765)
- [ ] Verify `systemctl --user status macro-data-api.service` active
- [ ] Add Caddy `macro.217-15-165-83.sslip.io` site block + reload
- [ ] `curl https://macro.217-15-165-83.sslip.io/healthz` returns `{"status": "ok"}`

## Out of scope (explicitly Option A)
- No Cloudflare front-door (covered separately in deferred #135)
- No CF Health Checks → DQ filer wiring (the rest of #137 — depends on CF being adopted; revisit if traffic justifies)
- Bench's quanttutor on `217-15-165-83.sslip.io` root is untouched; we're adding a sibling site block, not modifying his

Refs #137.