### PR TITLE
feat(ops): full-DB backup + B2 off-site replication (#136)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,33 @@ dev-local artifacts (`.agents/`, `.claude/`, `.coderabbit.yaml`,
 `sudo` group); the ed25519 deploy key is the only credential GitHub Actions
 holds.
 
+### Backup + off-site replication (issue #136)
+
+Two systemd timers cover physical recovery:
+
+- `macro-data-backup.timer` — daily 19:00 UTC. Online SQLite `.backup` of
+  `engine.db` + ClickHouse `BACKUP DATABASE market`, both written under
+  `/var/lib/macro-data/backups/{sqlite,clickhouse}/<date>/`, then pushed to
+  Backblaze B2 via rclone with a client-side crypt remote so plaintext never
+  leaves the host. Local retention 7 days; B2 `daily/` retention 30 days
+  (bucket lifecycle); B2 `monthly/<YYYY-MM>/` written on day 1 and exempt
+  from lifecycle.
+- `macro-data-restore-drill.timer` — monthly 1st 08:00 UTC. Pulls the most
+  recent `daily/` snapshots, validates SQLite via golden queries + sha256
+  hash, validates the ClickHouse archive structurally (tar OK + `metadata/`
+  + `data/` present + size sane), and writes a JSON record to
+  `/var/log/macro-data/restore_drill.log`.
+
+Failure in either pipeline files a `data-quality` + `backup-failure` GitHub
+issue via the wrapper. Setup details (B2 keys, `rclone obscure`,
+`/etc/clickhouse-server/config.d/backups.xml`) live in
+`docs/runbooks/backup_b2.md`.
+
+The legacy `te_calendar_<date>/engine.db` snapshots produced by
+`scripts/parity_daily.py` are unrelated — they're a per-parity-run
+checkpoint kept inside `.macro-data/backups/` and are not part of the
+off-site replication path.
+
 ---
 
 ## Layers

--- a/docs/ops/vps_bootstrap.md
+++ b/docs/ops/vps_bootstrap.md
@@ -133,7 +133,9 @@ take it forward:
 - **#134** *(closed)* — production HTTP stack; the reader unit lands
   in #106.
 - **#135** — Cloudflare front-door + UFW-vs-CF IP whitelist.
-- **#136** — backup + Backblaze B2 off-site replication.
+- **#136** — backup + Backblaze B2 off-site replication. Setup runbook:
+  `docs/runbooks/backup_b2.md` (B2 bucket + key, `rclone obscure`,
+  ClickHouse backup-disk config, systemd install).
 - **#137** — systemd unit hardening + Cloudflare Health Checks.
 - **#140** — cold migration of local `engine.db` + ClickHouse to VPS.
 

--- a/docs/runbooks/backup_b2.md
+++ b/docs/runbooks/backup_b2.md
@@ -1,0 +1,246 @@
+# Backup + off-site replication runbook (issue #136)
+
+End-to-end procedure for the full-DB backup pipeline:
+SQLite `engine.db` + ClickHouse `market` → local `/var/lib/macro-data/backups/`
+→ Backblaze B2 with client-side encryption via rclone.
+
+Cadence:
+
+| Job | Cadence | systemd unit |
+| --- | --- | --- |
+| Daily snapshot + B2 sync | 19:00 UTC (= 03:00 SGT) | `macro-data-backup.timer` |
+| Monthly recovery drill   | 08:00 UTC, 1st of month | `macro-data-restore-drill.timer` |
+
+Retention:
+
+| Location | Retention | Mechanism |
+| --- | --- | --- |
+| `/var/lib/macro-data/backups/` | 7 days | local prune in `daily_backup.sh` |
+| `b2://<bucket>/daily/`         | 30 days | B2 bucket lifecycle rule |
+| `b2://<bucket>/monthly/`       | indefinite | written on day 1; lifecycle exempts `monthly/` |
+
+---
+
+## One-time setup
+
+### 1. Backblaze B2
+
+1. Sign up / sign in to Backblaze, B2 Cloud Storage.
+2. Create a private bucket — default name `macro-data-backups`. Region
+   choice does not matter much; pick the one nearest the VPS.
+3. Lifecycle settings: keep the default "Keep all versions". B2 will
+   not auto-delete anything. Manual lifecycle (below) handles the
+   30-day daily/ rule.
+4. Create an Application Key scoped to the bucket. Allowed operations
+   need at minimum `listFiles`, `readFiles`, `writeFiles`, `deleteFiles`.
+   Save the **keyID** (B2_ACCOUNT_ID) and **applicationKey** (B2_APPLICATION_KEY)
+   — the application key is shown only once.
+5. (Optional, recommended.) Add a bucket-level lifecycle rule so daily
+   uploads expire after 30 days:
+   - Match prefix: `daily/`
+   - Hide files after 1 day, delete after 30 days.
+   - Leave `monthly/` rule absent → never expires.
+
+### 2. Crypt password
+
+`rclone` cannot read a plaintext password from env; it requires the
+output of `rclone obscure`. Generate it once on the VPS:
+
+```bash
+# Pick a strong password (≥32 random chars), then obscure it.
+PLAINTEXT='<a very long random string — keep a secure copy>'
+rclone obscure "$PLAINTEXT"
+# output: <obscured-blob>  ← paste this into RCLONE_CRYPT_PASSWORD
+```
+
+Crypt config in this repo runs with `filename_encryption=off` so the
+B2 object keys stay plaintext (e.g. `daily/sqlite/2026-05-09/engine.db`).
+The bucket lifecycle prefix rule in step 1 only matches plaintext
+prefixes, so encrypting the filenames would silently break retention.
+File contents still ship encrypted; the filenames themselves are not
+considered sensitive.
+
+### 3. Populate `/etc/macro-data/.env`
+
+```
+B2_ACCOUNT_ID=<keyID from B2>
+B2_APPLICATION_KEY=<applicationKey from B2>
+B2_BUCKET=macro-data-backups
+RCLONE_CRYPT_PASSWORD=<output of `rclone obscure '<plaintext>'`>
+```
+
+The wrapper sources `/etc/macro-data/.env` at run-time. Production
+systemd units load it via `EnvironmentFile=`.
+
+### 4. ClickHouse BACKUP disk
+
+`snapshot_clickhouse.sh` calls `BACKUP DATABASE market TO Disk('backup', ...)`.
+That disk has to be declared in ClickHouse server config:
+
+```bash
+sudo tee /etc/clickhouse-server/config.d/backups.xml >/dev/null <<'XML'
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <backup>
+                <type>local</type>
+                <path>/var/lib/clickhouse/backups/</path>
+            </backup>
+        </disks>
+    </storage_configuration>
+    <backups>
+        <allowed_disk>backup</allowed_disk>
+        <allowed_path>/var/lib/clickhouse/backups/</allowed_path>
+    </backups>
+</clickhouse>
+XML
+
+# The 'data' user runs the backup timer and needs to remove
+# /var/lib/clickhouse/backups/<date>/ after tarring it up. Make the
+# disk group-writable and add `data` to the clickhouse group so both
+# users can stage + clean up there.
+sudo install -d -m 0775 -o clickhouse -g clickhouse /var/lib/clickhouse/backups
+sudo usermod -aG clickhouse data
+# `data` must re-login (or `sudo -u data -i`) for the group membership
+# to take effect for that user's processes.
+
+sudo systemctl restart clickhouse-server
+clickhouse-client --query "SELECT name FROM system.disks WHERE name='backup'"
+```
+
+### 5. Local backup root
+
+```bash
+sudo install -d -m 0750 -o data -g data /var/lib/macro-data/backups
+sudo install -d -m 0750 -o data -g data /var/log/macro-data
+```
+
+### 6. Install systemd units
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp scripts/systemd/macro-data-backup.service        ~/.config/systemd/user/
+cp scripts/systemd/macro-data-backup.timer          ~/.config/systemd/user/
+cp scripts/systemd/macro-data-restore-drill.service ~/.config/systemd/user/
+cp scripts/systemd/macro-data-restore-drill.timer   ~/.config/systemd/user/
+
+# Edit Environment=REPO_ROOT= and ExecStart= paths to point at the
+# checkout (e.g. /home/data/macro-data-service on the data VPS).
+
+systemctl --user daemon-reload
+systemctl --user enable --now macro-data-backup.timer
+systemctl --user enable --now macro-data-restore-drill.timer
+
+# user-level timers fire only while the user has a session — enable
+# linger so they keep firing on a headless VPS.
+loginctl enable-linger "$USER"
+```
+
+Verify:
+
+```bash
+systemctl --user list-timers macro-data-backup.timer macro-data-restore-drill.timer
+journalctl --user -u macro-data-backup.service -n 50
+journalctl --user -u macro-data-restore-drill.service -n 50
+```
+
+### 7. First-run smoke
+
+```bash
+# Snapshot only — does not touch B2.
+scripts/backup/snapshot_sqlite.sh
+scripts/backup/snapshot_clickhouse.sh
+
+# Full pipeline including B2 push (will create encrypted objects).
+scripts/backup/daily_backup.sh
+
+# Recovery drill against today's push.
+scripts/backup/restore_drill.sh
+```
+
+After the first backup run, `rclone lsf backups:daily/` shows
+encrypted filenames; `rclone tree backups:` decrypts on-the-fly via
+the local crypt remote so file listings are readable.
+
+---
+
+## Operations
+
+### Manual run
+
+```bash
+scripts/backup/daily_backup_wrapper.sh
+scripts/backup/restore_drill_wrapper.sh
+```
+
+The wrappers file a `data-quality` GitHub issue on non-zero exit.
+
+### Inspect remote
+
+```bash
+# Decrypt + list
+rclone lsf backups:daily/sqlite/
+rclone lsf backups:monthly/
+
+# Disk usage on B2
+rclone size backups:
+```
+
+### Restore (manual recovery)
+
+SQLite:
+
+```bash
+LATEST=$(rclone lsf backups:daily/sqlite/ --dirs-only | sort | tail -n1 | sed 's:/$::')
+rclone copy "backups:daily/sqlite/$LATEST" /tmp/restore-sqlite/
+sudo systemctl stop macro-data-api.service
+sudo cp /tmp/restore-sqlite/engine.db /var/lib/macro-data/engine.db
+sudo chown data:data /var/lib/macro-data/engine.db
+sudo systemctl start macro-data-api.service
+```
+
+ClickHouse — single database from the latest archive:
+
+```bash
+LATEST=$(rclone lsf backups:daily/clickhouse/ --dirs-only | sort | tail -n1 | sed 's:/$::')
+rclone copy "backups:daily/clickhouse/$LATEST" /tmp/restore-ch/
+sudo install -d -m 0755 -o clickhouse -g clickhouse /var/lib/clickhouse/backups/manual-restore
+sudo tar -xzf /tmp/restore-ch/market.tar.gz -C /var/lib/clickhouse/backups/manual-restore
+sudo chown -R clickhouse:clickhouse /var/lib/clickhouse/backups/manual-restore
+clickhouse-client --query \
+    "RESTORE DATABASE \`market\` AS \`market_restore\` FROM Disk('backup', 'manual-restore/market')"
+# Validate, then DROP + RENAME if you want to swap in:
+clickhouse-client --query "DROP DATABASE market"
+clickhouse-client --query "RENAME DATABASE market_restore TO market"
+```
+
+### Failure escalation
+
+Backup-pipeline and restore-drill failures are filed under a dedicated
+`backup-failure` label (auto-created by the wrapper if absent). The
+ingestion DQ filer uses the `data-quality` label, so the two streams
+stay separate — a backup outage does not interfere with the daily DQ
+issue's open-issue selector. Triage:
+
+1. `journalctl --user -u <unit>.service` — see the actual error.
+2. If the failure is B2-side (403, network), confirm credentials in
+   `/etc/macro-data/.env`. Application keys can be revoked in the B2
+   console — generate a new one + restart.
+3. If the failure is local (disk full, CH BACKUP refused), free space
+   under `/var/lib/clickhouse/backups/` + `/var/lib/macro-data/backups/`
+   and re-run `daily_backup_wrapper.sh`.
+
+---
+
+## Known limitations
+
+- **Single-region B2.** Spec is single bucket; cross-region replication
+  is out of scope.
+- **No PITR.** Daily granularity only — last 24 h of writes are at risk.
+- **Restore drill skips full CH RESTORE.** Validates archive structural
+  integrity (tar ok, metadata/ + data/ present, size sane) but doesn't
+  exercise `RESTORE DATABASE`. The manual section above is the full
+  exercise; perform it once a quarter as belt-and-braces.
+- **rclone obscure is reversible.** The obscured value protects against
+  shoulder-surfing, not exfiltration. Treat `/etc/macro-data/.env` as a
+  secret file (chmod 600, owned by `data`).

--- a/scripts/backup/daily_backup.sh
+++ b/scripts/backup/daily_backup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# daily_backup.sh — chain the backup pipeline (issue #136).
+#
+# Order: snapshot_sqlite → snapshot_clickhouse → sync_to_b2 → prune local
+# beyond BACKUP_LOCAL_RETENTION_DAYS. Any non-zero exit aborts the chain
+# and the wrapper above us files a data-quality issue.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+DATE="${BACKUP_DATE:-$(date -u +%F)}"
+LOCAL_ROOT="${BACKUP_LOCAL_ROOT:-/var/lib/macro-data/backups}"
+RETENTION_DAYS="${BACKUP_LOCAL_RETENTION_DAYS:-7}"
+
+cd "$REPO_ROOT"
+
+# Pull secrets so rclone env vars resolve. systemd already injects this
+# via EnvironmentFile= but a manual run from a terminal needs it too.
+ENV_FILE="${MACRO_DATA_ENV_FILE:-/etc/macro-data/.env}"
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+scripts/backup/snapshot_sqlite.sh --date "$DATE"
+scripts/backup/snapshot_clickhouse.sh --date "$DATE"
+scripts/backup/sync_to_b2.sh --date "$DATE"
+
+# Local retention: drop per-date subdirs older than the window. Each
+# date dir is mtime-stamped on creation, so -mtime is the simplest gate.
+for kind in sqlite clickhouse; do
+    base="$LOCAL_ROOT/$kind"
+    [[ -d "$base" ]] || continue
+    find "$base" -mindepth 1 -maxdepth 1 -type d -mtime "+$RETENTION_DAYS" \
+        -exec rm -rf {} +
+done
+
+echo "daily_backup ok: $DATE"

--- a/scripts/backup/daily_backup_wrapper.sh
+++ b/scripts/backup/daily_backup_wrapper.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Wrapper for scripts/backup/daily_backup.sh from systemd
+# macro-data-backup.service.
+#
+# Responsibilities:
+#   * flock guard so a slow run + next-day fire don't overlap.
+#   * On failure, file a `data-quality` GitHub issue so #102's filer
+#     surfaces the breakage in the same place as ingestion DQ misses.
+#   * Pass through the underlying exit code so systemd reports failed.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+LOCK_FILE="${REPO_ROOT}/.macro-data/backup_daily.lock"
+mkdir -p "$(dirname "$LOCK_FILE")"
+
+cd "$REPO_ROOT"
+
+set +e
+flock --nonblock --conflict-exit-code 0 "$LOCK_FILE" \
+    "$REPO_ROOT/scripts/backup/daily_backup.sh" "$@"
+RC=$?
+set -e
+
+if (( RC != 0 )); then
+    TITLE="backup pipeline failed $(date -u +%F)"
+    LOG_TAIL="$(journalctl --user -u macro-data-backup.service -n 80 --no-pager 2>/dev/null || true)"
+    BODY=$(cat <<EOF
+\`macro-data-backup.service\` returned $RC at $(date -u +%FT%TZ).
+
+Likely culprits: B2 unreachable, application key revoked, disk full
+on /var/lib/macro-data/backups, or ClickHouse BACKUP refused. Check
+/etc/macro-data/.env and re-run manually:
+
+\`\`\`
+$REPO_ROOT/scripts/backup/daily_backup_wrapper.sh
+\`\`\`
+
+\`\`\`
+$LOG_TAIL
+\`\`\`
+
+Auto-filed by daily_backup_wrapper.sh — issue #136.
+EOF
+)
+    # Use a dedicated label so the DQ filer's `data-quality`-keyed
+    # selector (data_quality_filer.py:_list_open_data_quality_issue)
+    # doesn't pick this issue up and start commenting on it.
+    gh label create backup-failure --color FBCA04 \
+        --description "Backup pipeline failure" 2>/dev/null || true
+    gh issue create \
+        --title "$TITLE" \
+        --label backup-failure \
+        --body "$BODY" >/dev/null 2>&1 \
+        || echo "gh issue create failed; check creds + manual run" >&2
+fi
+
+exit "$RC"

--- a/scripts/backup/restore_drill.sh
+++ b/scripts/backup/restore_drill.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# restore_drill.sh — monthly recovery drill (issue #136).
+#
+# 1. Pull the most recent daily/{sqlite,clickhouse}/<date>/ from B2.
+# 2. SQLite: open the restored engine.db and run a fixed set of golden
+#    queries; sha256 the result line block. Failure of any query, or a
+#    corrupt DB, exits non-zero so the wrapper's filer fires.
+# 3. ClickHouse: validate tar archive integrity (tar -tzf), confirm the
+#    expected metadata/ + data/ subtrees exist, and that the unpacked
+#    size is plausible. We skip a full RESTORE here — it requires root
+#    or a writable CH backup disk owned by the data user; archive-level
+#    integrity is enough to catch corrupt-on-upload regressions in the
+#    monthly cadence the spec calls for.
+# 4. Append a JSON line (date + hashes + sizes) to the drill log.
+# 5. Always cleanup tmpdir on exit.
+#
+# Usage:
+#   restore_drill.sh [--date YYYY-MM-DD] [--tmpdir PATH] [--log PATH]
+
+set -euo pipefail
+
+DATE="$(date -u +%F)"
+TMPDIR="${RESTORE_DRILL_TMPDIR:-/tmp/restore-$DATE}"
+LOG="${RESTORE_DRILL_LOG:-/var/log/macro-data/restore_drill.log}"
+
+while (( $# )); do
+    case "$1" in
+        --date) DATE="$2"; shift 2;;
+        --tmpdir) TMPDIR="$2"; shift 2;;
+        --log) LOG="$2"; shift 2;;
+        -h|--help) sed -n '2,20p' "$0"; exit 0;;
+        *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+done
+
+ENV_FILE="${MACRO_DATA_ENV_FILE:-/etc/macro-data/.env}"
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+: "${B2_ACCOUNT_ID:?B2_ACCOUNT_ID not set}"
+: "${B2_APPLICATION_KEY:?B2_APPLICATION_KEY not set}"
+: "${RCLONE_CRYPT_PASSWORD:?RCLONE_CRYPT_PASSWORD not set}"
+
+BUCKET="${B2_BUCKET:-macro-data-backups}"
+export RCLONE_CONFIG_B2RAW_TYPE=b2
+export RCLONE_CONFIG_B2RAW_ACCOUNT="$B2_ACCOUNT_ID"
+export RCLONE_CONFIG_B2RAW_KEY="$B2_APPLICATION_KEY"
+export RCLONE_CONFIG_BACKUPS_TYPE=crypt
+export RCLONE_CONFIG_BACKUPS_REMOTE="b2raw:$BUCKET"
+export RCLONE_CONFIG_BACKUPS_PASSWORD="$RCLONE_CRYPT_PASSWORD"
+# Match sync_to_b2.sh — paths plaintext so B2 lifecycle prefix rules
+# work; only file contents are encrypted.
+export RCLONE_CONFIG_BACKUPS_FILENAME_ENCRYPTION=off
+export RCLONE_CONFIG_BACKUPS_DIRECTORY_NAME_ENCRYPTION=false
+
+cleanup() {
+    local code=$?
+    rm -rf "$TMPDIR"
+    exit "$code"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMPDIR" "$(dirname "$LOG")"
+
+# Pick the latest date that has BOTH sqlite and clickhouse uploaded.
+# Picking each independently would happily validate a half-complete day
+# (e.g. SQLite synced for T but ClickHouse stuck on T-1) and report ok.
+SQLITE_DATES=$(rclone lsf "backups:daily/sqlite/"     --dirs-only 2>/dev/null | sed 's:/$::' | sort)
+CH_DATES=$(    rclone lsf "backups:daily/clickhouse/" --dirs-only 2>/dev/null | sed 's:/$::' | sort)
+LATEST_DATE=$(comm -12 <(printf '%s\n' "$SQLITE_DATES") <(printf '%s\n' "$CH_DATES") | tail -n1)
+
+[[ -n "$LATEST_DATE" ]] || { echo "no matching daily backup pair in B2" >&2; exit 1; }
+
+# Reject stale pairs — if uploads stopped weeks ago we'd otherwise
+# happily validate ancient state and report ok. 2-day window absorbs a
+# missed run + UTC/local timezone wraparound.
+FRESHNESS_DAYS="${RESTORE_DRILL_FRESHNESS_DAYS:-2}"
+TODAY=$(date -u +%F)
+DAYS_OLD=$(( ( $(date -u -d "$TODAY" +%s) - $(date -u -d "$LATEST_DATE" +%s) ) / 86400 ))
+if (( DAYS_OLD > FRESHNESS_DAYS )); then
+    echo "stale backup: latest matched pair $LATEST_DATE is $DAYS_OLD days old (max $FRESHNESS_DAYS)" >&2
+    exit 1
+fi
+
+echo "drill: matched_date=$LATEST_DATE days_old=$DAYS_OLD"
+
+rclone copy "backups:daily/sqlite/$LATEST_DATE"     "$TMPDIR/sqlite/"
+rclone copy "backups:daily/clickhouse/$LATEST_DATE" "$TMPDIR/clickhouse/"
+
+# --- SQLite: open + golden queries -------------------------------
+RESTORED_DB="$TMPDIR/sqlite/engine.db"
+[[ -f "$RESTORED_DB" ]] || { echo "engine.db missing in restored backup" >&2; exit 1; }
+
+PYTHON_BIN=""
+for c in "/home/data/macro-data-service/.venv/bin/python" "$(command -v python3)"; do
+    if [[ -x "$c" ]]; then PYTHON_BIN="$c"; break; fi
+done
+[[ -n "$PYTHON_BIN" ]] || { echo "python3 not found" >&2; exit 1; }
+
+SQLITE_OUTPUT=$("$PYTHON_BIN" - "$RESTORED_DB" <<'PY'
+import hashlib, sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+# integrity_check returns rows. A clean DB returns [('ok',)]; corruption
+# shows up as one or more error rows that .fetchall() would otherwise
+# silently discard.
+chk = con.execute("PRAGMA integrity_check").fetchall()
+if chk != [("ok",)]:
+    print(f"integrity_check failed: {chk}", file=sys.stderr)
+    sys.exit(1)
+ops = [
+    "SELECT COUNT(*) FROM concept_map",
+    "SELECT COUNT(*) FROM release_schedule",
+    "SELECT COUNT(*) FROM source_capability",
+    "SELECT COUNT(*) FROM sqlite_master WHERE type='table'",
+]
+lines = []
+for q in ops:
+    lines.append(f"{q}={con.execute(q).fetchone()[0]}")
+con.close()
+blob = "\n".join(lines).encode()
+print(hashlib.sha256(blob).hexdigest())
+print("|".join(lines))
+PY
+)
+SQLITE_HASH=$(echo "$SQLITE_OUTPUT" | sed -n '1p')
+SQLITE_OPS=$(echo  "$SQLITE_OUTPUT" | sed -n '2p')
+
+# --- ClickHouse: archive structural integrity --------------------
+CH_ARCHIVE="$TMPDIR/clickhouse/${CLICKHOUSE_DATABASE:-market}.tar.gz"
+[[ -f "$CH_ARCHIVE" ]] || { echo "archive missing: $CH_ARCHIVE" >&2; exit 1; }
+
+# tar -tzf returns non-zero on a corrupt gz/tar stream. Capture the
+# listing once — `tar -tzf | grep -q` under `set -o pipefail` can
+# surface tar's SIGPIPE (141) as a false alarm once grep short-circuits
+# on a large archive.
+CH_LISTING=$(tar -tzf "$CH_ARCHIVE")
+CH_ENTRIES=$(printf '%s\n' "$CH_LISTING" | wc -l)
+(( CH_ENTRIES > 0 )) || { echo "tar archive empty: $CH_ARCHIVE" >&2; exit 1; }
+
+printf '%s\n' "$CH_LISTING" | grep -q '/metadata/' \
+    || { echo "archive missing metadata/" >&2; exit 1; }
+printf '%s\n' "$CH_LISTING" | grep -q '/data/' \
+    || { echo "archive missing data/" >&2; exit 1; }
+
+CH_SIZE=$(stat -c '%s' "$CH_ARCHIVE")
+
+# --- Log + verdict ----------------------------------------------
+ENTRY=$(printf '{"date":"%s","matched_backup":"%s","sqlite_hash":"%s","sqlite_ops":"%s","clickhouse_archive_size":%s,"clickhouse_entries":%s,"ok":true}\n' \
+    "$DATE" "$LATEST_DATE" "$SQLITE_HASH" "$SQLITE_OPS" \
+    "$CH_SIZE" "$CH_ENTRIES")
+echo "$ENTRY" >> "$LOG"
+echo "$ENTRY"

--- a/scripts/backup/restore_drill_wrapper.sh
+++ b/scripts/backup/restore_drill_wrapper.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Wrapper for scripts/backup/restore_drill.sh from systemd
+# macro-data-restore-drill.service.
+#
+# On failure, file a `data-quality` GitHub issue so a broken backup
+# pipeline surfaces in the same place as ingestion DQ misses.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+LOCK_FILE="${REPO_ROOT}/.macro-data/restore_drill.lock"
+mkdir -p "$(dirname "$LOCK_FILE")"
+
+cd "$REPO_ROOT"
+
+set +e
+flock --nonblock --conflict-exit-code 0 "$LOCK_FILE" \
+    "$REPO_ROOT/scripts/backup/restore_drill.sh" "$@"
+RC=$?
+set -e
+
+if (( RC != 0 )); then
+    TITLE="restore drill failed $(date -u +%F)"
+    LOG_TAIL="$(journalctl --user -u macro-data-restore-drill.service -n 80 --no-pager 2>/dev/null || true)"
+    BODY=$(cat <<EOF
+\`macro-data-restore-drill.service\` returned $RC at $(date -u +%FT%TZ).
+
+Likely culprits: B2 fetch failed, archive corrupt, SQLite integrity
+check failed, ClickHouse archive missing metadata/. The drill is
+read-only — a failure means the most recent backup is not recoverable
+without manual intervention. Re-run after fixing:
+
+\`\`\`
+$REPO_ROOT/scripts/backup/restore_drill_wrapper.sh
+\`\`\`
+
+\`\`\`
+$LOG_TAIL
+\`\`\`
+
+Auto-filed by restore_drill_wrapper.sh — issue #136.
+EOF
+)
+    # Use a dedicated label so the DQ filer's `data-quality`-keyed
+    # selector (data_quality_filer.py:_list_open_data_quality_issue)
+    # doesn't pick this issue up and start commenting on it.
+    gh label create backup-failure --color FBCA04 \
+        --description "Backup pipeline failure" 2>/dev/null || true
+    gh issue create \
+        --title "$TITLE" \
+        --label backup-failure \
+        --body "$BODY" >/dev/null 2>&1 \
+        || echo "gh issue create failed; check creds + manual run" >&2
+fi
+
+exit "$RC"

--- a/scripts/backup/snapshot_clickhouse.sh
+++ b/scripts/backup/snapshot_clickhouse.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# snapshot_clickhouse.sh — ClickHouse BACKUP DATABASE → tar.gz (issue #136).
+#
+# Drives clickhouse-client BACKUP into the pre-configured 'backup' disk,
+# then tars + gzips the result for off-site upload. Assumes the disk is
+# defined in /etc/clickhouse-server/config.d/backups.xml — see runbook
+# docs/runbooks/backup_b2.md for the one-time CH config.
+#
+# Usage:
+#   snapshot_clickhouse.sh [--date YYYY-MM-DD] [--db NAME] [--dest-root PATH]
+#
+# Env:
+#   CLICKHOUSE_DATABASE   source DB name             (default market)
+#   BACKUP_LOCAL_ROOT     backup dir root            (default /var/lib/macro-data/backups)
+#   CH_BACKUP_DISK        ClickHouse disk name       (default backup)
+#   CH_DISK_PATH          filesystem path of disk    (default /var/lib/clickhouse/backups)
+#
+# Stdout: absolute path of the tar.gz archive.
+
+set -euo pipefail
+
+DATE="$(date -u +%F)"
+DB="${CLICKHOUSE_DATABASE:-market}"
+DEST_ROOT="${BACKUP_LOCAL_ROOT:-/var/lib/macro-data/backups}"
+CH_BACKUP_DISK="${CH_BACKUP_DISK:-backup}"
+CH_DISK_PATH="${CH_DISK_PATH:-/var/lib/clickhouse/backups}"
+
+while (( $# )); do
+    case "$1" in
+        --date) DATE="$2"; shift 2;;
+        --db)   DB="$2";   shift 2;;
+        --dest-root) DEST_ROOT="$2"; shift 2;;
+        -h|--help) sed -n '2,18p' "$0"; exit 0;;
+        *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+done
+
+DEST_DIR="$DEST_ROOT/clickhouse/$DATE"
+mkdir -p "$DEST_DIR"
+
+# Inside ClickHouse the BACKUP target is keyed by Disk('<name>', '<rel-path>').
+# Remove any prior partial run on the same date so BACKUP doesn't refuse.
+SRC_PATH="$CH_DISK_PATH/$DATE/$DB"
+[[ -d "$SRC_PATH" ]] && rm -rf "$SRC_PATH"
+
+clickhouse-client --query \
+    "BACKUP DATABASE \`$DB\` TO Disk('$CH_BACKUP_DISK', '$DATE/$DB')"
+
+[[ -d "$SRC_PATH" ]] || { echo "expected ClickHouse backup at $SRC_PATH" >&2; exit 1; }
+
+DEST="$DEST_DIR/$DB.tar.gz"
+tar -C "$CH_DISK_PATH/$DATE" -czf "$DEST" "$DB"
+rm -rf "$CH_DISK_PATH/$DATE"
+
+echo "$DEST"

--- a/scripts/backup/snapshot_sqlite.sh
+++ b/scripts/backup/snapshot_sqlite.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# snapshot_sqlite.sh — online SQLite snapshot of engine.db (issue #136).
+#
+# Uses Python's sqlite3 .backup API so the snapshot is consistent even
+# while a writer holds the WAL — a plain shutil.copy / cp could capture
+# pages mid-flight. Same pattern as parity_daily.py:_refresh_backup_snapshot.
+#
+# Usage:
+#   snapshot_sqlite.sh [--date YYYY-MM-DD] [--src PATH] [--dest-root PATH]
+#
+# Env (lower priority than flags):
+#   ANALYST_MACRO_DATA_DB_PATH    source engine.db   (default /var/lib/macro-data/engine.db)
+#   BACKUP_LOCAL_ROOT             backup dir root    (default /var/lib/macro-data/backups)
+#
+# Stdout: absolute path of the written snapshot.
+
+set -euo pipefail
+
+DATE="$(date -u +%F)"
+SRC="${ANALYST_MACRO_DATA_DB_PATH:-/var/lib/macro-data/engine.db}"
+DEST_ROOT="${BACKUP_LOCAL_ROOT:-/var/lib/macro-data/backups}"
+
+while (( $# )); do
+    case "$1" in
+        --date) DATE="$2"; shift 2;;
+        --src)  SRC="$2";  shift 2;;
+        --dest-root) DEST_ROOT="$2"; shift 2;;
+        -h|--help) sed -n '2,15p' "$0"; exit 0;;
+        *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+done
+
+[[ -f "$SRC" ]] || { echo "source DB not found: $SRC" >&2; exit 1; }
+
+DEST_DIR="$DEST_ROOT/sqlite/$DATE"
+DEST="$DEST_DIR/engine.db"
+mkdir -p "$DEST_DIR"
+
+PYTHON_BIN=""
+for c in "/home/data/macro-data-service/.venv/bin/python" "$(command -v python3)"; do
+    if [[ -x "$c" ]]; then PYTHON_BIN="$c"; break; fi
+done
+[[ -n "$PYTHON_BIN" ]] || { echo "python3 not found" >&2; exit 1; }
+
+"$PYTHON_BIN" - "$SRC" "$DEST" <<'PY'
+import sqlite3, sys
+src, dest = sys.argv[1], sys.argv[2]
+s = sqlite3.connect(src)
+try:
+    d = sqlite3.connect(dest)
+    try:
+        s.backup(d)
+    finally:
+        d.close()
+finally:
+    s.close()
+PY
+
+echo "$DEST"

--- a/scripts/backup/sync_to_b2.sh
+++ b/scripts/backup/sync_to_b2.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# sync_to_b2.sh — encrypted off-site sync to Backblaze B2 (issue #136).
+#
+# Streams /var/lib/macro-data/backups/{sqlite,clickhouse}/<date>/ to a
+# B2 bucket via rclone's crypt remote. The crypt remote sits on top of
+# a raw B2 remote so files are encrypted client-side before they leave
+# the host. Bucket lifecycle on the B2 side enforces 30-day retention
+# for daily/. On the 1st of each month the day's snapshots are also
+# copied to monthly/<YYYY-MM>/, which is kept indefinitely.
+#
+# Required env (sourced from /etc/macro-data/.env in production):
+#   B2_ACCOUNT_ID, B2_APPLICATION_KEY,
+#   RCLONE_CRYPT_PASSWORD          (already 'rclone obscure'd — see runbook)
+# Optional:
+#   B2_BUCKET                      bucket name      (default macro-data-backups)
+#   BACKUP_LOCAL_ROOT              local source dir (default /var/lib/macro-data/backups)
+#
+# Usage:
+#   sync_to_b2.sh [--date YYYY-MM-DD]
+
+set -euo pipefail
+
+DATE="$(date -u +%F)"
+SRC="${BACKUP_LOCAL_ROOT:-/var/lib/macro-data/backups}"
+BUCKET="${B2_BUCKET:-macro-data-backups}"
+
+while (( $# )); do
+    case "$1" in
+        --date) DATE="$2"; shift 2;;
+        -h|--help) sed -n '2,21p' "$0"; exit 0;;
+        *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+done
+
+: "${B2_ACCOUNT_ID:?B2_ACCOUNT_ID not set}"
+: "${B2_APPLICATION_KEY:?B2_APPLICATION_KEY not set}"
+: "${RCLONE_CRYPT_PASSWORD:?RCLONE_CRYPT_PASSWORD not set (run 'rclone obscure' first)}"
+
+# rclone reads RCLONE_CONFIG_<remote>_<key> for env-var-driven remotes,
+# so we don't need a config file on disk. Two remotes: 'b2raw' (the
+# bucket) and 'backups' (crypt over b2raw).
+export RCLONE_CONFIG_B2RAW_TYPE=b2
+export RCLONE_CONFIG_B2RAW_ACCOUNT="$B2_ACCOUNT_ID"
+export RCLONE_CONFIG_B2RAW_KEY="$B2_APPLICATION_KEY"
+export RCLONE_CONFIG_B2RAW_HARD_DELETE=false
+
+export RCLONE_CONFIG_BACKUPS_TYPE=crypt
+export RCLONE_CONFIG_BACKUPS_REMOTE="b2raw:$BUCKET"
+export RCLONE_CONFIG_BACKUPS_PASSWORD="$RCLONE_CRYPT_PASSWORD"
+# Encrypt file CONTENTS only, leave the path/filename in plaintext on
+# B2. With default crypt settings the daily/ + monthly/ keys would be
+# scrambled too, defeating bucket lifecycle rules that match prefix.
+# Backup file names ('engine.db', 'market.tar.gz', date dirs) are not
+# sensitive on their own; the data inside still ships encrypted.
+export RCLONE_CONFIG_BACKUPS_FILENAME_ENCRYPTION=off
+export RCLONE_CONFIG_BACKUPS_DIRECTORY_NAME_ENCRYPTION=false
+
+# Daily push: copy today's per-date dirs into daily/. We use copy not
+# sync — local /var/lib retention is shorter (7d) than remote (30d), so
+# remote files older than 7d must NOT be deleted by the local side.
+RCLONE_FLAGS=(--transfers=4 --checkers=8 --fast-list)
+
+if [[ -d "$SRC/sqlite/$DATE" ]]; then
+    rclone copy "$SRC/sqlite/$DATE" "backups:daily/sqlite/$DATE" "${RCLONE_FLAGS[@]}"
+else
+    echo "warn: no sqlite snapshot at $SRC/sqlite/$DATE" >&2
+fi
+
+if [[ -d "$SRC/clickhouse/$DATE" ]]; then
+    rclone copy "$SRC/clickhouse/$DATE" "backups:daily/clickhouse/$DATE" "${RCLONE_FLAGS[@]}"
+else
+    echo "warn: no clickhouse snapshot at $SRC/clickhouse/$DATE" >&2
+fi
+
+# Monthly archive — never expired by lifecycle.
+DAY=$(date -u -d "$DATE" +%d)
+if [[ "$DAY" == "01" ]]; then
+    YYYYMM=$(date -u -d "$DATE" +%Y-%m)
+    [[ -d "$SRC/sqlite/$DATE" ]] && \
+        rclone copy "$SRC/sqlite/$DATE" \
+            "backups:monthly/$YYYYMM/sqlite/$DATE" "${RCLONE_FLAGS[@]}"
+    [[ -d "$SRC/clickhouse/$DATE" ]] && \
+        rclone copy "$SRC/clickhouse/$DATE" \
+            "backups:monthly/$YYYYMM/clickhouse/$DATE" "${RCLONE_FLAGS[@]}"
+fi

--- a/scripts/bootstrap/secrets.env.template
+++ b/scripts/bootstrap/secrets.env.template
@@ -60,9 +60,16 @@ WAYBACK_S3_ACCESSKEY=
 WAYBACK_S3_SECRET=
 
 # ---------------- Backups → Backblaze B2 (#136) --------
+# B2 application-key creds (NOT the master account id). Create a key in
+# the B2 console scoped to the bucket below; allowedOperations should
+# cover read/write/list/delete.
 B2_ACCOUNT_ID=
 B2_APPLICATION_KEY=
-B2_BUCKET=
+B2_BUCKET=macro-data-backups
+# Crypt password — value MUST be the output of `rclone obscure '<plaintext>'`,
+# not the plaintext itself. Without obscuring, rclone refuses the password.
+# We run with filename_encryption=off so paths stay plaintext on B2 (lets
+# bucket lifecycle prefix rules work); only file contents are encrypted.
 RCLONE_CRYPT_PASSWORD=
 
 # ---------------- Cloudflare (#135) ---------------------

--- a/scripts/bootstrap/vps_bootstrap.sh
+++ b/scripts/bootstrap/vps_bootstrap.sh
@@ -47,7 +47,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
 sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
   ca-certificates curl gnupg lsb-release apt-transport-https \
   unattended-upgrades chrony fail2ban ufw git \
-  python3.12 python3.12-venv python3-pip
+  python3.12 python3.12-venv python3-pip \
+  rclone
 sudo systemctl enable --now unattended-upgrades.service >/dev/null
 
 # ---------- 2/8 timezone UTC + chrony -------------------------------------

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -20,6 +20,8 @@ jobs run under the VPS writer profile.
 | `shadow-digest.timer` | every 6h at :30 (00/06/12/18 UTC) | full ingestion cycle + coverage digest (`shadow_runner.py --once`) | #106 |
 | `data-quality-daily.timer` | daily 07:00 UTC | macro DQ rollup → single GH `data-quality` issue (filer #102, packaging #106) | #106 |
 | `macro-data-api.service` | always-on | uvicorn HTTP reader API on 127.0.0.1:8765 — Caddy / proxy fronts external traffic | #137 (Option A subset, no CF Health Check) |
+| `macro-data-backup.timer` | daily 19:00 UTC (= 03:00 SGT) | engine.db + ClickHouse `market` snapshot → encrypted B2 sync | #136 |
+| `macro-data-restore-drill.timer` | monthly 1st 08:00 UTC | pull latest backup → integrity check; failure → `data-quality` filer | #136 |
 
 # Parity tripwire systemd unit
 
@@ -410,3 +412,37 @@ Design notes:
   Caddyfile addition is a brand-new site block, not a modification of
   bench's existing block. `caddy reload` is graceful (zero downtime
   for quanttutor). No coordination needed beyond a heads-up.
+
+## Backup + restore drill (issue #136)
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp scripts/systemd/macro-data-backup.service        ~/.config/systemd/user/
+cp scripts/systemd/macro-data-backup.timer          ~/.config/systemd/user/
+cp scripts/systemd/macro-data-restore-drill.service ~/.config/systemd/user/
+cp scripts/systemd/macro-data-restore-drill.timer   ~/.config/systemd/user/
+
+# Edit Environment=REPO_ROOT= and ExecStart= paths in each .service if
+# the checkout is not at ~/Desktop/analyst/macro-data-service. On the
+# data VPS: /home/data/macro-data-service.
+
+systemctl --user daemon-reload
+systemctl --user enable --now macro-data-backup.timer
+systemctl --user enable --now macro-data-restore-drill.timer
+```
+
+The full setup — B2 bucket + application key, `rclone obscure` for the
+crypt password, ClickHouse backup-disk config, env-file population — is
+in `docs/runbooks/backup_b2.md`.
+
+Operations:
+
+* Daily structured log: `/var/log/macro-data/restore_drill.log` (one JSON
+  per drill: hashes, archive size, freshness).
+* Failure path: `daily_backup_wrapper.sh` and `restore_drill_wrapper.sh`
+  file a GitHub issue under the dedicated `backup-failure` label
+  (auto-created on first failure) so the DQ filer's `data-quality`
+  selector stays out of backup territory.
+* Local snapshots roll over after 7 days; B2 `daily/` rolls over after
+  30 days via bucket lifecycle; B2 `monthly/` is written on day 1 and
+  kept indefinitely.

--- a/scripts/systemd/macro-data-backup.service
+++ b/scripts/systemd/macro-data-backup.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Macro-data daily full-DB backup → Backblaze B2 (issue #136)
+After=network-online.target
+Wants=network-online.target
+# Run after the heaviest writer (shadow-digest 18:30 UTC) finishes so
+# the snapshot captures the day's freshest state.
+After=shadow-digest.service
+
+[Service]
+Type=oneshot
+# Production secrets (B2 keys, RCLONE_CRYPT_PASSWORD) live here. Same
+# convention as the other writer units in this directory.
+EnvironmentFile=/etc/macro-data/.env
+# Replace REPO_ROOT below with your checkout path. On the data VPS:
+#   /home/data/macro-data-service.
+Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
+ExecStart=%h/Desktop/analyst/macro-data-service/scripts/backup/daily_backup_wrapper.sh
+
+# SQLite ~1GB + ClickHouse data tar over residential upload usually
+# completes in 10-20 min. 60 min ceiling absorbs cold starts and B2
+# rate-limit backoff.
+TimeoutStartSec=3600
+
+Restart=no
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/macro-data-backup.timer
+++ b/scripts/systemd/macro-data-backup.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=Daily 19:00 UTC (= 03:00 SGT) full-DB backup (issue #136)
+
+[Timer]
+# 19:00 UTC sits 30 min after the 18:30 shadow-digest fires and well
+# clear of the 22:00 ET market refresh, so the snapshot captures the
+# freshest writer state without contending for the engine DB lock.
+OnCalendar=*-*-* 19:00:00
+AccuracySec=1m
+
+# Catch up after a host suspend — the daily_backup is idempotent so a
+# late catch-up just re-uploads the same per-date snapshot.
+Persistent=true
+
+Unit=macro-data-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/systemd/macro-data-restore-drill.service
+++ b/scripts/systemd/macro-data-restore-drill.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Macro-data monthly restore drill from B2 (issue #136)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/macro-data/.env
+# Replace REPO_ROOT below with your checkout path. On the data VPS:
+#   /home/data/macro-data-service.
+Environment=REPO_ROOT=%h/Desktop/analyst/macro-data-service
+Environment=MACRO_DATA_PROFILE=prod
+ExecStart=%h/Desktop/analyst/macro-data-service/scripts/backup/restore_drill_wrapper.sh
+
+# Pull + verify usually completes in 5-10 min; 30 min covers cold-start
+# B2 throttling.
+TimeoutStartSec=1800
+
+Restart=no
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/macro-data-restore-drill.timer
+++ b/scripts/systemd/macro-data-restore-drill.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Monthly 08:00 UTC restore drill (issue #136)
+
+[Timer]
+# Monthly first day at 08:00 UTC — quiet window between the 07:00 DQ
+# rollup and the US market refreshes. Cadence is light (12 fires/year)
+# so collision risk is small either way.
+OnCalendar=*-*-01 08:00:00
+AccuracySec=1m
+
+# Catch-up after suspend or downtime is fine — the drill is read-only.
+Persistent=true
+
+Unit=macro-data-restore-drill.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Daily full-DB snapshot pipeline: SQLite `engine.db` (online `.backup`) + ClickHouse `BACKUP DATABASE market` → tar.gz, written under `/var/lib/macro-data/backups/{sqlite,clickhouse}/<date>/`.
- Encrypted off-site replication via rclone crypt → Backblaze B2 (`daily/` 30 d, `monthly/<YYYY-MM>/` indefinite). `filename_encryption=off` so B2 lifecycle prefix rules can match.
- Monthly recovery drill (`restore_drill.sh`) — pulls latest matched-pair, runs `PRAGMA integrity_check` + golden-ops sha256 + freshness gate (2 d) + CH archive structural integrity. Failure files a `backup-failure`-labeled issue (separate from DQ filer's `data-quality` selector).
- `scripts/systemd/macro-data-backup.{service,timer}` (daily 19:00 UTC = 03:00 SGT) and `macro-data-restore-drill.{service,timer}` (monthly 1st 08:00 UTC).
- Runbook + bootstrap apt for `rclone` + arch / systemd README updates.

## Test plan

Manual on data VPS after merge — see `docs/runbooks/backup_b2.md` for the operator-side setup (B2 bucket + key + lifecycle, `rclone obscure`, CH `backup` disk + `data` group access, systemd install).

- [ ] First-run smoke: `scripts/backup/daily_backup.sh` produces encrypted objects under `b2://macro-data-backups/daily/sqlite/<date>/` and `…/clickhouse/<date>/`.
- [ ] `scripts/backup/restore_drill.sh` exits 0; JSON line lands in `/var/log/macro-data/restore_drill.log`.
- [ ] `systemctl --user list-timers macro-data-backup.timer macro-data-restore-drill.timer` shows the next firing.
- [ ] Simulate failure (revoke B2 key or unplug network mid-run): `gh issue list --label backup-failure` returns the auto-filed issue.

Closes #136