### PR TITLE
feat(ops): cold migration laptop → data VPS (#140)

### DIFF
--- a/docs/ops/cutover.md
+++ b/docs/ops/cutover.md
@@ -1,0 +1,190 @@
+# Cold migration: laptop → data VPS (issue #140)
+
+One-shot procedure to move 823 MB local `engine.db` (272k+ `cal_econ_raw`
+rows, 551k+ `indicator_vintages`, 27k+ `news_articles`, …) and the local
+ClickHouse `market` database to the data VPS. Bronze raw responses cannot
+be re-fetched (upstreams don't keep snapshots), so the cutover preserves
+data identity rather than re-deriving it from upstream.
+
+`scripts/migrate/cutover.sh` orchestrates the move; this doc is the
+operator checklist around it.
+
+---
+
+## Prereqs
+
+Verify each before running:
+
+| Check | Command | Expected |
+| --- | --- | --- |
+| VPS bootstrap done (#133) | `ssh data@vl 'systemctl is-active clickhouse-server'` | `active` |
+| VPS API service installed (#137) | `ssh data@vl 'systemctl --user is-enabled macro-data-api.service'` | `enabled` |
+| VPS backup pipeline installed (#136) | `ssh data@vl 'systemctl --user list-timers macro-data-backup.timer'` | timer listed |
+| VPS writer timers NOT yet enabled | `ssh data@vl 'systemctl --user list-unit-files \*.timer --state=enabled'` | macro-data-backup only |
+| ClickHouse versions compatible | `docker exec macro-data-clickhouse clickhouse-client -q 'SELECT version()'` vs `ssh data@vl clickhouse-client -q 'SELECT version()'` | same major.minor |
+| SSH alias works | `ssh data@vl 'echo ok'` | `ok` |
+| VPS disk free | `ssh data@vl 'df -h /var/lib'` | ≥ 5 GB free |
+
+If VPS clickhouse-server is on a different major than local, **stop here**
+— file-copy migration assumes binary on-disk format compatibility within
+the same major. Either pin both to the same image or use `BACKUP/RESTORE`
+manually (see Troubleshooting below).
+
+---
+
+## Execution
+
+```bash
+# Stage the run (no mutations, prints planned phases):
+scripts/migrate/cutover.sh --dry-run
+
+# Real run. Will prompt for confirmation before stopping local writers.
+scripts/migrate/cutover.sh
+```
+
+Phases (each gated on the previous; failure exits non-zero):
+
+1. **preflight** — SSH reachable, docker running, disk space ok, version compat, operator confirm.
+2. **stop_writers** — `systemctl --user disable --now` each writer timer; verify lock files released.
+3. **snapshot_sqlite** — `sqlite3.backup` API → `/tmp/cutover-<date>/sqlite/engine.db`.
+4. **snapshot_ch** — `docker stop`, `tar czf` the data dir, `docker start`. Brief CH downtime (~30 s) on the local laptop.
+5. **local_baseline** — `cutover_baseline.py` against the snapshots → `local-baseline.json` (per-table COUNT + SQLite file sha256 + CH per-table sum-of-cityHash64).
+6. **upload** — `rsync` the bundle + the baseline tool itself to `data@vl:/var/lib/macro-data/migrate/<date>/`.
+7. **vps_restore** — SSH session: stop API, mv existing engine.db to `.pre-migrate-<date>.bak`, copy the snapshot in; stop clickhouse-server, mv `/var/lib/clickhouse` to `.pre-migrate-<date>.bak`, untar, chown, start.
+8. **vps_baseline** — same `cutover_baseline.py` run on the VPS against the live restored DBs.
+9. **compare** — `diff -u local-baseline.json vps-baseline.json`. Identical → success; any diff → exit 1 with a written `baseline.diff` and the rollback command sequence.
+
+The script prints the exact rollback shell on mismatch.
+
+---
+
+## Verification
+
+After the script reports success, smoke-test from the operator laptop:
+
+```bash
+# 1. API liveness.
+curl -fsS https://<vps-host>/healthz
+
+# 2. Authenticated read against a real route.
+curl -fsS -H "X-API-Key: $TOKEN" https://<vps-host>/v1/manifest | jq
+
+# 3. Bronze counts match the issue's acceptance bar.
+ssh data@vl "sqlite3 /var/lib/macro-data/engine.db 'SELECT COUNT(*) FROM cal_econ_raw'"  # ≥ 272000
+ssh data@vl "clickhouse-client -q 'SELECT count() FROM market.bars_1d'"                    # = local
+```
+
+Then trigger the first VPS backup (#136 acceptance):
+
+```bash
+ssh data@vl 'systemctl --user start macro-data-backup.service'
+ssh data@vl 'journalctl --user -u macro-data-backup.service -n 80 --no-pager'
+ssh data@vl 'rclone lsf backups:daily/sqlite/'   # encrypted SQLite snapshot for today
+```
+
+Once green for 24 h, enable VPS writer timers per
+`scripts/systemd/README.md`.
+
+---
+
+## Rollback
+
+The cutover never touches local DBs after the initial snapshot, and on
+the VPS it preserves the prior state at:
+
+- `/var/lib/macro-data/engine.db.pre-migrate-<date>.bak` (plus any
+  `engine.db-wal.pre-migrate-<date>.bak` / `engine.db-shm.pre-migrate-<date>.bak` sidecars)
+- `/var/lib/clickhouse.pre-migrate-<date>.bak`
+
+Roll back any time before VPS writers fire:
+
+```bash
+ssh data@vl '
+  systemctl --user stop macro-data-api
+  sudo systemctl stop clickhouse-server
+  sudo rm -f /var/lib/macro-data/engine.db /var/lib/macro-data/engine.db-wal /var/lib/macro-data/engine.db-shm
+  for ext in db db-wal db-shm; do
+      if [[ -f "/var/lib/macro-data/engine.$ext.pre-migrate-<date>.bak" ]]; then
+          sudo mv "/var/lib/macro-data/engine.$ext.pre-migrate-<date>.bak" \
+                  "/var/lib/macro-data/engine.$ext"
+      fi
+  done
+  sudo rm -rf /var/lib/clickhouse && sudo mv /var/lib/clickhouse.pre-migrate-<date>.bak /var/lib/clickhouse
+  sudo systemctl start clickhouse-server
+  systemctl --user start macro-data-api
+'
+
+# Re-enable local writers (matches cutover.sh's LOCAL_WRITER_TIMERS list).
+for t in macro-data-refresh.timer parity-daily.timer calendar-schedule-refresh.timer \
+         calendar-value-sweep.timer calendar-corp-forward.timer \
+         macro-data-release-watch.timer fundamentals-forward.timer \
+         macro-data-market-refresh.timer macro-data-market-self-heal.timer \
+         macro-data-market-spot-check.timer shadow-digest.timer data-quality-daily.timer \
+         macro-data-backup.timer; do
+    systemctl --user enable --now "$t" 2>/dev/null || true
+done
+```
+
+Once VPS writers HAVE fired and produced new rows, rollback is no longer
+clean — those rows would be lost. The cutover sequence is designed so
+verification (steps 8–9) gates writer re-enablement; do not enable VPS
+writers until baselines match.
+
+---
+
+## Cleanup (after 24 h green)
+
+```bash
+ssh data@vl '
+  sudo rm -rf /var/lib/macro-data/engine.db.pre-migrate-<date>.bak \
+              /var/lib/clickhouse.pre-migrate-<date>.bak \
+              /var/lib/macro-data/migrate/<date>
+'
+rm -rf /tmp/cutover-<date>
+```
+
+---
+
+## Out of scope
+
+- Periodic / streaming replication — that lives in #136.
+- Live cutover with zero downtime — not worth the build cost for a 1-person operation.
+- Migrating `.macro-data/logs/`, `.macro-data/backfill_cursor.json`, lock files, or other runtime state. The VPS regenerates these.
+- Migrating `.macro-data/backups/te_calendar_*` snapshots — superseded by the `te_calendar_*` tables that already live in `engine.db`.
+
+---
+
+## Troubleshooting
+
+**`stop_writers` reports lock still held.** A long-running ingestion
+job is mid-flight. Wait for it to finish (`ps aux | grep python3 | grep
+macro`), then re-run.
+
+**`docker stop macro-data-clickhouse` hangs.** A long query is in
+flight. `docker exec macro-data-clickhouse clickhouse-client --query
+'KILL QUERY WHERE 1=1 ASYNC'`, then retry.
+
+**Baselines diverge in `clickhouse.hashes` only.** ReplicatedMergeTree
+or ReplacingMergeTree parts can have different physical row sets
+representing the same logical state. If counts match and `sum(cityHash64(*))`
+diverges, query a few specific rows by primary key to compare. If
+those match, it's a part-merge artifact; rerun on the VPS after `OPTIMIZE
+TABLE … FINAL` and re-baseline.
+
+**Cross-major ClickHouse versions.** The file-copy path in `cutover.sh`
+assumes the binary on-disk format is compatible. If versions diverge,
+do `BACKUP/RESTORE` manually:
+
+```bash
+# Local (one-time prep): bind-mount a config.d entry for the backup disk,
+# recreate container, then:
+docker exec macro-data-clickhouse clickhouse-client --query \
+    "BACKUP DATABASE market TO Disk('backup', 'cutover/')"
+# Tarball the host-side path (the bind-mount surfaces it),
+# rsync to VPS, then:
+ssh data@vl 'clickhouse-client --query \
+    "RESTORE DATABASE market FROM Disk(\"backup\", \"cutover/\")"'
+```
+
+That detour skips `cutover.sh phase 4 + 7-CH`; everything else (SQLite
+side, baselines, rollback) is reusable.

--- a/docs/ops/vps_bootstrap.md
+++ b/docs/ops/vps_bootstrap.md
@@ -138,6 +138,8 @@ take it forward:
   ClickHouse backup-disk config, systemd install).
 - **#137** — systemd unit hardening + Cloudflare Health Checks.
 - **#140** — cold migration of local `engine.db` + ClickHouse to VPS.
+  Runbook: `docs/ops/cutover.md` (preflight, execution phases, verify,
+  rollback). Driver script: `scripts/migrate/cutover.sh`.
 
 ## Rollback / re-bootstrap
 

--- a/scripts/migrate/cutover.sh
+++ b/scripts/migrate/cutover.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# cutover.sh — one-shot migration of local engine.db + ClickHouse 'market'
+# database to the data VPS (issue #140).
+#
+# Phases (single-pass; either all succeed or operator follows rollback):
+#   1. preflight       — ssh / docker / disk-space checks; interactive confirm
+#   2. stop_writers    — disable local systemd --user writer timers; verify
+#                        lock files released
+#   3. snapshot_sqlite — sqlite3 .backup → /tmp/cutover-<date>/sqlite/
+#   4. snapshot_ch     — docker stop CH, tar data dir, restart CH
+#   5. local_baseline  — cutover_baseline.py against the snapshot
+#   6. upload          — rsync snapshot bundle to VPS staging
+#   7. vps_restore     — SSH: stop API, swap engine.db, swap CH data dir
+#   8. vps_baseline    — cutover_baseline.py on VPS (live DBs)
+#   9. compare         — diff baselines; succeed only on byte-equal
+#
+# Pre-existing files on the VPS are preserved as
+# `<path>.pre-migrate-<date>.bak` so rollback is a single mv away.
+#
+# Usage:
+#   scripts/migrate/cutover.sh [--vps data@vl] [--vps-staging /path] [--yes] [--dry-run]
+#
+# Required prereqs (see docs/ops/cutover.md):
+#   - VPS bootstrap (#133), prod API service (#137), backup pipeline (#136) all in place.
+#   - VPS writer timers NOT yet enabled — they should only fire after this cutover passes.
+#   - Local + VPS ClickHouse versions compatible (same major, ideally same minor).
+
+set -euo pipefail
+
+VPS_HOST="${VPS_HOST:-data@vl}"
+VPS_STAGING="${VPS_STAGING:-/var/lib/macro-data/migrate}"
+DRY_RUN=0
+ASSUME_YES=0
+SKIP_STOP=0
+
+while (( $# )); do
+    case "$1" in
+        --vps) VPS_HOST="$2"; shift 2;;
+        --vps-staging) VPS_STAGING="$2"; shift 2;;
+        --dry-run) DRY_RUN=1; shift;;
+        --yes|-y) ASSUME_YES=1; shift;;
+        --skip-stop-writers) SKIP_STOP=1; shift;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0;;
+        *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DATE="$(date -u +%F)"
+SNAPSHOT_DIR="/tmp/cutover-$DATE"
+LOCAL_BASELINE="$SNAPSHOT_DIR/local-baseline.json"
+VPS_BASELINE="$SNAPSHOT_DIR/vps-baseline.json"
+
+cd "$REPO_ROOT"
+
+# Local writer timers from scripts/systemd/. We disable rather than stop
+# so a missed catch-up doesn't fire mid-cutover. The list mirrors
+# scripts/systemd/README.md.
+LOCAL_WRITER_TIMERS=(
+    macro-data-refresh.timer
+    parity-daily.timer
+    calendar-schedule-refresh.timer
+    calendar-value-sweep.timer
+    calendar-corp-forward.timer
+    macro-data-release-watch.timer
+    fundamentals-forward.timer
+    macro-data-market-refresh.timer
+    macro-data-market-self-heal.timer
+    macro-data-market-spot-check.timer
+    shadow-digest.timer
+    data-quality-daily.timer
+    macro-data-backup.timer
+)
+
+log() { printf '[%s] cutover: %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+run() {
+    if (( DRY_RUN )); then
+        printf '[dry-run] %s\n' "$*"
+    else
+        "$@"
+    fi
+}
+
+confirm() {
+    (( ASSUME_YES )) && return 0
+    local prompt="$1"
+    read -r -p "$prompt [y/N] " ans
+    [[ "$ans" == "y" || "$ans" == "Y" ]]
+}
+
+# --------------------------------------------------------------------
+# 1. preflight
+# --------------------------------------------------------------------
+phase_preflight() {
+    log "preflight: ssh + docker + disk space"
+
+    ssh -o ConnectTimeout=10 "$VPS_HOST" "echo ssh-ok" >/dev/null
+
+    command -v rsync >/dev/null || { echo "rsync not installed locally" >&2; exit 1; }
+    command -v docker >/dev/null || { echo "docker not installed locally" >&2; exit 1; }
+
+    [[ -f .macro-data/engine.db ]] || { echo "local engine.db missing" >&2; exit 1; }
+    docker ps --format '{{.Names}}' | grep -q '^macro-data-clickhouse$' \
+        || { echo "macro-data-clickhouse container not running" >&2; exit 1; }
+
+    local local_size_kb
+    local_size_kb=$(du -sk .macro-data/engine.db .macro-data/clickhouse/data 2>/dev/null | awk '{s += $1} END {print s}')
+    log "local snapshot footprint estimate: $((local_size_kb / 1024)) MB"
+
+    local vps_avail_kb
+    vps_avail_kb=$(ssh "$VPS_HOST" "df --output=avail -k /var/lib | tail -1")
+    if (( vps_avail_kb < local_size_kb * 3 )); then
+        echo "VPS disk too small: $((vps_avail_kb/1024)) MB free, need ~$((local_size_kb*3/1024)) MB" >&2
+        exit 1
+    fi
+    log "vps free space ok: $((vps_avail_kb/1024)) MB"
+
+    # ClickHouse version gate — file-copy across CH major.minor is unsafe.
+    local local_v vps_v local_mm vps_mm
+    local_v=$(docker exec macro-data-clickhouse clickhouse-client --query "SELECT version()" 2>/dev/null || echo "?")
+    vps_v=$(ssh "$VPS_HOST" "clickhouse-client --query 'SELECT version()'" 2>/dev/null || echo "?")
+    local_mm=$(printf '%s' "$local_v" | cut -d. -f1-2)
+    vps_mm=$(printf  '%s' "$vps_v"   | cut -d. -f1-2)
+    log "clickhouse versions: local=$local_v vps=$vps_v"
+    if [[ "$local_mm" != "$vps_mm" ]]; then
+        echo "clickhouse major.minor mismatch ($local_mm vs $vps_mm) — file-copy is unsafe; see cutover.md troubleshooting" >&2
+        exit 1
+    fi
+
+    confirm "Cutover from $(hostname) → $VPS_HOST will stop local writers and overwrite VPS engine.db + ClickHouse market. Proceed?" \
+        || { echo "aborted by operator"; exit 1; }
+}
+
+# --------------------------------------------------------------------
+# 2. stop_writers
+# --------------------------------------------------------------------
+phase_stop_writers() {
+    if (( SKIP_STOP )); then log "stop_writers: skipped (--skip-stop-writers)"; return; fi
+    log "stopping local writer timers"
+    for t in "${LOCAL_WRITER_TIMERS[@]}"; do
+        run systemctl --user disable --now "$t" 2>/dev/null || true
+    done
+    # Lock files are released only when the holder exits. Give catch-up
+    # fires a moment to drain.
+    sleep 5
+    for lock in .macro-data/*.lock; do
+        [[ -f "$lock" ]] || continue
+        if fuser "$lock" >/dev/null 2>&1; then
+            echo "lock still held: $lock — investigate before retrying" >&2
+            exit 1
+        fi
+    done
+    log "writers stopped, locks released"
+}
+
+# --------------------------------------------------------------------
+# 3. snapshot_sqlite — online .backup so the live DB stays consistent
+# even if a writer reconnects between disable and snapshot.
+# --------------------------------------------------------------------
+phase_snapshot_sqlite() {
+    log "snapshot SQLite engine.db"
+    run mkdir -p "$SNAPSHOT_DIR/sqlite"
+    if (( DRY_RUN )); then return; fi
+    python3 - "$REPO_ROOT/.macro-data/engine.db" "$SNAPSHOT_DIR/sqlite/engine.db" <<'PY'
+import sqlite3, sys
+src, dst = sys.argv[1], sys.argv[2]
+s = sqlite3.connect(src)
+try:
+    d = sqlite3.connect(dst)
+    try:
+        s.backup(d)
+    finally:
+        d.close()
+finally:
+    s.close()
+PY
+    log "wrote $SNAPSHOT_DIR/sqlite/engine.db ($(du -sh "$SNAPSHOT_DIR/sqlite/engine.db" | cut -f1))"
+}
+
+# --------------------------------------------------------------------
+# 4. snapshot_ch — clean shutdown + tar the bind-mounted data dir, then
+# restart. File-copy is what we ship to the VPS; cross-server portability
+# requires same major.minor CH version (the runbook gates on this).
+# --------------------------------------------------------------------
+phase_snapshot_ch() {
+    log "snapshot ClickHouse data dir (clean shutdown + tar)"
+    run mkdir -p "$SNAPSHOT_DIR/clickhouse"
+
+    run docker stop macro-data-clickhouse >/dev/null
+    if ! (( DRY_RUN )); then
+        # Cover Ctrl-C / tar-failure between stop and start so local
+        # market reads recover even on aborted cutovers. Cleared after
+        # the explicit start succeeds.
+        trap 'docker start macro-data-clickhouse >/dev/null 2>&1 || true' EXIT
+        tar -C .macro-data/clickhouse/data -czf "$SNAPSHOT_DIR/clickhouse/clickhouse-data.tar.gz" .
+        trap - EXIT
+    fi
+    run docker start macro-data-clickhouse >/dev/null
+
+    if (( DRY_RUN )); then return; fi
+    # Wait for CH to come back up — local baseline below queries it.
+    for _ in $(seq 1 30); do
+        if docker exec macro-data-clickhouse clickhouse-client --query "SELECT 1" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+    log "wrote $SNAPSHOT_DIR/clickhouse/clickhouse-data.tar.gz ($(du -sh "$SNAPSHOT_DIR/clickhouse/clickhouse-data.tar.gz" | cut -f1))"
+}
+
+# --------------------------------------------------------------------
+# 5. local_baseline — counts + content hashes against the snapshot
+# (SQLite) and live CH (which is identical to the tarball, since CH was
+# stopped during tar).
+# --------------------------------------------------------------------
+phase_local_baseline() {
+    log "compute local baseline"
+    if (( DRY_RUN )); then return; fi
+    python3 scripts/migrate/cutover_baseline.py \
+        --sqlite-db "$SNAPSHOT_DIR/sqlite/engine.db" \
+        --clickhouse-via docker \
+        > "$LOCAL_BASELINE"
+    log "wrote $LOCAL_BASELINE ($(wc -c < "$LOCAL_BASELINE") bytes)"
+}
+
+# --------------------------------------------------------------------
+# 6. upload — rsync the bundle + the baseline tool itself so we can
+# rerun it on the VPS with identical logic.
+# --------------------------------------------------------------------
+phase_upload() {
+    log "rsync snapshot bundle to $VPS_HOST:$VPS_STAGING/$DATE/"
+    run ssh "$VPS_HOST" "sudo install -d -m 0755 -o data -g data $VPS_STAGING && sudo install -d -m 0755 -o data -g data $VPS_STAGING/$DATE"
+    run rsync -av --info=progress2 "$SNAPSHOT_DIR/sqlite" "$SNAPSHOT_DIR/clickhouse" \
+        "$VPS_HOST:$VPS_STAGING/$DATE/"
+    run rsync -av scripts/migrate/cutover_baseline.py "$VPS_HOST:$VPS_STAGING/$DATE/"
+}
+
+# --------------------------------------------------------------------
+# 7. vps_restore — stop API, swap engine.db, stop CH, untar data, start.
+# Existing VPS files moved to .pre-migrate-<date>.bak for rollback.
+# --------------------------------------------------------------------
+phase_vps_restore() {
+    log "VPS restore: stop API → swap engine.db → swap CH data → restart"
+    if (( DRY_RUN )); then return; fi
+    ssh "$VPS_HOST" "VPS_STAGING='$VPS_STAGING' DATE='$DATE' bash -se" <<'EOSSH'
+set -euo pipefail
+
+cd "$VPS_STAGING/$DATE"
+
+# API is a `systemctl --user` unit owned by the data user we're SSHed
+# in as; sudo would target the (non-existent) system unit.
+systemctl --user stop macro-data-api.service 2>/dev/null || true
+
+# --- SQLite ---
+sudo install -d -m 0750 -o data -g data /var/lib/macro-data
+# Move BOTH the main DB and any `-wal` / `-shm` sidecars into the
+# rollback backup. Leaving stale sidecars next to the new engine.db
+# corrupts SQLite's WAL view on first read.
+for ext in db db-wal db-shm; do
+    if [[ -f "/var/lib/macro-data/engine.$ext" ]]; then
+        sudo mv "/var/lib/macro-data/engine.$ext" \
+                "/var/lib/macro-data/engine.$ext.pre-migrate-$DATE.bak"
+    fi
+done
+sudo cp sqlite/engine.db /var/lib/macro-data/engine.db
+sudo chown data:data /var/lib/macro-data/engine.db
+sudo chmod 600 /var/lib/macro-data/engine.db
+
+# --- ClickHouse ---
+sudo systemctl stop clickhouse-server.service
+if [[ -d /var/lib/clickhouse ]]; then
+    sudo mv /var/lib/clickhouse "/var/lib/clickhouse.pre-migrate-$DATE.bak"
+fi
+sudo install -d -m 0750 -o clickhouse -g clickhouse /var/lib/clickhouse
+sudo tar -xzf clickhouse/clickhouse-data.tar.gz -C /var/lib/clickhouse
+sudo chown -R clickhouse:clickhouse /var/lib/clickhouse
+sudo systemctl start clickhouse-server.service
+
+# Wait for CH ready.
+for _ in $(seq 1 60); do
+    if clickhouse-client --query "SELECT 1" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+clickhouse-client --query "SELECT 1" >/dev/null \
+    || { echo "clickhouse-server failed to start" >&2; exit 1; }
+
+# Restart API last; reads both DBs.
+systemctl --user start macro-data-api.service
+EOSSH
+    log "VPS restore complete"
+}
+
+# --------------------------------------------------------------------
+# 8. vps_baseline + 9. compare
+# --------------------------------------------------------------------
+phase_vps_baseline() {
+    log "compute VPS baseline"
+    if (( DRY_RUN )); then return; fi
+    ssh "$VPS_HOST" \
+        "python3 $VPS_STAGING/$DATE/cutover_baseline.py \
+            --sqlite-db /var/lib/macro-data/engine.db \
+            --clickhouse-via local" \
+        > "$VPS_BASELINE"
+}
+
+phase_compare() {
+    log "compare local vs VPS baselines"
+    if (( DRY_RUN )); then return; fi
+    if diff -u "$LOCAL_BASELINE" "$VPS_BASELINE" > "$SNAPSHOT_DIR/baseline.diff"; then
+        log "BASELINE MATCH — cutover successful"
+        rm "$SNAPSHOT_DIR/baseline.diff"
+    else
+        echo "BASELINE MISMATCH — see $SNAPSHOT_DIR/baseline.diff" >&2
+        cat "$SNAPSHOT_DIR/baseline.diff" >&2
+        cat >&2 <<EOR
+
+Rollback on VPS (mirrors the swap path — API is a --user unit;
+restore all sqlite sidecars not just engine.db):
+
+  ssh $VPS_HOST '
+      systemctl --user stop macro-data-api 2>/dev/null || true
+      sudo systemctl stop clickhouse-server
+      sudo rm -f /var/lib/macro-data/engine.db /var/lib/macro-data/engine.db-wal /var/lib/macro-data/engine.db-shm
+      for ext in db db-wal db-shm; do
+          if [[ -f "/var/lib/macro-data/engine.\$ext.pre-migrate-$DATE.bak" ]]; then
+              sudo mv "/var/lib/macro-data/engine.\$ext.pre-migrate-$DATE.bak" \
+                      "/var/lib/macro-data/engine.\$ext"
+          fi
+      done
+      sudo rm -rf /var/lib/clickhouse
+      sudo mv /var/lib/clickhouse.pre-migrate-$DATE.bak /var/lib/clickhouse
+      sudo systemctl start clickhouse-server
+      systemctl --user start macro-data-api
+  '
+EOR
+        exit 1
+    fi
+}
+
+# --------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------
+phase_preflight
+phase_stop_writers
+phase_snapshot_sqlite
+phase_snapshot_ch
+phase_local_baseline
+phase_upload
+phase_vps_restore
+phase_vps_baseline
+phase_compare
+
+cat <<EONEXT
+Cutover complete on $DATE.
+
+Next steps (operator):
+  1. Smoke-test API: curl -fsS https://<vps-host>/healthz
+  2. Authenticated read from a real route (any of /v1/manifest, /v1/calendar, /v1/fundamentals/{ticker}, /v1/ops/{op}):
+       curl -fsS -H "X-API-Key: \$TOKEN" https://<vps-host>/v1/manifest
+  3. Trigger first VPS backup (from #136):
+       ssh $VPS_HOST 'systemctl --user start macro-data-backup.service'
+       ssh $VPS_HOST 'journalctl --user -u macro-data-backup.service -n 50'
+  4. Enable VPS writer timers per scripts/systemd/README.md.
+  5. After 24h of green ops, drop rollback artifacts:
+       ssh $VPS_HOST 'sudo rm -rf /var/lib/macro-data/engine.db.pre-migrate-$DATE.bak /var/lib/clickhouse.pre-migrate-$DATE.bak $VPS_STAGING/$DATE'
+
+Rollback (if any of 1-3 fails — VPS-side data is unchanged from cutover snapshot):
+  ssh $VPS_HOST '
+    systemctl --user stop macro-data-api 2>/dev/null || true
+    sudo systemctl stop clickhouse-server
+    sudo rm -f /var/lib/macro-data/engine.db /var/lib/macro-data/engine.db-wal /var/lib/macro-data/engine.db-shm
+    for ext in db db-wal db-shm; do
+        if [[ -f "/var/lib/macro-data/engine.\$ext.pre-migrate-$DATE.bak" ]]; then
+            sudo mv "/var/lib/macro-data/engine.\$ext.pre-migrate-$DATE.bak" \
+                    "/var/lib/macro-data/engine.\$ext"
+        fi
+    done
+    sudo rm -rf /var/lib/clickhouse
+    sudo mv /var/lib/clickhouse.pre-migrate-$DATE.bak /var/lib/clickhouse
+    sudo systemctl start clickhouse-server
+    systemctl --user start macro-data-api
+  '
+  Locally, re-enable writer timers:
+    for t in ${LOCAL_WRITER_TIMERS[*]}; do systemctl --user enable --now \$t; done
+EONEXT

--- a/scripts/migrate/cutover_baseline.py
+++ b/scripts/migrate/cutover_baseline.py
@@ -1,0 +1,131 @@
+"""Compute SQLite + ClickHouse baseline for the cutover migration (issue #140).
+
+Runs on the local laptop against the live (or snapshotted) DBs and on the
+VPS post-restore against the migrated DBs. Same tool both sides so the
+comparison is like-for-like.
+
+Output: a JSON document on stdout.
+
+```
+{
+  "sqlite": {
+    "file_sha256": "<hex>",
+    "tables": {"<name>": <row count>, ...}
+  },
+  "clickhouse": {
+    "tables": {"<name>": <row count>, ...},
+    "hashes": {"<name>": "<sum-of-cityHash64-rows>", ...}
+  }
+}
+```
+
+Pure stdlib — no third-party deps so we can scp this file to the VPS and
+run it with the system python3 if the .venv isn't installed yet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sqlite_baseline(db_path: Path) -> dict:
+    if not db_path.is_file():
+        raise SystemExit(f"sqlite db not found: {db_path}")
+    out: dict = {"file_sha256": _file_sha256(db_path), "tables": {}}
+    con = sqlite3.connect(str(db_path))
+    try:
+        rows = con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+        for (name,) in rows:
+            cnt = con.execute(f'SELECT COUNT(*) FROM "{name}"').fetchone()[0]
+            out["tables"][name] = int(cnt)
+    finally:
+        con.close()
+    return out
+
+
+def _ch(client: list[str], query: str) -> str:
+    """Run a single ClickHouse query and return stripped stdout."""
+    r = subprocess.run(
+        client + ["--query", query],
+        capture_output=True, text=True, check=True,
+    )
+    return r.stdout.strip()
+
+
+def clickhouse_baseline(client: list[str], database: str) -> dict:
+    tables_tsv = _ch(
+        client,
+        f"SELECT name FROM system.tables WHERE database = '{database}' ORDER BY name FORMAT TSV",
+    )
+    tables = [t for t in tables_tsv.splitlines() if t]
+    out: dict = {"tables": {}, "hashes": {}}
+    for t in tables:
+        cnt = int(_ch(client, f"SELECT count() FROM `{database}`.`{t}`"))
+        # Content hash — order-independent uint64 sum over per-row
+        # cityHash64. Identical rowsets → identical sum, even if part
+        # ordering on disk differs across hosts.
+        h = _ch(
+            client,
+            f"SELECT toString(sum(cityHash64(*))) FROM `{database}`.`{t}`",
+        )
+        out["tables"][t] = cnt
+        out["hashes"][t] = h or "0"
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--sqlite-db", type=Path,
+        default=Path(os.environ.get(
+            "ANALYST_MACRO_DATA_DB_PATH", "/var/lib/macro-data/engine.db",
+        )),
+        help="Path to engine.db (default: $ANALYST_MACRO_DATA_DB_PATH or /var/lib/macro-data/engine.db).",
+    )
+    ap.add_argument(
+        "--clickhouse-database",
+        default=os.environ.get("CLICKHOUSE_DATABASE", "market"),
+    )
+    ap.add_argument(
+        "--clickhouse-via", default="local", choices=("local", "docker"),
+        help="Use local clickhouse-client (default) or `docker exec <container> clickhouse-client`.",
+    )
+    ap.add_argument(
+        "--docker-container", default="macro-data-clickhouse",
+        help="Docker container name when --clickhouse-via=docker.",
+    )
+    args = ap.parse_args(argv)
+
+    if args.clickhouse_via == "local":
+        client = ["clickhouse-client"]
+    else:
+        client = ["docker", "exec", "-i", args.docker_container, "clickhouse-client"]
+
+    result = {
+        "sqlite": sqlite_baseline(args.sqlite_db),
+        "clickhouse": clickhouse_baseline(client, args.clickhouse_database),
+    }
+    json.dump(result, sys.stdout, sort_keys=True, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `scripts/migrate/cutover_baseline.py` — pure-stdlib SQLite + ClickHouse baseline emitter (per-table COUNT, file sha256, `sum(cityHash64(*))`); same code runs both sides for byte-equal comparison.
- `scripts/migrate/cutover.sh` — 9-phase orchestrator: preflight (SSH + docker + disk + CH major.minor compat + interactive confirm) → stop_writers (disable local timers, verify lock-file release) → snapshot SQLite (online `.backup`) → snapshot CH (docker stop + tar + start, EXIT-trap-protected) → local baseline → rsync to `data@vl:/var/lib/macro-data/migrate/<date>/` → VPS restore (swap engine.db + sidecars, swap CH data dir, `.pre-migrate-<date>.bak` for rollback) → VPS baseline → `diff -u`. Never enables VPS writer timers — that's the operator's go/no-go after match.
- `docs/ops/cutover.md` runbook + `vps_bootstrap.md` Phase 6 pointer.

## Test plan

Manual one-shot from the laptop after merge — runbook has the full sequence:

- [ ] `scripts/migrate/cutover.sh --dry-run` lists all 9 phases with no errors.
- [ ] Real run prompts for confirmation, stops local writers, snapshots both DBs, ships, restores, baselines match (`diff` clean).
- [ ] Post-cutover smoke: `curl https://<vps-host>/healthz` + authenticated `/v1/manifest`.
- [ ] First VPS backup (#136) succeeds against migrated data: `ssh data@vl 'systemctl --user start macro-data-backup.service'`.
- [ ] After 24 h green, drop rollback artifacts per the cleanup section.

Closes #140