### PR TITLE
fix(ops): prefer repo venv in recurring wrappers

### DIFF
--- a/scripts/backfill_fundamentals_wrapper.sh
+++ b/scripts/backfill_fundamentals_wrapper.sh
@@ -16,5 +16,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/fundamentals_recurring.lock"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/backfill_fundamentals.py --execute "$@"
+    "$PYTHON_BIN" scripts/backfill_fundamentals.py --execute "$@"

--- a/scripts/calendar_corp_forward_wrapper.sh
+++ b/scripts/calendar_corp_forward_wrapper.sh
@@ -20,5 +20,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/calendar_recurring.lock"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/calendar_corp_forward.py "$@"
+    "$PYTHON_BIN" scripts/calendar_corp_forward.py "$@"

--- a/scripts/calendar_refresh_schedules_wrapper.sh
+++ b/scripts/calendar_refresh_schedules_wrapper.sh
@@ -24,5 +24,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/calendar_recurring.lock"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/calendar_refresh_schedules.py "$@"
+    "$PYTHON_BIN" scripts/calendar_refresh_schedules.py "$@"

--- a/scripts/calendar_sweep_values_wrapper.sh
+++ b/scripts/calendar_sweep_values_wrapper.sh
@@ -24,5 +24,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/calendar_recurring.lock"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/calendar_sweep_values.py "$@"
+    "$PYTHON_BIN" scripts/calendar_sweep_values.py "$@"

--- a/scripts/market_daily_refresh_wrapper.sh
+++ b/scripts/market_daily_refresh_wrapper.sh
@@ -6,5 +6,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/market_recurring.lock"
 
 mkdir -p "$(dirname "$LOCK_FILE")"
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/market_daily_refresh.py "$@"
+    "$PYTHON_BIN" scripts/market_daily_refresh.py "$@"

--- a/scripts/market_self_heal_wrapper.sh
+++ b/scripts/market_self_heal_wrapper.sh
@@ -6,5 +6,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/market_recurring.lock"
 
 mkdir -p "$(dirname "$LOCK_FILE")"
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/detect_missing_bars.py "$@"
+    "$PYTHON_BIN" scripts/detect_missing_bars.py "$@"

--- a/scripts/market_spot_check_wrapper.sh
+++ b/scripts/market_spot_check_wrapper.sh
@@ -6,5 +6,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/market_spot_check.lock"
 
 mkdir -p "$(dirname "$LOCK_FILE")"
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/spot_check_close.py "$@"
+    "$PYTHON_BIN" scripts/spot_check_close.py "$@"

--- a/scripts/parity_daily_wrapper.sh
+++ b/scripts/parity_daily_wrapper.sh
@@ -19,5 +19,7 @@ LOCK_FILE="${REPO_ROOT}/.macro-data/parity_daily.lock"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --nonblock "$LOCK_FILE" \
-    python3 scripts/parity_daily.py "$@"
+    "$PYTHON_BIN" scripts/parity_daily.py "$@"

--- a/scripts/release_aware_refresh_wrapper.sh
+++ b/scripts/release_aware_refresh_wrapper.sh
@@ -11,5 +11,7 @@ RUN_STARTED_AT="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
 mkdir -p "$(dirname "$LOCK_FILE")"
 
 cd "$REPO_ROOT"
+PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 exec flock --wait 120 "$LOCK_FILE" \
-    python3 scripts/release_aware_refresh.py --now "$RUN_STARTED_AT" "$@"
+    "$PYTHON_BIN" scripts/release_aware_refresh.py --now "$RUN_STARTED_AT" "$@"


### PR DESCRIPTION
## Changes
- Make the 9 affected recurring systemd wrappers choose `${REPO_ROOT}/.venv/bin/python` when executable.
- Fall back to `python3` for workstations that rely on system-wide dependencies.
- Preserve existing `flock` behavior, lock files, Python entrypoints, and argument forwarding.

## Verification
- `bash -n` across all 9 wrappers
- `scripts/<wrapper> --help` across all 9 wrappers
- temp `REPO_ROOT` with executable `.venv/bin/python` confirms repo-local interpreter selection
- `codex exec review --uncommitted`

Closes #161
